### PR TITLE
Modified notes from 'slist-in-meta' to 'bundle_return_value_index-in-reports' + created new bug reports for issues

### DIFF
--- a/bundles-logs-functions-variables/Bundles-for-common-0-classes-in-common-promises-1.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0-classes-in-common-promises-1.markdown
@@ -14,6 +14,12 @@ tags: [xx]
 These are not related to object oriented classes, but are more like tag
 labels representing different properties of the environment.
 
+Classes promises may be made in any bundle. In other words, bundles that
+pertain to any agent.
+
+Classes that are defined in common bundles are global in scope, while
+classes in all other bundles are local.
+
 Note: The words class and context are sometimes used interchangeably.
 
 \
@@ -26,14 +32,6 @@ Note: The words class and context are sometimes used interchangeably.
 
       "client_network" expression => iprange("128.39.89.0/24");
     }
-
-\
-
-Classes promises may be made in any bundle. In other words, bundles that
-pertain to any agent.
-
-Classes that are defined in common bundles are global in scope, while
-classes in all other bundles are local.
 
 -   and in classes
 -   dist in classes
@@ -52,6 +50,11 @@ classes in all other bundles are local.
 
 **Synopsis**: Combine class sources with AND
 
+If an expression contains a mixture of different object types that need
+to be ANDed together, this list form is more convenient than providing
+an expression. If all of the class expressions listed on the right-hand
+side match, then the class on the left-hand side is defined.
+
 **Example**:\
  \
 
@@ -59,22 +62,17 @@ classes in all other bundles are local.
 
       "compound_class" and => { classmatch("host[0-9].*"), "Monday", "Hr02" };
 
-**Notes**:\
- \
-
-If an expression contains a mixture of different object types that need
-to be ANDed together, this list form is more convenient than providing
-an expression. If all of the class expressions listed on the right-hand
-side match, then the class on the left-hand side is defined.
-
 #### `dist`
 
 **Type**: rlist
 
 **Allowed input range**: `-9.99999E100,9.99999E100`
 
-**Synopsis**: Generate a probabilistic class distribution (from
-strategies in CFEngine 2)
+**Synopsis**: Generate a probabilistic class distribution
+
+Assign one generic class ('always') and one additional class, randomly
+weighted on a probability distribution. This was previous called a
+strategy in CFEngine 2.
 
 **Example**:\
  \
@@ -85,21 +83,15 @@ strategies in CFEngine 2)
 
         dist => { "10", "20", "40", "50" };
 
-**Notes**:\
- \
-
-Assign one generic class (always) and one additional class, randomly
-weighted on a probability distribution. The sum of `10+20+40+50 = 120`
-in the example above, so in generating a distribution, CFEngine picks a
-number between `1-120`. This will generate the following classes:
+Referring to the the sum of `10+20+40+50 = 120` in the example above,
+when generating the distribution, CFEngine picks a number between
+`1-120`. This will generate the following classes:
 
          my_dist    (always)
          my_dist_10 (10/120 of the time)
          my_dist_20 (20/120 of the time)
          my_dist_40 (40/120 of the time)
          my_dist_50 (50/120 of the time)
-
-This was previous called a strategy in CFEngine 2.
 
 #### `expression`
 
@@ -109,6 +101,8 @@ This was previous called a strategy in CFEngine 2.
 
 **Synopsis**: Evaluate string expression of classes in normal form
 
+A way of aliasing class combinations.
+
 **Example**:\
  \
 
@@ -117,11 +111,6 @@ This was previous called a strategy in CFEngine 2.
       "class_name" expression => "solaris|(linux.specialclass)";
       "has_toor"   expression => userexists("toor");
 
-**Notes**:\
- \
-
-A way of aliasing class combinations.
-
 #### `or`
 
 **Type**: clist
@@ -129,6 +118,10 @@ A way of aliasing class combinations.
 **Allowed input range**: `[a-zA-Z0-9_!@@$|.()\[\]{}:]+`
 
 **Synopsis**: Combine class sources with inclusive OR
+
+The class on the left-hand side will be defined if any one (or more) of
+the class expressions on the right-hand side are true. This is useful
+construction for writing expressions that contain special functions.
 
 **Example**:\
  \
@@ -139,21 +132,19 @@ A way of aliasing class combinations.
 
           or => { classmatch("linux_x86_64_2_6_22.*"), "suse_10_3" };
 
-**Notes**:\
- \
-
-The class on the left-hand side will be defined if any one (or more) of
-the class expressions on the right-hand side are true. This is useful
-construction for writing expressions that contain special functions.
-
 #### `persistence`
 
 **Type**: int
 
 **Allowed input range**: `0,99999999999`
 
-**Synopsis**: Make the class persistent (cached) to avoid reevaluation,
+**Synopsis**: Make the class persistent (cached) to avoid re-evaluation,
 time in minutes
+
+This feature can be used to avoid recomputing expensive classes
+calculations on each invocation. This is useful if a class discovered is
+essentially constant or only slowly varying, such as a hostname or alias
+from a non-standard naming facility.
 
 **Example**:\
  \
@@ -171,14 +162,6 @@ time in minutes
            persistence => "1";
 
     }
-
-**Notes**:\
- \
-
-This feature can be used to avoid recomputing expensive classes
-calculations on each invocation, if a class discovered is essentially
-constant or only slowly varying. For example, a hostname or alias from a
-non-standard naming facility)
 
 For example, to create a conditional inclusion of costly class
 definitions, put them into a separate bundle in a file classes.cf.
@@ -236,6 +219,10 @@ Then create classes.cf
 
 **Synopsis**: Evaluate the negation of string expression in normal form
 
+This negates the effect of the promiser-pattern regular expression. The
+class on the left-hand side will only be defined if the class expression
+on the right-hand side is false.
+
 **Example**:\
  \
 
@@ -243,13 +230,6 @@ Then create classes.cf
 
        "others"  not => "linux|solaris";
        "no_toor" not => userexists("toor");
-
-**Notes**:\
- \
-
-This negates the effect of the promiser-pattern regular expression. The
-class on the left-hand side will only be defined if the class expression
-on the right-hand side is false.
 
 #### `select_class`
 
@@ -261,6 +241,16 @@ on the right-hand side is false.
 
 **Synopsis**: Select one of the named list of classes to define based on
 host identity
+
+This feature is similar to the `splayclass` function. However, instead
+of selecting a class for a moment in time, it always chooses one class
+in the list; the same class each time for a given host. This allows
+hosts to be distributed across a controlled list of classes (e.g for
+load balancing purposes).
+
+The class is chosen deterministically (not randomly) but it is not
+possible to say which host will end up in which class in advance. Only
+that hosts will always end up in the same class every time.
 
 **Example**:\
  \
@@ -279,19 +269,6 @@ host identity
          "A selection was made";
     }
 
-**Notes**:\
- \
-
-This feature is similar to the `splayclass` function. However, instead
-of selecting a class for a moment in time, it always chooses one class
-in the list; the same class each time for a given host. This allows
-hosts to be distributed across a controlled list of classes (e.g for
-load balancing purposes).
-
-The class is chosen deterministically (not randomly) but it is not
-possible to say which host will end up in which class in advance. Only
-that hosts will always end up in the same class every time.
-
 #### `xor`
 
 **Type**: clist
@@ -300,16 +277,13 @@ that hosts will always end up in the same class every time.
 
 **Synopsis**: Combine class sources with XOR
 
+This behaves as the XOR operation on class expressions. It can be used
+to define a class if exactly one of the class expressions on the
+right-hand side matches.
+
 **Example**:\
  \
 
     classes:
 
      "another_global" xor => { "any", "linux", "solaris"};
-
-**Notes**:\
- \
-
-This behaves as the XOR operation on class expressions. It can be used
-to define a class if exactly one of the class expressions on the
-right-hand side matches.

--- a/bundles-logs-functions-variables/Bundles-for-common-0-defaults-in-common-promises-2.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0-defaults-in-common-promises-2.markdown
@@ -15,11 +15,9 @@ Defaults promises are related to variables. If a variable or parameter
 in a promise bundle is undefined, or its value is defined to be invalid,
 a default value can be promised instead.
 
-\
-
-Note carefully that CFEngine does not use Perl semantics: i.e. undefined
-variables do not map to the empty string, they remain as variables for
-possible future expansion.
+CFEngine does not use Perl semantics: i.e. undefined variables do not
+map to the empty string, they remain as variables for possible future
+expansion.
 
 Some variables might be defined but still contain unresolved variables.
 To handle this you will need to match the `$(abc)` form of the
@@ -119,6 +117,10 @@ Another example:
 **Synopsis**: If this regular expression matches the current value of
 the variable, replace it with default
 
+If a parameter or variable is already defined in the current context,
+and the value matches this regular expression, it will be deemed invalid
+and replaced with the default value.
+
 **Example**:\
  \
 
@@ -130,13 +132,6 @@ the variable, replace it with default
       "b" string => "BBBBBBBBB",   if_match_regex => "";
     }
 
-**Notes**:\
- \
-
-If a parameter or variable is already defined in the current context,
-and the value matches this regular expression, it will be deemed invalid
-and replaced with the default value.
-
 #### `string`
 
 **Type**: string
@@ -144,6 +139,10 @@ and replaced with the default value.
 **Allowed input range**: (arbitrary string)
 
 **Synopsis**: A scalar string
+
+In previous versions of CFEngine lists were represented (as in the
+shell) using separated scalars; similar to the PATH variable. In
+CFEngine 3 lists are kept as an independent type.
 
 **Example**:\
  \
@@ -154,13 +153,6 @@ and replaced with the default value.
 
      "yyy"    string => readfile( "/home/mark/tmp/testfile" , "33" );
 
-**Notes**:\
- \
-
-In previous versions of CFEngine lists were represented (as in the
-shell) using separated scalars; similar to the PATH variable. In
-CFEngine 3 lists are kept as an independent type.
-
 #### `slist`
 
 **Type**: slist
@@ -168,6 +160,11 @@ CFEngine 3 lists are kept as an independent type.
 **Allowed input range**: (arbitrary string)
 
 **Synopsis**: A list of scalar strings
+
+Some functions return `slist`s (see Introduction to functions), and an
+`slist` may contain the values copied from another `slist`, `rlist`, or
+`ilist` (see List variable substitution and expansion, and policy in
+vars).
 
 **Example**:\
  \
@@ -188,9 +185,3 @@ CFEngine 3 lists are kept as an independent type.
 
      "zzz"    slist  => { readstringlist("/home/mark/tmp/testlist2","#[^\n]*",",",5,4000) };
 
-**Notes**:\
- \
- Some functions return `slist`s (see Introduction to functions), and an
-`slist` may contain the values copied from another `slist`, `rlist`, or
-`ilist` (see List variable substitution and expansion, see policy in
-vars).

--- a/bundles-logs-functions-variables/Bundles-for-common-0-meta-in-common-promises-3.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0-meta-in-common-promises-3.markdown
@@ -49,6 +49,10 @@ be used as variables and will appear in Enterprise variable reports.
 
 **Synopsis**: A scalar string
 
+In previous versions of CFEngine lists were represented (as in the
+shell) using separated scalars; similar to the PATH variable. In
+CFEngine 3 lists are kept as an independent type.
+
 **Example**:\
  \
 
@@ -58,13 +62,6 @@ be used as variables and will appear in Enterprise variable reports.
 
      "yyy"    string => readfile( "/home/mark/tmp/testfile" , "33" );
 
-**Notes**:\
- \
-
-In previous versions of CFEngine lists were represented (as in the
-shell) using separated scalars; similar to the PATH variable. In
-CFEngine 3 lists are kept as an independent type.
-
 #### `slist`
 
 **Type**: slist
@@ -72,6 +69,11 @@ CFEngine 3 lists are kept as an independent type.
 **Allowed input range**: (arbitrary string)
 
 **Synopsis**: A list of scalar strings
+
+Some functions return `slist`s (see Introduction to functions), and an
+`slist` may contain the values copied from another `slist`, `rlist`, or
+`ilist` (see List variable substitution and expansion, and policy in
+vars).
 
 **Example**:\
  \
@@ -92,9 +94,3 @@ CFEngine 3 lists are kept as an independent type.
 
      "zzz"    slist  => { readstringlist("/home/mark/tmp/testlist2","#[^\n]*",",",5,4000) };
 
-**Notes**:\
- \
- Some functions return `slist`s (see Introduction to functions), and an
-`slist` may contain the values copied from another `slist`, `rlist`, or
-`ilist` (see List variable substitution and expansion, see policy in
-vars).

--- a/bundles-logs-functions-variables/Bundles-for-common-0-reports-in-common-promises-4.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0-reports-in-common-promises-4.markdown
@@ -65,6 +65,9 @@ has been replaced by `reports`.
 **Synopsis**: Regular expression to keep selected hosts from the friends
 report list
 
+This regular expression should match hosts we want to exclude from
+friend reports.
+
 **Example**:\
  \
 
@@ -76,12 +79,6 @@ report list
 
               lastseen => "0",
          friend_pattern => "host1|host2|.*\.domain\.tld";
-
-**Notes**:\
- \
-
-This regular expression should match hosts we want to exclude from
-friend reports.
 
 #### `intermittency`
 
@@ -97,9 +94,6 @@ peers, report above
 **Example**:\
  \
 
-**Notes**:\
- \
-
 #### `lastseen`
 
 **Type**: int
@@ -108,6 +102,17 @@ peers, report above
 
 **Synopsis**: Integer time threshold in hours since current peers were
 last seen, report absence
+
+In reports: After this time (hours) has passed, CFEngine will begin to
+warn about the host being overdue. After the `lastseenexpireafter`
+expiry time, hosts will be purged from this host's database (default is
+a week).
+
+In control: Determines whether CFEngine will record last seen
+intermittency profiles (reliability diagnostics) in WORKDIR/lastseen.
+This generates a separate file for each each host that connects to the
+current host. For central hubs this can result is a huge number of
+files.
 
 **Example**:\
  \
@@ -127,20 +132,6 @@ See also in reports:
 
         lastseen => "10";
 
-**Notes**:\
- \
-
-In reports: After this time (hours) has passed, CFEngine will begin to
-warn about the host being overdue. After the `lastseenexpireafter`
-expiry time, hosts will be purged from this host's database (default is
-a week).
-
-In control: Determines whether CFEngine will record last seen
-intermittency profiles (reliability diagnostics) in WORKDIR/lastseen.
-This generates a separate file for each each host that connects to the
-current host. For central hubs this can result is a huge number of
-files.
-
 #### `printfile` (body template)
 
 **Type**: (ext body)
@@ -154,6 +145,8 @@ files.
 **Synopsis**: Path name to the file that is to be sent to standard
 output
 
+Include part of a file in a report.
+
 **Example**:\
  \
 
@@ -165,10 +158,7 @@ output
          }
          
 
-**Notes**:\
- \
-
-Include the first 'x' number of lines of a file in a report. \
+\
 
 `number_of_lines`
 
@@ -178,6 +168,8 @@ Include the first 'x' number of lines of a file in a report. \
 
 **Synopsis**: Integer maximum number of lines to print from selected
 file
+
+Include the first 'x' number of lines of a file in a report.
 
 **Example**:\
  \
@@ -189,9 +181,6 @@ file
          }
          
 
-**Notes**:\
- \
-
 #### `report_to_file`
 
 **Type**: string
@@ -199,6 +188,10 @@ file
 **Allowed input range**: `"?(/.*)`
 
 **Synopsis**: The path and filename to which output should be appended
+
+Append the output of the report to the named file instead of standard
+output. If the file cannot be opened for writing then the report
+defaults to the standard output.
 
 **Example**:\
  \
@@ -213,13 +206,6 @@ file
 
            report_to_file => "/tmp/test_log";
     }
-
-**Notes**:\
- \
-
-Append the output of the report to the named file instead of standard
-output. If the file cannot be opened for writing then the report
-defaults to the standard output.
 
 #### `bundle_return_value_index`
 

--- a/bundles-logs-functions-variables/Bundles-for-common-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0.markdown
@@ -12,6 +12,16 @@ Bundles of `common`
 
 \
 
+Common bundles may only contain the promise types that are common to all
+bodies. Their main function is to define cross-component global
+definitions.
+
+Common bundles are observed by every agent, whereas the agent specific
+bundle types are ignored by components other than the intended
+recipient.
+
+\
+
          
          bundle common globals
          {
@@ -24,16 +34,6 @@ Bundles of `common`
            "global_class" expression = "value";
          }
          
-
-\
-
-Common bundles may only contain the promise types that are common to all
-bodies. Their main function is to define cross-component global
-definitions.
-
-Common bundles are observed by every agent, whereas the agent specific
-bundle types are ignored by components other than the intended
-recipient.
 
 -   classes in common promises:
 -   defaults in common promises:


### PR DESCRIPTION
Moved some notes closer to the top of node sections, modified some of the notes' content, and resolved some editing notes from previous rounds of content modification (generating bug reports https://cfengine.com/dev/issues/2558 and https://cfengine.com/dev/issues/2557 in the process). Started at 'slist-in-meta' and stopped before node 'bundle_return_value_index-in-reports' in the master file of original content, which is then parsed to produce the markdown files included in this commit.
