### PR TITLE
Files in bundles-logs-functions-variables using strict markdown

### DIFF
--- a/bundles-logs-functions-variables/Bundles-for-agent-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent-0.markdown
@@ -10,9 +10,9 @@ tags: [Bundles-for-agent]
 Bundles of `agent`
 ------------------
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      bundle agent main(parameter)
      
@@ -42,7 +42,7 @@ Bundles of `agent`
      
 ~~~~
 
-\
+  
 
 Agent bundles contain user-defined promises for `cf-agent`. The types of
 promises and their corresponding bodies are detailed below.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fline-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,Miscellaneous-in-edit_005fline-promises]
 
 ### Miscelleneous in `edit_line` promises
 
-\
+  
 
 Line based editing is a simple model for editing files. Before XML, and
 later JSON, most configuration files were line based. The line-based
@@ -26,9 +26,9 @@ templating.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -41,10 +41,10 @@ templating.
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body select_region MySection(x)
      {
@@ -55,15 +55,15 @@ templating.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In a sectioned file, the line that marks the opening of a section is not
 normally included in the defined region (that is, it is recognized as a
 delimiter, but it is not included as one of the lines available for
 editing). Setting this option to true makes it included. For example:
 
-~~~~ {.verbatim}
+~~~~
      [My section]
      one
      two
@@ -79,15 +79,15 @@ unaffected by any `delete_lines` promises. See the next section on
 `include_start_delimiter` for further details.
 
 **History**: This attribute was introduced in CFEngine version 3.0.5
-(2010) \
+(2010)   
 
 `include_end_delimiter`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -100,10 +100,10 @@ unaffected by any `delete_lines` promises. See the next section on
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body select_region BracketSection(x)
      {
@@ -114,15 +114,15 @@ unaffected by any `delete_lines` promises. See the next section on
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In a sectioned file, the line that marks the end of a section is not
 normally included in the defined region; that is, it is recognized as a
 delimiter, but it is not included as one of the lines available for
 editing. Setting this option to true makes it included. For example:
 
-~~~~ {.verbatim}
+~~~~
      /var/log/mail.log {
          monthly
          missingok
@@ -145,7 +145,7 @@ with them. Note that sections can be bounded at both the start and end
 in `include_start_delimiter`).
 
 **History**: This attribute was introduced in CFEngine version 3.0.5
-(2010) \
+(2010)   
 
 `select_start`
 
@@ -155,10 +155,10 @@ in `include_start_delimiter`).
 
 **Synopsis**: Regular expression matching start of edit region
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body select_region example(x)
      
@@ -169,14 +169,14 @@ in `include_start_delimiter`).
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 See also `select_end`. These delimiters mark out the region of a file to
 be edited. In the example, it is assumed that the file has section
 markers.
 
-~~~~ {.smallexample}
+~~~~
           [section 1]
           
           lines.
@@ -190,7 +190,7 @@ markers.
           
 ~~~~
 
-The start marker includes the first matched line. \
+The start marker includes the first matched line.   
 
 `select_end`
 
@@ -200,10 +200,10 @@ The start marker includes the first matched line. \
 
 **Synopsis**: Regular expression matches end of edit region from start
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body select_region example(x)
      
@@ -214,14 +214,14 @@ The start marker includes the first matched line. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 See also `select_start`. These delimiters mark out the region of a file
 to be edited. In this example, it is assumed that the file has section
 markers:
 
-~~~~ {.smallexample}
+~~~~
           [section 1]
           
           lines.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,Miscellaneous-in-edit_005fxml-promises]
 
 ### Miscelleneous in `edit_xml` promises
 
-\
+  
 
 The use of XML documents in systems configuration is widespread. XML
 documents represent data that is complex and can be structured in
@@ -27,18 +27,18 @@ editing hierarchical and structured XML datasets.
 
 **Synopsis**: Build an XPath within the XML file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body build_xpath example(s)
   {
   build_xpath => "$(s)";
   }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Please note that when `build_xpath` is defined as an attribute, within
 an `edit_xml` promise body, the tree described by the specified XPath
@@ -54,17 +54,17 @@ of such promises.
 
 **Synopsis**: Select the XPath node in the XML file to edit
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body select_xpath example(s)
 {
 select_xpath => "$(s)";
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Edits to the XML document take place within the selected node. This
 attribute is not used when inserting XML content into an empty file.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-build_005fxpath-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-build_005fxpath-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,build_005fxpath-in-edit_005fxml-promises]
 
 ### `build_xpath` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a
 balanced XML tree, described by the given XPath, will be present within
@@ -22,9 +22,9 @@ that is described by the XPath and also found within the document. The
 promise object referred to is a literal string representation of an
 XPath.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   build_xpath:
@@ -32,7 +32,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically, only a single XPath is built in each `build_xpath`
 promise. You may of course have multiple promises that each build an

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-commands-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-commands-in-agent-promises.markdown
@@ -9,9 +9,9 @@ tags: [Bundles-for-agent,commands-in-agent-promises]
 
 ### `commands` promises in agent
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      commands:
      
@@ -43,9 +43,9 @@ It is possible to set classes based on the return code of a
 commands-promise in a very flexible way. See the `kept_returncodes`,
 `repaired_returncodes` and `failed_returncodes` attributes.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {
@@ -61,13 +61,13 @@ commands:
 }
 ~~~~
 
-\
+  
 
 When referring to executables whose paths contain spaces, you should
 quote the entire program string separately so that CFEngine knows the
 name of the executable file. For example:
 
-~~~~ {.smallexample}
+~~~~
      
       commands:
      
@@ -94,10 +94,10 @@ name of the executable file. For example:
 **Synopsis**: Alternative string of arguments for the command
 (concatenated with promiser string)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
 
   "/bin/echo one"
@@ -105,14 +105,14 @@ commands:
    args => "two three";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Sometimes it is convenient to separate the arguments to a command from
 the command itself. The final arguments are the concatenation with one
 space. So in the example above the command would be:
 
-~~~~ {.verbatim}
+~~~~
  /bin/echo one two three
 ~~~~
 
@@ -124,9 +124,9 @@ space. So in the example above the command would be:
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -139,10 +139,10 @@ space. So in the example above the command would be:
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -151,8 +151,8 @@ space. So in the example above the command would be:
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The default is to *not* use a shell when executing commands. Use of a
 shell has both resource and security consequences. A shell consumes an
@@ -161,15 +161,15 @@ files and performs other actions beyond the control of CFEngine. If one
 does not need shell functionality such as piping through multiple
 commands then it is best to manage without it. In the Windows version of
 CFEngine Nova, the command is run in the the Command Prompt if useshell
-is true. \
+is true.   
 
 `umask`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     0
                     77
                     22
@@ -183,10 +183,10 @@ is true. \
 
 **Synopsis**: The umask value for the child process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -195,12 +195,12 @@ is true. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Sets the internal umask for the process. Default value for the mask is
 077. On Windows, umask is not supported and is thus ignored by Windows
-versions of CFEngine. \
+versions of CFEngine.   
 
 `exec_owner`
 
@@ -210,10 +210,10 @@ versions of CFEngine. \
 
 **Synopsis**: The user name or id under which to run the process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -222,8 +222,8 @@ versions of CFEngine. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is part of the restriction of privilege for child processes when
 running `cf-agent` as the root user, or a user with privileges.
@@ -231,7 +231,7 @@ running `cf-agent` as the root user, or a user with privileges.
 Windows requires the clear text password for the user account to run
 under. Keeping this in CFEngine policies could be a security hazard.
 Therefore, this option is not yet implemented on Windows versions of
-CFEngine. \
+CFEngine.   
 
 `exec_group`
 
@@ -241,10 +241,10 @@ CFEngine. \
 
 **Synopsis**: The group name or id under which to run the process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -253,13 +253,13 @@ CFEngine. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is part of the restriction of privilege for child processes when
 running `cf-agent` as the root group, or a group with privileges. It is
 ignored on Windows, as processes do not have any groups associated with
-them. \
+them.   
 
 `exec_timeout`
 
@@ -269,10 +269,10 @@ them. \
 
 **Synopsis**: Timeout in seconds for command completion
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -281,12 +281,12 @@ them. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Attempt to time-out after this number of seconds. This cannot be
 guaranteed as not all commands are willing to be interrupted in case of
-failure. \
+failure.   
 
 `chdir`
 
@@ -297,10 +297,10 @@ failure. \
 **Synopsis**: Directory for setting current/base directory for the
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      
@@ -310,12 +310,12 @@ process
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This command has the effect of placing the running command into a
 current working directory equal to the parameter given; in other words,
-it works like the cd shell command. \
+it works like the cd shell command.   
 
 `chroot`
 
@@ -325,10 +325,10 @@ it works like the cd shell command. \
 
 **Synopsis**: Directory of root sandbox for process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      
@@ -338,20 +338,20 @@ it works like the cd shell command. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Sets the path of the directory that will be experienced as the top-most
 root directory for the process. In security parlance, this creates a
-\`sandbox' for the process. Windows does not support this feature. \
+\`sandbox' for the process. Windows does not support this feature.   
 
 `preview`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -365,10 +365,10 @@ root directory for the process. In security parlance, this creates a
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -377,22 +377,22 @@ root directory for the process. In security parlance, this creates a
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Previewing shell scripts during a dry-run is a potentially misleading
 activity. It should only be used on scripts that make no changes to the
 system. It is CFEngine best practice to never write change-functionality
 into user-written scripts except as a last resort. CFEngine can apply
-its safety checks to user defined scripts. \
+its safety checks to user defined scripts.   
 
 `no_output`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -405,10 +405,10 @@ its safety checks to user defined scripts. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body contain example
      {
@@ -417,8 +417,8 @@ its safety checks to user defined scripts. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is equivalent to piping standard output and error to /dev/null.
 
@@ -426,9 +426,9 @@ This is equivalent to piping standard output and error to /dev/null.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -441,10 +441,10 @@ This is equivalent to piping standard output and error to /dev/null.
 
 **Synopsis**: true/false whether to expect the cfengine module protocol
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
 
    "/masterfiles/user_script"
@@ -452,8 +452,8 @@ commands:
      module => "true";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If true, the module protocol is supported for this script. In other
 words, it is treated as a user module. A plug-in module may be written
@@ -467,7 +467,7 @@ beginning with @ are lists. Any other lines of output are cited by
 `cf-agent` as being erroneous, so you should normally make your module
 completely silent. Here is an example written in shell:
 
-~~~~ {.smallexample}
+~~~~
      #!/bin/sh
      /bin/echo "@mylist= { \"one\", \"two\", \"three\" }"
      /bin/echo "=myscalar= scalar val"
@@ -476,7 +476,7 @@ completely silent. Here is an example written in shell:
 
 And here is an example using it:
 
-~~~~ {.verbatim}
+~~~~
 body common control
    {
    any::
@@ -528,7 +528,7 @@ reports:
 
 Here is an example module written in Perl:
 
-~~~~ {.smallexample}
+~~~~
      #!/usr/bin/perl
      #
      # module:myplugin
@@ -550,7 +550,7 @@ reading the promises file). For example, the promises could read as
 follows (the two `echo` commands are to ensure that the shell always
 exits with a successful execution of a command):
 
-~~~~ {.verbatim}
+~~~~
 bundle agent sendmail
 {
 commands:
@@ -583,7 +583,7 @@ body contain not_paranoid
 Modules inherit the environment variables from cfagent and accept
 arguments, just as a regular command does.
 
-~~~~ {.smallexample}
+~~~~
      #!/bin/sh
      #
      # module:myplugin
@@ -595,7 +595,7 @@ arguments, just as a regular command does.
 
 Modules define variables in `cf-agent` by outputting strings of the form
 
-~~~~ {.smallexample}
+~~~~
      
      =variablename=value
      

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-databases-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-databases-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,databases-in-agent-promises]
 
 ### `databases` promises in agent
 
-\
+  
 
 CFEngine Nova can interact with commonly used database servers to keep
 promises about the structure and content of data within them.
@@ -32,12 +32,12 @@ There are three kinds of database supported by Nova:
 
 *LDAP - The Lightweight Directory Access Protocol*
 
-A hierarchical network database primarily for reading simple schema. \
+A hierarchical network database primarily for reading simple schema.   
 
 *SQL - Structured Query Language*
 
 A number of relational databases (currently supported: MySQL, Postgres)
-for reading and writing complex data. \
+for reading and writing complex data.   
 
 *Registry - Microsoft Registry*
 
@@ -55,7 +55,7 @@ and CFEngine cannot make promises on their behalf, unless they promise
 pre-requisite for making SQL database promises is to grant a point of
 access on the server.
 
-~~~~ {.smallexample}
+~~~~
      
       databases:
      
@@ -82,9 +82,9 @@ access on the server.
      
 ~~~~
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "databases" };
@@ -143,7 +143,7 @@ exec_owner => "$(x)";
 }
 ~~~~
 
-\
+  
 
 The promiser in database promises is a concatenation of the database
 name and underlying tables. This presents a simple hierarchical model
@@ -172,18 +172,18 @@ a hierarchy of depth 1.
 
 **Synopsis**: User name for database connection
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      db_server_owner => "mark";
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `db_server_password`
 
@@ -193,18 +193,18 @@ a hierarchy of depth 1.
 
 **Synopsis**: Clear text password for database connection
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      db_server_password => "xyz.1234";
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `db_server_host`
 
@@ -215,27 +215,27 @@ a hierarchy of depth 1.
 **Synopsis**: Hostname or address for connection to database (blank
 means localhost)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      db_server_host => "sqlserv.example.org";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-Hostname or IP address of the server. \
+Hostname or IP address of the server.   
 
 `db_server_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     postgres
                     mysql
 ~~~~
@@ -244,18 +244,18 @@ Hostname or IP address of the server. \
 
 **Default value:** none
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      db_server_type => "postgres";
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `db_server_connection_db`
 
@@ -266,10 +266,10 @@ Hostname or IP address of the server. \
 **Synopsis**: The name of an existing database to connect to in order to
 create/manage other databases
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body database_server myserver(x)
      {
@@ -284,8 +284,8 @@ create/manage other databases
 
 where x is currently `mysql` or `postgres`.
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In order to create a database on a database server (all of which
 practice voluntary cooperation), one has to be able to connect to the
@@ -302,9 +302,9 @@ body.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                sql
                ms_registry
 ~~~~
@@ -313,23 +313,23 @@ body.
 
 **Synopsis**: The type of database that is to be manipulated
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 database_type => "ms_registry";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 #### `database_operation`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                create
                delete
                drop
@@ -340,15 +340,15 @@ database_type => "ms_registry";
 
 **Synopsis**: The nature of the promise - to be or not to be
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 database_operation => "create";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 #### `database_columns`
 
@@ -359,10 +359,10 @@ database_operation => "create";
 **Synopsis**: A list of column definitions to be promised by SQL
 databases
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
   "cf_topic_maps/topics"
 
     database_operation => "create",
@@ -378,8 +378,8 @@ databases
     database_server => myserver;
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Columns are a list of tuplets (Name,type,size). Array items are
 triplets, and fixed size data elements are doublets.
@@ -393,10 +393,10 @@ triplets, and fixed size data elements are doublets.
 **Synopsis**: An ordered list of row values to be promised by SQL
 databases
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent databases
 
 {
@@ -414,8 +414,8 @@ databases:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This constraint is used only in adding data to database columns. Rows
 are considered to be instances of individual columns.
@@ -434,10 +434,10 @@ for the Windows registry are `REG_SZ` (string), `REG_EXPAND_SZ`
 **Synopsis**: A list of regular expressions to ignore in key/value
 verification
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 databases:
 
  "HKEY_LOCAL_MACHINE\SOFTWARE"
@@ -456,8 +456,8 @@ databases:
     database_type     => "ms_registry";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 During recursive Windows registry scanning, this option allows us to
 ignore keys of values matching a list of regular expressions. Some

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005fattribute-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005fattribute-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,delete_005fattribute-in-edit_005fxml-promises]
 
 ### `delete_attribute` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that an
 attribute, with the given name, will not be present in the specified
@@ -19,9 +19,9 @@ specified node is determined by body-attributes. The promise object
 referred to is a literal string representation of the name of the
 attribute to be deleted.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   delete_attribute:
@@ -31,7 +31,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically, only a single attribute, within a single specified
 node, is deleted in each `delete_attribute` promise. You may of course

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005flines-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005flines-in-edit_005fline-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,delete_005flines-in-edit_005fline-promises]
 
 ### `delete_lines` promises in edit\_line
 
-\
+  
 
 This promise assures that certain lines exactly matching regular
 expression patterns will not be present in a text file. If the lines are
@@ -17,9 +17,9 @@ found, the default promise is to remove them (this behavior may be
 modified with further pattern matching in `delete_select` and/or changed
 with `not_matching`).
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line example
   {
   delete_lines:
@@ -39,7 +39,7 @@ are present in the file *in exactly the same order* as specified in the
 promise (with no intervening lines). That is, all the lines must match
 as a unit for the `delete_lines` promise to be kept.
 
-\
+  
 
 If the promiser contains multiple lines, then CFEngine assumes that all
 of the lines must exist as a contiguous block in order to be deletes.
@@ -63,10 +63,10 @@ promise.
 
 **Synopsis**: Delete line if it starts with a string in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select example(s)
      {
@@ -75,15 +75,15 @@ promise.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from a file if they begin with the sub-strings listed. Note
 that this determination is made only on promised lines (that is, this
 attribute modifies the selection criteria, it does not make the initial
 selection). Therefore, if the file contains the following lines:
 
-~~~~ {.verbatim}
+~~~~
      start alpha igniter
      start beta igniter
      init alpha burner
@@ -97,7 +97,7 @@ Then the following promise initially selects the four lines containing
 alpha, but is moderated by the `delete_select` attribute. Thus, the
 promise will delete only the first and third lines of the file:
 
-~~~~ {.verbatim}
+~~~~
      bundle edit_line alpha
      {
      delete_lines:
@@ -111,7 +111,7 @@ promise will delete only the first and third lines of the file:
      }
 ~~~~
 
-\
+  
 
 `delete_if_not_startwith_from_list`
 
@@ -121,10 +121,10 @@ promise will delete only the first and third lines of the file:
 
 **Synopsis**: Delete line if it DOES NOT start with a string in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select example(s)
      {
@@ -133,13 +133,13 @@ promise will delete only the first and third lines of the file:
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from a file unless they start with the sub-strings in the
 list given. Note that this determination is made only on promised lines.
 In other words, this attribute modifies the selection criteria, it does
-not make the initial selection. \
+not make the initial selection.   
 
 `delete_if_match_from_list`
 
@@ -149,10 +149,10 @@ not make the initial selection. \
 
 **Synopsis**: Delete line if it fully matches a regex in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select example(s)
      {
@@ -161,8 +161,8 @@ not make the initial selection. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from a file if the lines *completely* match any of the
 regular expressions listed. In other words, the regular expression is
@@ -171,7 +171,7 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 
 Note that this attribute modifies the selection criteria, it does not
 make the initial selection, and the match determination is made only on
-promised lines. \
+promised lines.   
 
 `delete_if_not_match_from_list`
 
@@ -181,10 +181,10 @@ promised lines. \
 
 **Synopsis**: Delete line if it DOES NOT fully match a regex in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select example(s)
      {
@@ -193,8 +193,8 @@ promised lines. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from a file unless the lines *completely* match any of the
 regular expressions listed. In other words, the regular expressions are
@@ -203,7 +203,7 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 
 Note that this attribute modifies the selection criteria, it does not
 make the initial selection, and the match determination is made only on
-promised lines. \
+promised lines.   
 
 `delete_if_contains_from_list`
 
@@ -213,10 +213,10 @@ promised lines. \
 
 **Synopsis**: Delete line if a regex in the list match a line fragment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select example(s)
      {
@@ -225,14 +225,14 @@ promised lines. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from a file if they contain the sub-strings listed.
 
 Note that this attribute modifies the selection criteria, it does not
 make the initial selection, and the match determination is made only on
-promised lines. \
+promised lines.   
 
 `delete_if_not_contains_from_list`
 
@@ -243,10 +243,10 @@ promised lines. \
 **Synopsis**: Delete line if a regex in the list DOES NOT match a line
 fragment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete_select discard(s)
      {
@@ -255,8 +255,8 @@ fragment
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Delete lines from the file which do not contain the sub-strings listed.
 
@@ -268,9 +268,9 @@ promised lines.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -283,10 +283,10 @@ promised lines.
 
 **Synopsis**: true/false negate match criterion
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 delete_lines:
 
   # edit /etc/passwd - account names that are not "mark" or "root"
@@ -294,8 +294,8 @@ delete_lines:
   "(mark|root):.*" not_matching => "true";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When this option is true, it negates the pattern match of the promised
 lines.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftext-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,delete_005ftext-in-edit_005fxml-promises]
 
 ### `delete_text` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a value
 string, containing the matching substring, will not be present in the
@@ -18,9 +18,9 @@ default promise is to remove the existing value string, from within the
 specified node. The specified node is determined by body-attributes. The
 promise object referred to is a literal string of text.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   delete_text:
@@ -30,7 +30,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically, only a single value string, within a single
 specified node, is deleted in each `delete_text` promise. You may of

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftree-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftree-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,delete_005ftree-in-edit_005fxml-promises]
 
 ### `delete_tree` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a
 balanced XML tree, containing the matching subtree, will not be present
@@ -19,9 +19,9 @@ specified node. The specified node is determined by body-attributes. The
 promise object referred to is a literal string representation of a
 balanced XML subtree.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   delete_tree:
@@ -31,7 +31,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically, only a single tree, within a single specified node,
 is deleted in each `delete_tree` promise. You may of course have

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-field_005fedits-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-field_005fedits-in-edit_005fline-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,field_005fedits-in-edit_005fline-promises]
 
 ### `field_edits` promises in edit\_line
 
-\
+  
 
 Certain types of text files (e.g. the passwd and group files in Unix)
 are tabular in nature, with field separators (e.g. : or ,). This promise
@@ -23,7 +23,7 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). Then a
 sub-fields, along with policies for editing these fields, ordering the
 items within them.
 
-~~~~ {.smallexample}
+~~~~
      
      field_edits:
      
@@ -33,9 +33,9 @@ items within them.
      
 ~~~~
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {
@@ -103,14 +103,14 @@ extend_fields => "true";
 }
 ~~~~
 
-\
+  
 
 Field editing allows us to edit tabular files in a unique way, adding
 and removing data from addressable fields. The passwd and group files
 are classic examples of tabular files, but there are many ways to use
 this feature. For example, editing a string:
 
-~~~~ {.verbatim}
+~~~~
 VARIABLE="one two three"
 ~~~~
 
@@ -127,9 +127,9 @@ given by the space.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -142,10 +142,10 @@ given by the space.
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field example
      {
@@ -155,21 +155,21 @@ given by the space.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When editing a file using the field or column model, blank fields,
 especially at the start and end are generally discarded. If this is set
 to true, CFEngine will retain the blank fields and print the appropriate
-number of field separators. \
+number of field separators.   
 
 `extend_fields`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -183,10 +183,10 @@ complete edit
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field example
      {
@@ -195,22 +195,22 @@ complete edit
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If a user specifies a field that does not exist, because there are not
 so many fields, this allows the number of fields to be extended. Without
 this setting, CFEngine will issue an error if a non-existent field is
 referenced. Blank fields in a tabular file can be eliminated or kept
-depending in this setting. If in doubt, set this to true. \
+depending in this setting. If in doubt, set this to true.   
 
 `field_operation`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     prepend
                     append
                     alphanum
@@ -222,10 +222,10 @@ depending in this setting. If in doubt, set this to true. \
 
 **Default value:** none
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field example
      {
@@ -234,8 +234,8 @@ depending in this setting. If in doubt, set this to true. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The method by which to edit a field in multi-field/column editing of
 tabular files. The methods mean:
@@ -256,7 +256,7 @@ set - replace the entire field/column with the specified value
 delete - delete the specified value (if present) in the specified
 field/column
 
-**Default value**: append \
+**Default value**: append   
 
 `field_separator`
 
@@ -268,10 +268,10 @@ field/column
 
 **Default value:** none
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field example
      {
@@ -280,12 +280,12 @@ field/column
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Most tabular files are separated by simple characters, but by allowing a
 general regular expression one can make creative use of this model to
-edit all kinds of line-based text files. \
+edit all kinds of line-based text files.   
 
 `field_value`
 
@@ -295,10 +295,10 @@ edit all kinds of line-based text files. \
 
 **Synopsis**: Set field value to a fixed value
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field example(s)
      {
@@ -307,11 +307,11 @@ edit all kinds of line-based text files. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Set a field to a constant value. For example, reset the value to a
-constant default, empty the field, or set it fixed list. \
+constant default, empty the field, or set it fixed list.   
 
 `select_field`
 
@@ -322,10 +322,10 @@ constant default, empty the field, or set it fixed list. \
 **Synopsis**: Integer index of the field required 0..n (default starts
 from 1)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body field_edits example
      {
@@ -333,18 +333,18 @@ from 1)
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-Numbering starts from 1 (not from 0). \
+Numbering starts from 1 (not from 0).   
 
 `start_fields_from_zero`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -355,10 +355,10 @@ Numbering starts from 1 (not from 0). \
 
 **Synopsis**: If set, the default field numbering starts from 0
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_field col(split,col,newval,method)
      
@@ -375,8 +375,8 @@ Numbering starts from 1 (not from 0). \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.0b1,Nova 2.0.0b1 (2010)
 
@@ -384,7 +384,7 @@ The numbering of fields is a matter for consistency and convention.
 Arrays are usually thought to start with first index equal to zero (0),
 but the first column in a file would normally be 1. By setting this
 option, you can tell CFEngine that the first column should be understood
-as number 0 instead, for consistency with other array functions. \
+as number 0 instead, for consistency with other array functions.   
 
 `value_separator`
 
@@ -397,10 +397,10 @@ field
 
 **Default value:** none
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body field_edit example
      {
@@ -409,8 +409,8 @@ field
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 For example, elements in the group file are separated by :, but the
 lists of users in these fields are separated by ,.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
@@ -9,12 +9,12 @@ tags: [Bundles-for-agent,files-in-agent-promises]
 
 ### `files` promises in agent
 
-\
+  
 
 Files promises are an umbrella for attributes of files. Operations fall
 basically into three categories: create, delete and edit.
 
-~~~~ {.smallexample}
+~~~~
      
       files:
      
@@ -35,7 +35,7 @@ There is a natural ordering in file processing that obviates the need
 for the actionsequence. For example, the trick of using multiple
 actionsequence items with different classes.
 
-~~~~ {.verbatim}
+~~~~
  actionsequence = ( ... files.one  ..  files.two )
 ~~~~
 
@@ -73,7 +73,7 @@ See: \`File editing in CFEngine 3'
 
 The pseudo-code for this logic is shown in the diagram and below:
 
-~~~~ {.verbatim}
+~~~~
  for each file promise-object
     {
     if (depth_search) 
@@ -122,7 +122,7 @@ Recursion is now called "depth-search". In addition, it was possible to
 specify wildcards in the base-path for this search. CFEngine 3 replaces
 the \`globbing' symbols with standard regular expressions:
 
-~~~~ {.verbatim}
+~~~~
       CFEngine 2               CFEngine 3
 
 /one/*/two/thr*/four    /one/.*/two/thr.*/four
@@ -199,7 +199,7 @@ two examples, which assumethat there first exist files named /tmp/gar,
 /tmp/garbage and /tmp/garden. Initially, the two promises look like they
 should do the same thing; but there is a subtle difference:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent foobaz           bundle agent foobaz
 {                   {
 files:                  files:
@@ -278,7 +278,7 @@ external attributes.
 
 A typical file editing stanza has the elements in the following example:
 
-~~~~ {.verbatim}
+~~~~
 ######################################################################
 #
 # File editing
@@ -419,7 +419,7 @@ Community Edition only reports that changes were found, but Enterprise
 versions of CFEngine can also report on what exactly the significant
 changes were.
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {
 files:
@@ -442,7 +442,7 @@ update         => "yes";
 }
 ~~~~
 
-\
+  
 
 -   [acl in files](#acl-in-files)
 -   [changes in files](#changes-in-files)
@@ -477,10 +477,10 @@ update         => "yes";
 
 **Synopsis**: Native settings for access control entry
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body acl template
      
@@ -499,14 +499,14 @@ update         => "yes";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 POSIX ACL are available in CFEngine Community starting with 3.4.0. NTFS
 ACL are available with CFEngine Nova or above. Form of the permissions
 is:
 
-~~~~ {.smallexample}
+~~~~
                 aces = {
                         "user:uid:mode[:perm_type]", ...,
                         "group:gid:mode[:perm_type]", ...,
@@ -559,7 +559,7 @@ Semantics on file
 
 Semantics on directory
 
-\
+  
 
 `r`
 
@@ -567,7 +567,7 @@ Read
 
 Read data, permissions, attributes
 
-Read directory contents, permissions, attributes \
+Read directory contents, permissions, attributes   
 
 `w`
 
@@ -575,7 +575,7 @@ Write
 
 Write data
 
-Create, delete, rename subobjects \
+Create, delete, rename subobjects   
 
 `x`
 
@@ -583,19 +583,19 @@ Execute
 
 Execute file
 
-Access subobjects \
+Access subobjects   
 
 Note that the `r` permission is not necessary to read an object's
 permissions and attributes in all file systems. For example, in POSIX,
-having `x` on its containing directory is sufficient. \
+having `x` on its containing directory is sufficient.   
 
 `acl_directory_inherit`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     nochange
                     parent
                     specify
@@ -604,10 +604,10 @@ having `x` on its containing directory is sufficient. \
 
 **Synopsis**: Access control list type for the affected file system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body acl template
      
@@ -626,8 +626,8 @@ having `x` on its containing directory is sufficient. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Directories have ACLs associated with them, but they also have the
 ability to inherit an ACL to sub-objects created within them. POSIX
@@ -639,25 +639,25 @@ ACL of directories. The default ACL can be left unchanged (`nochange`),
 empty (`clear`), or be explicitly specified (`specify`). In addition,
 the default ACL can be set equal to the directory's access ACL
 (`parent`). This has the effect that child objects of the directory gets
-the same access ACL as the directory. \
+the same access ACL as the directory.   
 
 `acl_method`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     append
                     overwrite
 ~~~~
 
 **Synopsis**: Editing method for access control list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body acl template
      
@@ -669,8 +669,8 @@ the same access ACL as the directory. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When defining an ACL, we can either use an existing ACL as the starting
 point, or state all entries of the ACL. If we just care about one entry,
@@ -680,15 +680,15 @@ existing ACL entries that are not mentioned will be left unchanged. On
 the other hand, if `method` is set to `overwrite`, the resulting ACL
 will only contain the mentioned entries. When doing this, it is
 important to check that all the required ACL entries are set. For
-example, owning user, group and all in POSIX ACLs. \
+example, owning user, group and all in POSIX ACLs.   
 
 `acl_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     generic
                     posix
                     ntfs
@@ -696,10 +696,10 @@ example, owning user, group and all in POSIX ACLs. \
 
 **Synopsis**: Access control list type for the affected file system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body acl template
      
@@ -710,8 +710,8 @@ example, owning user, group and all in POSIX ACLs. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 ACLs are supported on multiple platforms, which may have different sets
 of available permission flags. By using the constraint `acl_type`, we
@@ -720,7 +720,7 @@ The default, `generic`, is designed to work on all supported platforms.
 However, if very specific permission flags are required, like Take
 Ownership on the NTFS platform, we must set `acl_type` to indicate the
 target platform. Currently, the supported values are `posix` and `ntfs`.
-\
+  
 
 `specify_inherit_aces`
 
@@ -731,18 +731,18 @@ target platform. Currently, the supported values are `posix` and `ntfs`.
 
 **Synopsis**: Native settings for access control entry
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body acl template
      {
      specify_inherit_aces => {  "all:r" };
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 `specify_inherit_aces` (optional) is a list of access control entries
 that are set on child objects. It is also parsed from left to right and
@@ -761,9 +761,9 @@ that do not have a clear inheritance policy.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     md5
                     sha1
                     sha224
@@ -775,10 +775,10 @@ that do not have a clear inheritance policy.
 
 **Synopsis**: Hash files for change detection
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body changes example
      {
@@ -787,19 +787,19 @@ that do not have a clear inheritance policy.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The `best` option cross correlates the best two available algorithms
-known in the OpenSSL library. \
+known in the OpenSSL library.   
 
 `report_changes`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     all
                     stats
                     content
@@ -808,10 +808,10 @@ known in the OpenSSL library. \
 
 **Synopsis**: Specify criteria for change warnings
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body changes example
      {
@@ -820,19 +820,19 @@ known in the OpenSSL library. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Files can change in permissions and contents, i.e. external or internal
-attributes. If all is chosen all attributes are checked. \
+attributes. If all is chosen all attributes are checked.   
 
 `update_hashes`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -843,10 +843,10 @@ attributes. If all is chosen all attributes are checked. \
 
 **Synopsis**: Update hash values immediately after change warning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body changes example
      {
@@ -855,20 +855,20 @@ attributes. If all is chosen all attributes are checked. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this is positive, file hashes should be updated as soon as a change
 is registered so that multiple warnings are not given about a single
-change. This applies to addition and removal too. \
+change. This applies to addition and removal too.   
 
 `report_diffs`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -880,10 +880,10 @@ change. This applies to addition and removal too. \
 **Synopsis**: Generate reports summarizing the major differences between
 individual text files
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body changes example
      {
@@ -892,8 +892,8 @@ individual text files
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *This feature is available only in enterprise levels Nova and above.*
 
@@ -921,10 +921,10 @@ the system.
 
 **Synopsis**: Reference source file from which to copy
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -940,10 +940,10 @@ the system.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-For remote copies this refers to the file name on the remote server. \
+For remote copies this refers to the file name on the remote server.   
 
 `servers`
 
@@ -953,10 +953,10 @@ For remote copies this refers to the file name on the remote server. \
 
 **Synopsis**: List of servers in order of preference from which to copy
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -966,18 +966,18 @@ For remote copies this refers to the file name on the remote server. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-The servers are tried in order until one of them succeeds. \
+The servers are tried in order until one of them succeeds.   
 
 `collapse_destination_dir`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -989,10 +989,10 @@ The servers are tried in order until one of them succeeds. \
 **Synopsis**: Place files in subdirectories into the root destination
 directory during copy
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from mycopy(from,server)
      
@@ -1004,8 +1004,8 @@ directory during copy
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Under normal operations, recursive copies cause CFEngine to track
 subdirectories of files. So, for instance, if we copy recursively from
@@ -1013,15 +1013,15 @@ src to dest, then src/subdir/file will map to dest/subdir/file.
 
 By setting this option to true, the promiser destination directory
 promises to aggregate files searched from all subdirectories into
-itself; in other words, a single destination directory. \
+itself; in other words, a single destination directory.   
 
 `compare`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     atime
                     mtime
                     ctime
@@ -1036,10 +1036,10 @@ attributes
 
 **Default value:** mtime or ctime differs
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      
@@ -1049,8 +1049,8 @@ attributes
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The default copy method is mtime (modification time), meaning that the
 source file is copied to the destination (promiser) file, if the source
@@ -1082,15 +1082,15 @@ The different options are:
     used.
 -   `digest` a synonym for `hash`
 
-\
+  
 
 `copy_backup`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     timestamp
@@ -1100,10 +1100,10 @@ The different options are:
 
 **Default value:** true
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1112,8 +1112,8 @@ The different options are:
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Determines whether a backup of the previous version is kept on the
 system. This should be viewed in connection with the system repository,
@@ -1121,15 +1121,15 @@ since a defined repository affects the location at which the backup is
 stored.
 
 See: [default\_repository](#default_005frepository-in-agent) and
-[repository](#repository-in-files) for further details. \
+[repository](#repository-in-files) for further details.   
 
 `encrypt`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1143,10 +1143,10 @@ host
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1156,20 +1156,20 @@ host
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Client connections are encrypted with using a Blowfish randomly
 generated session key. The initial connection is encrypted using the
-public/private keys for the client and server hosts. \
+public/private keys for the client and server hosts.   
 
 `check_root`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1181,10 +1181,10 @@ public/private keys for the client and server hosts. \
 **Synopsis**: true/false check permissions on the root directory when
 depth\_search
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1193,13 +1193,13 @@ depth\_search
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When copying files recursively (by depth search), this flag determines
 whether the permissions of the root directory should be set from the
 root of the source. The default is to check only copied file objects and
-subdirectories within this root (false). \
+subdirectories within this root (false).   
 
 `copylink_patterns`
 
@@ -1210,10 +1210,10 @@ subdirectories within this root (false). \
 **Synopsis**: List of patterns matching files that should be copied
 instead of linked
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1222,12 +1222,12 @@ instead of linked
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The matches are performed on the last node of the filename; in other
 words, the file without its path. As Windows does not support symbolic
-links, this feature is not available there. \
+links, this feature is not available there.   
 
 `copy_size`
 
@@ -1239,10 +1239,10 @@ links, this feature is not available there. \
 
 **Default value:** any size range
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1251,28 +1251,28 @@ links, this feature is not available there. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The use of the irange function is optional. Ranges may also be specified
-as a comma separated numbers. \
+as a comma separated numbers.   
 
 `findertype`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     MacOSX
 ~~~~
 
 **Synopsis**: Menu option for default finder type on MacOSX
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1281,10 +1281,10 @@ as a comma separated numbers. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This applies only to the Mac OS X variants. \
+This applies only to the Mac OS X variants.   
 
 `linkcopy_patterns`
 
@@ -1295,10 +1295,10 @@ This applies only to the Mac OS X variants. \
 **Synopsis**: List of patterns matching files that should be replaced
 with symbolic links
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from mycopy(from)
      
@@ -1309,21 +1309,21 @@ with symbolic links
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The pattern matches the last node filename; in other words, without the
 absolute path. Windows only supports hard links.
 
-See: `link_type`. \
+See: `link_type`.   
 
 `link_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     symlink
                     hardlink
                     relative
@@ -1334,10 +1334,10 @@ See: `link_type`. \
 
 **Default value:** symlink
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -1347,8 +1347,8 @@ See: `link_type`. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Users are advised to be wary of \`hard links' (see Unix manual pages for
 the ln command). The behaviour of non-symbolic links is often precarious
@@ -1360,15 +1360,15 @@ from relative links. Although all of these are symbolic links, the
 nomenclature here is defined such that symlink and absolute are
 equivalent . When verifying a link, choosing \`relative' means that the
 link *must* be relative to the source, so relative and absolute links
-are mutually exclusive. \
+are mutually exclusive.   
 
 `force_update`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1381,10 +1381,10 @@ are mutually exclusive. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1393,22 +1393,22 @@ are mutually exclusive. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Warning: this is a non-convergent operation. Although the end point
 might stabilize in content, the operation will never quiesce. Use of
 this feature is not recommended except in exceptional circumstances
 since it creates a busy-dependency. If the copy is a network copy, the
-system will be disturbed by network disruptions. \
+system will be disturbed by network disruptions.   
 
 `force_ipv4`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1421,10 +1421,10 @@ system will be disturbed by network disruptions. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1433,11 +1433,11 @@ system will be disturbed by network disruptions. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 IPv6 should be harmless to most users unless you have a partially or
-mis-configured setup. \
+mis-configured setup.   
 
 `portnumber`
 
@@ -1447,10 +1447,10 @@ mis-configured setup. \
 
 **Synopsis**: Port number to connect to on server host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1459,20 +1459,20 @@ mis-configured setup. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The standard or registered port number is tcp/5308. CFEngine does not
 presently use its registered udp port with the same number, but this
-could change in the future. \
+could change in the future.   
 
 `preserve`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1486,10 +1486,10 @@ file
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1498,21 +1498,21 @@ file
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Ensures the destination file (promiser) gets the same Unix mode as the
 source. This also applies to remote copies.
 
-*History*: Was introduced in version 3.1.0b3,Nova 2.0.0b1 (2010) \
+*History*: Was introduced in version 3.1.0b3,Nova 2.0.0b1 (2010)   
 
 `purge`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1526,10 +1526,10 @@ on server when a depth\_search is used
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1538,8 +1538,8 @@ on server when a depth\_search is used
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Purging files is a potentially dangerous matter during a file copy it
 implies that any promiser (destination) file which is not matched by a
@@ -1548,15 +1548,15 @@ will be irretrievable. Great care should be exercised when using this
 feature.
 
 Note that purging will also delete backup files generated during the
-file copying if `copy_backup` is set to true. \
+file copying if `copy_backup` is set to true.   
 
 `stealth`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1569,10 +1569,10 @@ file copying if `copy_backup` is set to true. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1581,10 +1581,10 @@ file copying if `copy_backup` is set to true. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-Preserves file access and modification times on the promiser files. \
+Preserves file access and modification times on the promiser files.   
 
 `timeout`
 
@@ -1594,10 +1594,10 @@ Preserves file access and modification times on the promiser files. \
 
 **Synopsis**: Connection timeout, seconds
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body runagent control
      {
@@ -1606,18 +1606,18 @@ Preserves file access and modification times on the promiser files. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-Timeout in seconds. \
+Timeout in seconds.   
 
 `trustkey`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1631,10 +1631,10 @@ previously unknown
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1643,8 +1643,8 @@ previously unknown
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the server's public key has not already been trusted, trustkey
 provides automated key-exchange.
@@ -1660,15 +1660,15 @@ trust issue is most important on the server side.
 As soon as a public key has been exchanged, the trust option has no
 effect. A machine that has been trusted remains trusted until its key is
 manually revoked by a system administrator. Keys are stored in
-WORKDIR/ppkeys. \
+WORKDIR/ppkeys.   
 
 `type_check`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1680,10 +1680,10 @@ WORKDIR/ppkeys. \
 **Synopsis**: true/false compare file types before copying and require
 match
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1692,20 +1692,20 @@ match
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 File types at source and destination should normally match in order for
 updates to overwrite them. This option allows this checking to be
-switched off. \
+switched off.   
 
 `verify`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1719,10 +1719,10 @@ switched off. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -1731,8 +1731,8 @@ switched off. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a highly resource intensive option, not recommended for large
 file transfers.
@@ -1741,9 +1741,9 @@ file transfers.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -1756,10 +1756,10 @@ file transfers.
 
 **Synopsis**: true/false whether to create non-existing file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
   "/path/plain_file"
@@ -1771,8 +1771,8 @@ files:
      create =>   "true";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Directories are created by using the /. to signify a directory type.
 Note that, if no permissions are specified, mode 600 is chosen for a
@@ -1800,9 +1800,9 @@ operations).
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     delete
                     tidy
                     keep
@@ -1811,10 +1811,10 @@ operations).
 **Synopsis**: Menu option policy for dealing with symbolic links to
 directories during deletion
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete example
      {
@@ -1823,8 +1823,8 @@ directories during deletion
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Links to directories are normally removed just like any other link or
 file objects. By keeping directory links, you preserve the logical
@@ -1835,22 +1835,22 @@ The value `keep` instructs CFEngine not to remove directory links. The
 values `delete` and `tidy` are synonymous, and instruct CFEngine to
 remove directory links.
 
-**Default value** (only if body is present):\
- \
+**Default value** (only if body is present):  
+   
 
 The default value only has significance if there is a `delete` body
 present. If there is no `delete` body then files (and directory links)
 are **not** deleted.
 
-`dirlinks = delete` \
+`dirlinks = delete`   
 
 `rmdirs`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1862,10 +1862,10 @@ are **not** deleted.
 **Synopsis**: true/false whether to delete empty directories during
 recursive deletion
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body delete example
      {
@@ -1874,15 +1874,15 @@ recursive deletion
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Note the parent directory of a search is not deleted in recursive
 deletions. In CFEngine 2 there was an option to delete the parent of the
 search. In CFEngine 3 you must code a separate promise to delete the
 single parent object.
 
-~~~~ {.verbatim}
+~~~~
      
      bundle agent cleanup
      {
@@ -1916,8 +1916,8 @@ single parent object.
      
 ~~~~
 
-**Default value** (only if body is present):\
- \
+**Default value** (only if body is present):  
+   
 
 The default value only has significance if there is a `delete` body
 present. If there is no `delete` body then files (and directories) are
@@ -1937,10 +1937,10 @@ present. If there is no `delete` body then files (and directories) are
 
 **Synopsis**: Maximum depth level for search
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -1949,15 +1949,15 @@ present. If there is no `delete` body then files (and directories) are
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This was previously called \`recurse' in earlier versions of CFEngine.
 Note that the value inf may be used for an unlimited value.
 
 When searching recursively from a directory, the parent directory is
 only the anchor point and is not part of the search. To alter the
-parent, a separate non-recursive promise should be made. \
+parent, a separate non-recursive promise should be made.   
 
 `exclude_dirs`
 
@@ -1968,10 +1968,10 @@ parent, a separate non-recursive promise should be made. \
 **Synopsis**: List of regexes of directory names NOT to include in depth
 search
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search
      {
@@ -1981,19 +1981,19 @@ search
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Directory names are treated specially when searching recursively through
-a file system. \
+a file system.   
 
 `include_basedir`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2005,10 +2005,10 @@ a file system. \
 **Synopsis**: true/false include the start/root dir of the search
 results
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -2017,14 +2017,14 @@ results
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When checking files recursively (with `depth_search`) the promiser is a
 directory. This parameter determines whether that initial directory
 should be considered part of the promise or simply a boundary that marks
 the edge of the search. If true, the promiser directory will also
-promise the same attributes as the files inside it. \
+promise the same attributes as the files inside it.   
 
 `include_dirs`
 
@@ -2035,10 +2035,10 @@ promise the same attributes as the files inside it. \
 **Synopsis**: List of regexes of directory names to include in depth
 search
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -2047,18 +2047,18 @@ search
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This is the complement of `exclude_dirs`. \
+This is the complement of `exclude_dirs`.   
 
 `rmdeadlinks`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2071,10 +2071,10 @@ This is the complement of `exclude_dirs`. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -2083,19 +2083,19 @@ This is the complement of `exclude_dirs`. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A value of true determines that links pointing to files that do not
-exist should be deleted; or kept if set to false. \
+exist should be deleted; or kept if set to false.   
 
 `traverse_links`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2108,10 +2108,10 @@ exist should be deleted; or kept if set to false. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -2120,20 +2120,20 @@ exist should be deleted; or kept if set to false. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this is true, `cf-agent` will treat symbolic links to directories as
 if they were directories. Normally this is considered a potentially
-dangerous assumption and links are not traversed. \
+dangerous assumption and links are not traversed.   
 
 `xdev`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2147,10 +2147,10 @@ devices
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body depth_search example
      {
@@ -2159,8 +2159,8 @@ devices
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 #### `edit_defaults` (body template)
 
@@ -2170,9 +2170,9 @@ devices
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     timestamp
@@ -2183,10 +2183,10 @@ devices
 
 **Default value:** true
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_defaults example
      {
@@ -2195,17 +2195,17 @@ devices
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `empty_file_before_editing`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2219,10 +2219,10 @@ commencing promised edits
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_defaults example
      {
@@ -2231,19 +2231,19 @@ commencing promised edits
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Emptying a file before reconstructing its contents according to a fixed
-recipe allows an ordered procedure to be convergent. \
+recipe allows an ordered procedure to be convergent.   
 
 `inherit`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2255,10 +2255,10 @@ recipe allows an ordered procedure to be convergent. \
 **Synopsis**: If true this causes the sub-bundle to inherit the private
 classes of its parent
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      bundle agent name
      {
      methods:
@@ -2274,8 +2274,8 @@ classes of its parent
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0, Enterprise 3.0.0 (2012)
 
@@ -2286,7 +2286,7 @@ places: for `edit_defaults` and in `methods` promises. If set to true,
 it causes the child-bundle named in the promise to inherit only the
 classes of the parent bundle. Inheriting the variables is unnecessary as
 the child can always access the parent's variables by a qualified
-reference using its bundle name. For example, \$(bundle.variable). \
+reference using its bundle name. For example, \$(bundle.variable).   
 
 `max_file_size`
 
@@ -2296,10 +2296,10 @@ reference using its bundle name. For example, \$(bundle.variable). \
 
 **Synopsis**: Do not edit files bigger than this number of bytes
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body edit_defaults example
      {
@@ -2308,8 +2308,8 @@ reference using its bundle name. For example, \$(bundle.variable). \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 max\_file\_size is a local, per-file sanity check to make sure the file
 editing is sensible. If this is set to zero, the check is disabled and
@@ -2317,15 +2317,15 @@ any size may be edited. The default value of `max_file_size` is
 determined by the global control body setting whose default value is
 `100k`.
 
-See: [editfilesize in agent](#editfilesize-in-agent) \
+See: [editfilesize in agent](#editfilesize-in-agent)   
 
 `recognize_join`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -2339,10 +2339,10 @@ limit
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      files:
      
        "/tmp/test_insert"
@@ -2359,8 +2359,8 @@ limit
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If set to true, this option allows CFEngine to process line based files
 with backslash continuation. The default is to not process continuation
@@ -2368,7 +2368,7 @@ backslashes.
 
 Back slash lines will only be concatenated if the file requires editing,
 and will not be restored. Restoration of the backslashes is not possible
-in a meaningful and convergent fashion. \
+in a meaningful and convergent fashion.   
 
 `rotate`
 
@@ -2379,10 +2379,10 @@ in a meaningful and convergent fashion. \
 **Synopsis**: How many backups to store if 'rotate' edit\_backup
 strategy is selected. Defaults to 1
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example
      {
@@ -2391,8 +2391,8 @@ strategy is selected. Defaults to 1
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Used for log rotation. If the file is named foo and the rotate attribute
 is set to 4, as above, then initially foo is copied to foo.1 and the old
@@ -2422,10 +2422,10 @@ deleted (that is, it "falls off the end" of the rotation).
 
 **Synopsis**: The name of a special CFEngine template file to expand
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 #This is a template file /templates/input.tmpl
 
 These lines apply to anyone
@@ -2448,7 +2448,7 @@ nameserver $(some.list)
 
 For example:
 
-~~~~ {.verbatim}
+~~~~
 [%CFEngine any:: %]
 VirtualHost $(sys.ipv4[eth0]):80>
         ServerAdmin             $(stage_file.params[apache_mail_address][1])
@@ -2480,8 +2480,8 @@ VirtualHost $(sys.ipv4[$(bundle.interfaces)]):443>
 [%CFEngine END %]
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -2489,7 +2489,7 @@ The template format uses inline tags to mark regions and classes. Each
 line represents an `insert_lines` promise, unless the promises are
 grouped into a block using:
 
-~~~~ {.verbatim}
+~~~~
 [%CFEngine BEGIN %]
 ...
 [%CFEngine END %]
@@ -2501,7 +2501,7 @@ lists are expanded (see the Special Topics Guide on editing).
 
 If a class-context modified is used:
 
-~~~~ {.verbatim}
+~~~~
 [%CFEngine class-expression:: %]
 ~~~~
 
@@ -2524,10 +2524,10 @@ agent's current context. This allows conditional insertion.
 
 **Synopsis**: List of regexes that match an acceptable name
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2537,10 +2537,10 @@ agent's current context. This allows conditional insertion.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This pattern matches only the node name of the file, not its path. \
+This pattern matches only the node name of the file, not its path.   
 
 `path_name`
 
@@ -2550,10 +2550,10 @@ This pattern matches only the node name of the file, not its path. \
 
 **Synopsis**: List of pathnames to match acceptable target
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2565,11 +2565,11 @@ This pattern matches only the node name of the file, not its path. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Path name and leaf name can be conveniently tested for separately by use
-of appropriate regular expressions. \
+of appropriate regular expressions.   
 
 `search_mode`
 
@@ -2579,10 +2579,10 @@ of appropriate regular expressions. \
 
 **Synopsis**: A list of mode masks for acceptable file permissions
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      #######################################################
      #
@@ -2635,12 +2635,12 @@ of appropriate regular expressions. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The mode may be specified in symbolic or numerical form with + and -
 constraints. Concatenation `ug+s` implies `u` OR `g`, and `u+g,u+s`
-implies `u` AND `g`. \
+implies `u` AND `g`.   
 
 `search_size`
 
@@ -2650,10 +2650,10 @@ implies `u` AND `g`. \
 
 **Synopsis**: Integer range of file sizes
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2663,9 +2663,9 @@ implies `u` AND `g`. \
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `search_owners`
 
@@ -2676,10 +2676,10 @@ implies `u` AND `g`. \
 **Synopsis**: List of acceptable user names or ids for the file, or
 regexes to match
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2689,13 +2689,13 @@ regexes to match
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of regular expressions any of which must match the entire userid
 (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). Windows
-does not have user ids, only names. \
+does not have user ids, only names.   
 
 `search_groups`
 
@@ -2706,10 +2706,10 @@ does not have user ids, only names. \
 **Synopsis**: List of acceptable group names or ids for the file, or
 regexes to match
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2719,13 +2719,13 @@ regexes to match
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of regular expressions, any of which must match the entire group
 (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). On
-Windows, files do not have group associations. \
+Windows, files do not have group associations.   
 
 `search_bsdflags`
 
@@ -2736,10 +2736,10 @@ Windows, files do not have group associations. \
 
 **Synopsis**: String of flags for bsd file system flags expected set
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select xyz
      {
@@ -2748,11 +2748,11 @@ Windows, files do not have group associations. \
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Extra BSD file system flags (these have no effect on non-BSD versions of
-CFEngine). See the manual page for `chflags` for more details. \
+CFEngine). See the manual page for `chflags` for more details.   
 
 `ctime`
 
@@ -2762,10 +2762,10 @@ CFEngine). See the manual page for `chflags` for more details. \
 
 **Synopsis**: Range of change times (ctime) for acceptable files
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body files_select example
      {
@@ -2775,12 +2775,12 @@ CFEngine). See the manual page for `chflags` for more details. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The file's change time refers to both modification of content and
 attributes, such as permissions. On Windows, `ctime` refers to creation
-time. \
+time.   
 
 `mtime`
 
@@ -2790,10 +2790,10 @@ time. \
 
 **Synopsis**: Range of modification times (mtime) for acceptable files
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body files_select example
      
@@ -2805,11 +2805,11 @@ time. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The file's modification time refers to both modification of content but
-not other attributes, such as permissions. \
+not other attributes, such as permissions.   
 
 `atime`
 
@@ -2819,10 +2819,10 @@ not other attributes, such as permissions. \
 
 **Synopsis**: Range of access times (atime) for acceptable files
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body file_select used_recently
      {
      
@@ -2842,11 +2842,11 @@ not other attributes, such as permissions. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A range of times during which a file was accessed can be specified in a
-`file_select` body. This is similar to file filters in CFEngine 2. \
+`file_select` body. This is similar to file filters in CFEngine 2.   
 
 `exec_regex`
 
@@ -2857,10 +2857,10 @@ A range of times during which a file was accessed can be specified in a
 **Synopsis**: Matches file if this regular expression matches any full
 line returned by the command
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2871,14 +2871,14 @@ line returned by the command
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The regular expression must be used in conjunction with the
 `exec_program` test. In this way the program must both return exit
 status 0 and its output must match the regular expression. The entire
 output must be matched (see [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `exec_program`
 
@@ -2889,10 +2889,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 **Synopsis**: Execute this command on each file and match if the exit
 status is zero
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2902,20 +2902,20 @@ status is zero
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is part of the customizable file search criteria. If the
 user-defined program returns exit status 0, the file is considered
-matched. \
+matched.   
 
 `file_types`
 
 **Type**: (option list)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     plain
                     reg
                     symlink
@@ -2929,10 +2929,10 @@ matched. \
 
 **Synopsis**: List of acceptable file types from menu choices
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select filter
      {
@@ -2943,12 +2943,12 @@ matched. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 File types vary in details between operating systems. The main POSIX
 types are provided here as menu options, with reg being a synonym for
-plain. In both cases this means not one of the "special" file types. \
+plain. In both cases this means not one of the "special" file types.   
 
 `issymlinkto`
 
@@ -2958,10 +2958,10 @@ plain. In both cases this means not one of the "special" file types. \
 
 **Synopsis**: List of regular expressions to match file objects
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select example
      {
@@ -2970,13 +2970,13 @@ plain. In both cases this means not one of the "special" file types. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of regular expressions. If the file is a symbolic link that
 points to files matched by one of these expressions, the file will be
 selected. Windows does not support symbolic links, so this attribute is
-not applicable on that platform. \
+not applicable on that platform.   
 
 `file_result`
 
@@ -2988,10 +2988,10 @@ not applicable on that platform. \
 **Synopsis**: Logical expression combining classes defined by file
 search criteria
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body file_select year_or_less
      
@@ -3012,8 +3012,8 @@ search criteria
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Sets the criteria for file selection outcome during file searches. The
 syntax is the same as for a class expression, since the file selection
@@ -3056,10 +3056,10 @@ following list:
 **Synopsis**: A set of patterns that should be copied and synchronized
 instead of linked
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -3068,22 +3068,22 @@ instead of linked
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 During the linking of files, it is sometimes useful to buffer changes
 with an actual copy, especially if the link is to an ephemeral file
 system. This list of patterns matches files that arise during a linking
 policy. A positive match means that the file should be copied and
-updated by modification time. \
+updated by modification time.   
 
 `link_children`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -3097,10 +3097,10 @@ source originals
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -3109,19 +3109,19 @@ source originals
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the promiser is a directory, instead of copying the children, link
-them to the source. \
+them to the source.   
 
 `link_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     symlink
                     hardlink
                     relative
@@ -3132,10 +3132,10 @@ them to the source. \
 
 **Default value:** symlink
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -3145,8 +3145,8 @@ them to the source. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This determines what kind of link should be used to link files. Users
 are advised to be wary of \`hard links' (see Unix manual pages for the
@@ -3159,7 +3159,7 @@ from relative links. Although all of these are symbolic links, the
 nomenclature here is defined such that symlink and absolute are
 equivalent . When verifying a link, choosing \`relative' means that the
 link *must* be relative to the source, so relative and absolute links
-are mutually exclusive. \
+are mutually exclusive.   
 
 `source`
 
@@ -3169,10 +3169,10 @@ are mutually exclusive. \
 
 **Synopsis**: The source file to which the link should point
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body copy_from example
      {
@@ -3188,18 +3188,18 @@ are mutually exclusive. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-For remote copies this refers to the file name on the remote server. \
+For remote copies this refers to the file name on the remote server.   
 
 `when_linking_children`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     override_file
                     if_no_such_file
 ~~~~
@@ -3207,10 +3207,10 @@ For remote copies this refers to the file name on the remote server. \
 **Synopsis**: Policy for overriding existing files when linking
 directories of children
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -3219,8 +3219,8 @@ directories of children
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The options refer to what happens if the directory already exists, and
 is already partially populated with files. If the directory being copied
@@ -3228,15 +3228,15 @@ from contains a file with the same name as that of a link to be created,
 it must be decided whether to override the existing destination object
 with a link, or simply omit the automatic linkage for files that already
 exist. The latter case can be used to make a copy of one directory with
-certain fields overridden. \
+certain fields overridden.   
 
 `when_no_source`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     force
                     delete
                     nop
@@ -3246,10 +3246,10 @@ certain fields overridden. \
 
 **Default value:** nop
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body link_from example
      {
@@ -3258,8 +3258,8 @@ certain fields overridden. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This describes how CFEngine should respond to an attempt to create a
 link to a file that does not exist. The options are to force the
@@ -3270,9 +3270,9 @@ or do nothing.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -3286,10 +3286,10 @@ or do nothing.
 **Synopsis**: true/false whether to move obstructions to file-object
 creation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
   "/tmp/testcopy" 
@@ -3299,8 +3299,8 @@ files:
     depth_search => recurse("inf");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If we have promised to make file X a link, but it already exists as a
 file, or vice-versa, or if a file is blocking the creation of a
@@ -3321,9 +3321,9 @@ link, if the behaviour is different.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                literal
                regex
                guess
@@ -3331,10 +3331,10 @@ link, if the behaviour is different.
 
 **Synopsis**: Menu option for interpreting promiser file object
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
    "/var/lib\d"
@@ -3351,8 +3351,8 @@ files:
          perms => system;
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  By default, CFEngine makes an educated guess as to whether the promise
 pathname involves a regular expression or not. This guesswork is needed
 due to cross-platform differences in filename interpretation.
@@ -3397,10 +3397,10 @@ more information.
 
 **Synopsis**: List of menu options for BSD file system flags to set
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body perms example
      
@@ -3411,12 +3411,12 @@ more information.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The BSD Unices (FreeBSD, OpenBSD, NetBSD) and MacOSX have additional
 file system flags which can be set. Refer to the BSD `chflags`
-documentation for this. \
+documentation for this.   
 
 `groups`
 
@@ -3427,10 +3427,10 @@ documentation for this. \
 **Synopsis**: List of acceptable groups of group ids, first is change
 target
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body perms example
      {
      groups => { "users", "administrators" };
@@ -3438,8 +3438,8 @@ target
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The first named group in the list is the default that will be configured
 if the file does not match an element of the list. The reserved word
@@ -3447,7 +3447,7 @@ none may be used to match files that are not owned by a registered
 group. On Windows, files do not have file groups associated with them,
 and thus this attribute is ignored.
 
-ACLs may be used in place for this. \
+ACLs may be used in place for this.   
 
 `mode`
 
@@ -3457,10 +3457,10 @@ ACLs may be used in place for this. \
 
 **Synopsis**: File permissions (like posix chmod)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body perms example
      {
@@ -3469,12 +3469,12 @@ ACLs may be used in place for this. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The mode string may be symbolic or numerical, like `chmod`. This is
 ignored on Windows, as the permission model uses ACLs. ACLs are
-supported by CFEngine Nova. \
+supported by CFEngine Nova.   
 
 `owners`
 
@@ -3485,10 +3485,10 @@ supported by CFEngine Nova. \
 **Synopsis**: List of acceptable owners or user ids, first is change
 target
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body perms example
      {
@@ -3497,8 +3497,8 @@ target
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The first user is the reference value that CFEngine will set the file to
 if none of the list items matches the true state of the file. The
@@ -3508,15 +3508,15 @@ registered user.
 On Windows, users can only take ownership of files, never give it. Thus,
 the first user in the list should be the user running the CFEngine
 process (usually Administrator). Additionally, some groups may be owners
-on Windows (such as the Administrators group). \
+on Windows (such as the Administrators group).   
 
 `rxdirs`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -3528,10 +3528,10 @@ on Windows (such as the Administrators group). \
 **Synopsis**: true/false add execute flag for directories if read flag
 is set
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body perms rxdirs
      {
@@ -3540,8 +3540,8 @@ is set
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Default behaviour is to set the x flag on directories automatically if
 the r flag is specified when specifying multiple files in a single
@@ -3555,9 +3555,9 @@ promise. This is ignored on Windows, as the permission model uses ACLs.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -3570,10 +3570,10 @@ promise. This is ignored on Windows, as the permission model uses ACLs.
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example
      {
@@ -3583,12 +3583,12 @@ promise. This is ignored on Windows, as the permission model uses ACLs.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Disabling a file means making it unusable. For executables this means
 preventing execution, for an information file it means making the file
-unreadable. \
+unreadable.   
 
 `disable_mode`
 
@@ -3598,10 +3598,10 @@ unreadable. \
 
 **Synopsis**: The permissions to set when a file is disabled
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example
      {
@@ -3610,11 +3610,11 @@ unreadable. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 To disable an executable it is not enough to rename it, you should also
-remove the executable flag. \
+remove the executable flag.   
 
 `disable_suffix`
 
@@ -3624,10 +3624,10 @@ remove the executable flag. \
 
 **Synopsis**: The suffix to add to files when disabling (.cfdisabled)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example
      {
@@ -3637,11 +3637,11 @@ remove the executable flag. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 To disable files in a particular manner, use this string suffix. The
-default value is .cf-disabled. \
+default value is .cf-disabled.   
 
 `newname`
 
@@ -3651,10 +3651,10 @@ default value is .cf-disabled. \
 
 **Synopsis**: The desired name for the current file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example(s)
      {
@@ -3663,9 +3663,9 @@ default value is .cf-disabled. \
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `rotate`
 
@@ -3675,10 +3675,10 @@ default value is .cf-disabled. \
 
 **Synopsis**: Maximum number of file rotations to keep
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body rename example
      {
@@ -3687,8 +3687,8 @@ default value is .cf-disabled. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Used for log rotation. If the file is named foo and the rotate attribute
 is set to 4, as above, then initially foo is copied to foo.1 and the old
@@ -3714,10 +3714,10 @@ deleted (that is, it "falls off the end" of the rotation).
 
 **Synopsis**: Name of a repository for versioning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
  "/path/file"
@@ -3726,8 +3726,8 @@ files:
    repository => "/var/cfengine/repository";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A local repository for this object, overrides the default.
 
@@ -3743,9 +3743,9 @@ ordinarily be stored in an alternative repository as
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -3756,10 +3756,10 @@ ordinarily be stored in an alternative repository as
 
 **Synopsis**: true/false whether to touch time stamps on file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
  "/path/file"
@@ -3767,8 +3767,8 @@ files:
    touch => "true";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 #### `transformer`
 
@@ -3779,10 +3779,10 @@ files:
 **Synopsis**: Command (with full path) used to transform current file
 (no shell wrapper used)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
   "/home/mark/tmp/testcopy"
 
@@ -3791,7 +3791,7 @@ files:
     depth_search => recurse("inf");
 ~~~~
 
-~~~~ {.verbatim}
+~~~~
  classes:
     "do_update" expression => isnewerthan("/etc/postfix/alias",
                                           "/etc/postfix/alias.cdb");
@@ -3803,8 +3803,8 @@ files:
        ifvarclass => "do_update";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A command to execute, usually for the promised file to transform it to
 something else (but possibly to create the promised file based on a
@@ -3828,7 +3828,7 @@ Note also that if you use the `$(this.promiser)` variable or other
 variable in this command, and the file object contains spaces, then you
 should quote the variable. For example:
 
-~~~~ {.verbatim}
+~~~~
     transformer => "/usr/bin/gzip \"$(this.promiser)\"",
 ~~~~
 
@@ -3836,7 +3836,7 @@ Note also that the transformer does not actually need to change the
 file. You can, for example, simply report on the existence of files
 with:
 
-~~~~ {.verbatim}
+~~~~
     transformer => "/bin/echo I found a file named $(this.promiser)",
 ~~~~
 

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-guest_005fenvironments-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-guest_005fenvironments-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,guest_005fenvironments-in-agent-promises]
 
 ### `guest_environments` promises in agent
 
-\
+  
 
 Guest environment promises describe enclosed computing environments that
 can host physical and virtual machines, Solaris zones, grids, clouds or
@@ -27,9 +27,9 @@ to manage what goes on within the virtual guests. For that purpose you
 should run CFEngine directly on the virtual machine, as if it were any
 other machine.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
  site1::
 
   "unique_name1"
@@ -47,7 +47,7 @@ other machine.
             environment_host => "atlas";
 ~~~~
 
-\
+  
 
 CFEngine currently provides a convergent interface to *libvirt*.
 
@@ -71,10 +71,10 @@ CFEngine currently provides a convergent interface to *libvirt*.
 **Synopsis**: A class indicating which physical node will execute this
 guest machine
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 guest_environments:
 
  linux::
@@ -87,8 +87,8 @@ guest_environments:
         environment_host => "ubuntu";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The promise will only apply to the machine with this class set. Thus,
 CFEngine must be running locally on the hypervisor for the promise to
@@ -111,10 +111,10 @@ This attribute is required.
 
 **Synopsis**: The IP addresses of the environment's network interfaces
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body environment_interface vnet(primary)
      {
@@ -132,11 +132,11 @@ This attribute is required.
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The IP addresses of the virtual machine can be overridden here at run
-time. \
+time.   
 
 `env_name`
 
@@ -146,10 +146,10 @@ time. \
 
 **Synopsis**: The hostname of the virtual environment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body environment_interface vnet(primary)
      {
      env_name      => "$(this.promiser)";
@@ -163,11 +163,11 @@ time. \
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The \`hostname' of a virtual guest may or may not be the same as the
-identifier used as \`promiser' by the virtualization manager. \
+identifier used as \`promiser' by the virtualization manager.   
 
 `env_network`
 
@@ -177,10 +177,10 @@ identifier used as \`promiser' by the virtualization manager. \
 
 **Synopsis**: The hostname of the virtual network
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body environment_interface vnet(primary)
           {
@@ -208,10 +208,10 @@ identifier used as \`promiser' by the virtualization manager. \
 
 **Synopsis**: Number of virtual CPUs in the environment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body environment_resources my_environment
      {
@@ -222,13 +222,13 @@ identifier used as \`promiser' by the virtualization manager. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The maximum number of cores or processors in the physical environment
 will set a natural limit on this value.
 
-This attribute conflicts with `env_spec`. \
+This attribute conflicts with `env_spec`.   
 
 `env_memory`
 
@@ -239,10 +239,10 @@ This attribute conflicts with `env_spec`. \
 **Synopsis**: Amount of primary storage (RAM) in the virtual environment
 (KB)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body environment_resources my_environment
      {
@@ -253,13 +253,13 @@ This attribute conflicts with `env_spec`. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The maximum amount of memory in the physical environment will set a
 natural limit on this value.
 
-This attribute conflicts with `env_spec`. \
+This attribute conflicts with `env_spec`.   
 
 `env_disk`
 
@@ -270,10 +270,10 @@ This attribute conflicts with `env_spec`. \
 **Synopsis**: Amount of secondary storage (DISK) in the virtual
 environment (MB)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body environment_resources my_environment
      {
@@ -284,12 +284,12 @@ environment (MB)
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This parameter is currently unsupported, for future extension.
 
-This attribute conflicts with `env_spec`. \
+This attribute conflicts with `env_spec`.   
 
 `env_baseline`
 
@@ -300,19 +300,19 @@ This attribute conflicts with `env_spec`. \
 **Synopsis**: The path to an image with which to baseline the virtual
 environment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      env_baseline => "/path/to/image";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This function is for future development. \
+This function is for future development.   
 
 `env_spec`
 
@@ -323,10 +323,10 @@ This function is for future development. \
 **Synopsis**: A string containing a technology specific set of promises
 for the virtual instance
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body environment_resources virt_xml(host)
      {
      env_spec => 
@@ -360,8 +360,8 @@ for the virtual instance
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  The preferred way to specify the resources of an environment on
 creation; in other words, when `environment_state` is create.
 
@@ -373,9 +373,9 @@ This attribute conflicts with `env_cpus`, `env_memory` and `env_disk`.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                create
                delete
                running
@@ -385,10 +385,10 @@ This attribute conflicts with `env_cpus`, `env_memory` and `env_disk`.
 
 **Synopsis**: The desired dynamical state of the specified environment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 guest_environments:
 
  linux::
@@ -402,28 +402,29 @@ guest_environments:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The allowed states have the following convergent semantics.
 
 create
 
-The guest machine is allocated, installed and left in a running state. \
+The guest machine is allocated, installed and left in a running state.
+  
 
 delete
 
 The guest machine is shut down and deallocated but no files are removed.
-\
+  
 
 running
 
-The guest machine is in a running state, if it previously exists. \
+The guest machine is in a running state, if it previously exists.   
 
 suspended
 
 The guest exists in a suspended state or a shutdown state. If the guest
-is running, it is suspended; otherwise it is ignored. \
+is running, it is suspended; otherwise it is ignored.   
 
 down
 
@@ -433,9 +434,9 @@ The guest machine is shut down, but not deallocated.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                xen
                kvm
                esx
@@ -452,10 +453,10 @@ The guest machine is shut down, but not deallocated.
 
 **Synopsis**: Virtual environment type
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent my_vm_cloud
 {
 guest_environments:
@@ -480,8 +481,8 @@ guest_environments:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The currently supported types are those supported by *libvirt*. More
 will be added in the future.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005flines-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005flines-in-edit_005fline-promises.markdown
@@ -9,14 +9,14 @@ tags: [Bundles-for-agent,insert_005flines-in-edit_005fline-promises]
 
 ### `insert_lines` promises in edit\_line
 
-\
+  
 
 This promise is part of the line-editing model. It inserts lines into
 the file at a specified location. The location is determined by
 body-attributes. The promise object referred to can be a literal line of
 a file-reference from which to read lines.
 
-~~~~ {.smallexample}
+~~~~
      
       insert_lines:
      
@@ -27,9 +27,9 @@ a file-reference from which to read lines.
      
 ~~~~
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -66,7 +66,7 @@ insert_lines:
 }
 ~~~~
 
-\
+  
 
 By parameterizing the editing bundle, one can make generic and reusable
 editing bundles.
@@ -76,7 +76,7 @@ file, be careful with your intuition. If your intention is to insert a
 set of lines in a given order after a marker, then the following is
 incorrect:
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line x
 {
 insert_lines:
@@ -100,7 +100,7 @@ This is not a bug, but an error of logic.
 What was probably intended was to add multiple ordered lines after the
 marker, which should be a single correlated promise.
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line x
 {
 insert_lines:
@@ -112,7 +112,7 @@ insert_lines:
 
 Or:
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line x
 {
 insert_lines:
@@ -137,9 +137,9 @@ line two" location => myloc;
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -152,10 +152,10 @@ line two" location => myloc;
 
 **Synopsis**: Expand any unexpanded variables
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -190,15 +190,15 @@ insert_lines:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A way of incorporating templates with variable expansion into file
 operations. Variables should be named and scoped appropriately for the
 bundle in which this promise is made. In other words, you should qualify
 the variables with the bundle in which they are defined. For example:
 
-~~~~ {.verbatim}
+~~~~
 $(bundle.variable)
 $(sys.host)
 $(mon.www_in)
@@ -210,9 +210,9 @@ In CFEngine 2 `editfiles` this was called ExpandVariables.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                literal
                string
                file
@@ -224,10 +224,10 @@ In CFEngine 2 `editfiles` this was called ExpandVariables.
 
 **Synopsis**: Type of object the promiser string refers to
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line lynryd_skynyrd
 {
  vars:
@@ -252,15 +252,15 @@ insert_if_startwith_from_list => { "@(s)" };
 This will ensure that the following lines are inserted into the promised
 file:
 
-~~~~ {.verbatim}
+~~~~
 And you'll never see me no more
 Gimme three steps, Mister
 Gimme three steps towards the door
 Gimme three steps
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The default is to treat the promiser as a literal string of convergent
 lines (the values `literal` and `string` are synonymous).
@@ -297,10 +297,10 @@ setting that does preserve the ordering of lines in the file is called
 
 **Synopsis**: Insert line if it starts with a string in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -309,8 +309,8 @@ setting that does preserve the ordering of lines in the file is called
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  The list contains literal strings to search for in the secondary file
 (the file being read via the `insert_type` attribute, not the main file
 being edited). If a string with matching starting characters is found,
@@ -320,7 +320,7 @@ location in the primary file.
 `insert_if_startswith_from_list` is ignored unless `insert_type` is
 `file` (see [insert\_type in
 insert\_lines](#insert_005ftype-in-insert_005flines)), or the promiser
-is a multi-line block. \
+is a multi-line block.   
 
 `insert_if_not_startwith_from_list`
 
@@ -330,10 +330,10 @@ is a multi-line block. \
 
 **Synopsis**: Insert line if it DOES NOT start with a string in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -342,8 +342,8 @@ is a multi-line block. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The complement of `insert_if_startwith_from_list`. If the start of a
 line does *not* match one of the strings, that line is inserted into the
@@ -353,7 +353,7 @@ file being edited.
 `file` or the promiser is a multi-line block.
 
 See: [insert\_type in
-insert\_lines](#insert_005ftype-in-insert_005flines) \
+insert\_lines](#insert_005ftype-in-insert_005flines)   
 
 `insert_if_match_from_list`
 
@@ -363,10 +363,10 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
 
 **Synopsis**: Insert line if it fully matches a regex in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -375,8 +375,8 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  The list contains literal strings to search for in the secondary file
 (the file being read via the `insert_type` attribute, not the main file
 being edited). If the regex matches a *complete* line of the file, that
@@ -390,7 +390,7 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)
 or the promiser is a multi-line block.
 
 See [insert\_type in
-insert\_lines](#insert_005ftype-in-insert_005flines) \
+insert\_lines](#insert_005ftype-in-insert_005flines)   
 
 `insert_if_not_match_from_list`
 
@@ -400,10 +400,10 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
 
 **Synopsis**: Insert line if it DOES NOT fully match a regex in the list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -412,8 +412,8 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The complement of `insert_if_match_from_list`. If the line does *not*
 match a line in the secondary file, it is inserted into the file being
@@ -423,7 +423,7 @@ edited.
 `file`, or the promiser is a multi-line block.
 
 See: [insert\_type in
-insert\_lines](#insert_005ftype-in-insert_005flines) \
+insert\_lines](#insert_005ftype-in-insert_005flines)   
 
 `insert_if_contains_from_list`
 
@@ -433,10 +433,10 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
 
 **Synopsis**: Insert line if a regex in the list match a line fragment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -445,8 +445,8 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The list contains literal strings to search for in the secondary file;
 in other words, the file being read via the `insert_type` attribute, not
@@ -458,7 +458,7 @@ location in the primary file.
 `file`, or the promiser is a multi-line block.
 
 See: [insert\_type in
-insert\_lines](#insert_005ftype-in-insert_005flines) \
+insert\_lines](#insert_005ftype-in-insert_005flines)   
 
 `insert_if_not_contains_from_list`
 
@@ -469,10 +469,10 @@ insert\_lines](#insert_005ftype-in-insert_005flines) \
 **Synopsis**: Insert line if a regex in the list DOES NOT match a line
 fragment
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body insert_select example
      {
@@ -481,8 +481,8 @@ fragment
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The complement of `insert_if_contains_from_list`. If the line is *not*
 found in the secondary file, it is inserted into the file being edited.
@@ -501,9 +501,9 @@ insert\_lines](#insert_005ftype-in-insert_005flines)
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     before
                     after
 ~~~~
@@ -512,10 +512,10 @@ insert\_lines](#insert_005ftype-in-insert_005flines)
 
 **Default value:** after
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body location append
      
@@ -526,19 +526,19 @@ insert\_lines](#insert_005ftype-in-insert_005flines)
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Determines whether an edit will occur before or after the currently
-matched line. \
+matched line.   
 
 `first_last`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     first
                     last
 ~~~~
@@ -548,10 +548,10 @@ file
 
 **Default value:** last
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body location example
      {
@@ -560,14 +560,14 @@ file
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In multiple matches, decide whether the first or last occurrence of the
 matching pattern in the case affected by the change. In principle this
 could be generalized to more cases but this seems like a fragile quality
 to evaluate, and only these two cases are deemed of reproducible
-significance. \
+significance.   
 
 `select_line_matching`
 
@@ -577,10 +577,10 @@ significance. \
 
 **Synopsis**: Regular expression for matching file line location
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      # Editing
      
@@ -598,8 +598,8 @@ significance. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The expression must match a whole line, not a fragment within a line;
 that is, it is anchored.
@@ -613,9 +613,9 @@ This attribute is mutually exclusive of `select_line_number`.
 
 **Type**: (option list)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                ignore_leading
                ignore_trailing
                ignore_embedded
@@ -626,10 +626,10 @@ This attribute is mutually exclusive of `select_line_number`.
 
 **Default value**: `exact_match`
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line Insert(service, filename)
 {
 insert_lines:
@@ -641,8 +641,8 @@ insert_lines:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The white space matching policy applies only to `insert_lines`, as a
 convenience. It works by rewriting the insert string as a regular

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftext-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,insert_005ftext-in-edit_005fxml-promises]
 
 ### `insert_text` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a value
 string, containing the matching substring, will be present in the
@@ -19,9 +19,9 @@ value string, within the specified node. The specified node is
 determined by body-attributes. The promise object referred to is a
 literal string of text.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   insert_text:
@@ -31,7 +31,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically only a single value string, within a single
 specified node, is inserted in each `insert_text` promise. You may of

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftree-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftree-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,insert_005ftree-in-edit_005fxml-promises]
 
 ### `insert_tree` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a
 balanced XML tree, containing the matching subtree, will be present in
@@ -18,9 +18,9 @@ default promise is to insert the tree into the specified node. The
 specified node is determined by body-attributes. The promise object
 referred to is a literal string representation of a balanced XML tree.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   insert_tree:
@@ -30,7 +30,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically, only a single tree, within a single specified node,
 is inserted in each `insert_tree` promise. You may of course have

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-interfaces-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-interfaces-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,interfaces-in-agent-promises]
 
 ### `interfaces` promises in agent
 
-\
+  
 
 Interfaces promises describe the configurable aspects relating to
 network interfaces. Most workstations and servers have only a single
@@ -19,7 +19,7 @@ identity, assumed netmask and routing policy in the case of multi-homed
 hosts. For virtual machines and hosts, the list of interfaces can be
 quite large.
 
-~~~~ {.smallexample}
+~~~~
      
       interfaces:
      
@@ -30,11 +30,11 @@ quite large.
      
 ~~~~
 
-\
+  
 
 For future use.
 
-\
+  
 
 For future use.
 
@@ -52,10 +52,10 @@ For future use.
 
 **Synopsis**: IPv4 address for the interface
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body tcp_ip example
      {
@@ -64,12 +64,12 @@ For future use.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The address will be checked and if necessary set. Today few hosts will
 be managed in this way. Address management will be handled by other
-services like DHCP. \
+services like DHCP.   
 
 `ipv4_netmask`
 
@@ -79,10 +79,10 @@ services like DHCP. \
 
 **Synopsis**: Netmask for the interface
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body tcp_ip example
      {
@@ -91,11 +91,11 @@ services like DHCP. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In many cases the CIDR form of address will show the netmask as /23, but
-this offers and \`old style' alternative. \
+this offers and \`old style' alternative.   
 
 `ipv6_address`
 
@@ -105,10 +105,10 @@ this offers and \`old style' alternative. \
 
 **Synopsis**: IPv6 address for the interface
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
        "eth0"
      
@@ -116,5 +116,5 @@ this offers and \`old style' alternative. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-methods-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-methods-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,methods-in-agent-promises]
 
 ### `methods` promises in agent
 
-\
+  
 
 Methods are compound promises that refer to whole bundles of promises.
 Methods may be parameterized. Methods promises are written in a form
@@ -19,7 +19,7 @@ objects that are affected by the promise-bundle. Since the use of these
 identifiers is for the future, you can simply use any string here for
 the time being.
 
-~~~~ {.smallexample}
+~~~~
      
       methods:
      
@@ -36,9 +36,9 @@ In CFEngine 2 methods referred to separate sub-programs executed as
 separate processes. Methods are now implemented as bundles that are run
 inline.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 
 bundle agent example
 {
@@ -70,7 +70,7 @@ reports:
 
 ~~~~
 
-\
+  
 
 Methods offer powerful ways to encapsulate multiple issues pertaining to
 a set of parameters.
@@ -88,7 +88,7 @@ Care should be exercised when using this approach. In order to make the
 function call uniquely classified, CFEngine requires the promiser to
 contain the variable name of the method if the variable is a list.
 
-~~~~ {.verbatim}
+~~~~
 bundle agent default
 {
 vars:
@@ -110,9 +110,9 @@ methods:
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -126,10 +126,10 @@ classes of its parent
 
 **Default value**: false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent name
 {
 methods:
@@ -145,8 +145,8 @@ inherit => "true";
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0, Enterprise 3.0.0 (2012)
 
@@ -170,10 +170,10 @@ reference using its bundle name. For example: \$(bundle.variable).
 **Synopsis**: Specify the name of a local variable to contain any
 result/return value from the child
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -213,8 +213,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0 (2012)
 

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-outputs-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-outputs-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,outputs-in-agent-promises]
 
 ### `outputs` promises in agent
 
-\
+  
 
 Outputs promises allow promises to make meta-promises about their output
 levels. More simply, you can switch on verbose or inform level output to
@@ -24,9 +24,9 @@ Output promises enable you to selectively debug individually named
 promises (or bundles), thus eliminating the need for scanning unrelated
 CFEngine output.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 outputs:
 
   "run_agent";      # Promise handle, verbose (default) output
@@ -39,7 +39,7 @@ outputs:
 A very handy paradigm is to include outputs promises in every bundle,
 and guard them with classes. For example:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent some_function
 {
 vars:
@@ -63,7 +63,7 @@ also supply multiple arguments to -D to debug multiple bundles. Of
 course, you can also provide much finer-grained control by creating
 outputs promises on specific promise handles.
 
-\
+  
 
 The default behaviour is to print verbose output for listed promise
 handles. See [handle in \*](#handle-in-_002a), for bundle names.
@@ -78,9 +78,9 @@ version 3.4.0 (2012)
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                verbose
                debug
                inform
@@ -91,10 +91,10 @@ version 3.4.0 (2012)
 **Synopsis**: Output level to observe for the named promise or bundle
 (meta-promise)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
 
   "/etc/init.d/agent start"
@@ -109,8 +109,8 @@ outputs:
     output_level => "inform"; 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 With no attribute, `verbose` output is assumed.
 
@@ -118,9 +118,9 @@ With no attribute, `verbose` output is assumed.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                promise
                bundle
 ~~~~
@@ -130,10 +130,10 @@ With no attribute, `verbose` output is assumed.
 **Synopsis**: Output level to observe for the named promise or bundle
 (meta-promise)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 outputs:
 
   "web_server"
@@ -141,8 +141,8 @@ outputs:
      promiser_type => "bundle";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Without this attribute, CFEngine assumes a list of promises to report
 on. There may be a promise for a thing that has the same name as a

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-packages-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-packages-in-agent-promises.markdown
@@ -9,9 +9,9 @@ tags: [Bundles-for-agent,packages-in-agent-promises]
 
 ### `packages` promises in agent
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
  vars:
 
   "match_package" slist => { 
@@ -82,7 +82,7 @@ one of two different ways:
 
 -   They may be specified independently, e.g.
 
-    ~~~~ {.verbatim}
+    ~~~~
          packages:
          
            "mypackage"
@@ -100,7 +100,7 @@ one of two different ways:
     7-Zip-4.50-x86\_64.msi and a package\_method containing the
     following:
 
-    ~~~~ {.verbatim}
+    ~~~~
           package_name_regex => "^(\S+)-(\d+\.?)+";
           package_version_regex => "^\S+-((\d+\.?)+)";
           package_arch_regex => "^\S+-[\d\.]+-(.*).msi";
@@ -134,70 +134,112 @@ We can discuss package promise repair in the following table:
 
 Identified package matches version constraints
 
-  ----------- ---------
-  add         never \
-              
-
-  delete      =,=,= \
-              
-
-  reinstall   =,=,= \
-              
-
-  upgrade     =,=,= \
-              
-
-  patch       =,=,= \
-              
-  ----------- ---------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left">add</td>
+<td align="left">never <br /></td>
+</tr>
+<tr class="even">
+<td align="left">delete</td>
+<td align="left">=,=,= <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">reinstall</td>
+<td align="left">=,=,= <br /></td>
+</tr>
+<tr class="even">
+<td align="left">upgrade</td>
+<td align="left">=,=,= <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">patch</td>
+<td align="left">=,=,= <br /></td>
+</tr>
+</tbody>
+</table>
 
 Identified package matched by name, but not version
 
-  -------------------------------------------------
-  Command     Dumb manager   Smart manager \
-                             
-  ----------- -------------- ----------------------
-  add         unable         Never \
-                             
-
-  delete      unable         Attempt deletion \
-                             
-
-  reinstall   unable         Attempt delete/add \
-                             
-
-  upgrade     unable         Upgrade if capable \
-                             
-
-  patch       unable         Patch if capable \
-                             
-  -------------------------------------------------
+<table>
+<thead>
+<tr class="header">
+<th align="left">Command</th>
+<th align="left">Dumb manager</th>
+<th align="left">Smart manager <br /></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">add</td>
+<td align="left">unable</td>
+<td align="left">Never <br /></td>
+</tr>
+<tr class="even">
+<td align="left">delete</td>
+<td align="left">unable</td>
+<td align="left">Attempt deletion <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">reinstall</td>
+<td align="left">unable</td>
+<td align="left">Attempt delete/add <br /></td>
+</tr>
+<tr class="even">
+<td align="left">upgrade</td>
+<td align="left">unable</td>
+<td align="left">Upgrade if capable <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">patch</td>
+<td align="left">unable</td>
+<td align="left">Patch if capable <br /></td>
+</tr>
+</tbody>
+</table>
 
 Package not installed
 
-  --------------------------------------------------------------
-  Command     Dumb manager               Smart manager \
-                                         
-  ----------- -------------------------- -----------------------
-  add         Attempt to install named   Install any version \
-                                         
+<table>
+<thead>
+<tr class="header">
+<th align="left">Command</th>
+<th align="left">Dumb manager</th>
+<th align="left">Smart manager <br /></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">add</td>
+<td align="left">Attempt to install named</td>
+<td align="left">Install any version <br /></td>
+</tr>
+<tr class="even">
+<td align="left">delete</td>
+<td align="left">unable</td>
+<td align="left">unable <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">reinstall</td>
+<td align="left">Attempt to install named</td>
+<td align="left">unable <br /></td>
+</tr>
+<tr class="even">
+<td align="left">upgrade</td>
+<td align="left">unable</td>
+<td align="left">unable <br /></td>
+</tr>
+<tr class="odd">
+<td align="left">patch</td>
+<td align="left">unable</td>
+<td align="left">unable <br /></td>
+</tr>
+</tbody>
+</table>
 
-  delete      unable                     unable \
-                                         
+  
 
-  reinstall   Attempt to install named   unable \
-                                         
-
-  upgrade     unable                     unable \
-                                         
-
-  patch       unable                     unable \
-                                         
-  --------------------------------------------------------------
-
-\
-
-~~~~ {.verbatim}
+~~~~
 bundle agent packages
 {
 vars:
@@ -220,7 +262,7 @@ packages:
 }
 ~~~~
 
-\
+  
 
 Packages promises can be very simple if the package manager is of the
 smart variety that handles details for you. If you need to specify
@@ -286,10 +328,10 @@ library for supported operating systems.
 
 **Synopsis**: Select the architecture for package selection
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 packages:
 
   "$(exact_package)"
@@ -299,8 +341,8 @@ packages:
      package_architectures => { "x86_64" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 It is possible to specify a list of packages of different architectures
 if it is desirable to install multiple architectures on the host. If no
@@ -319,10 +361,10 @@ package manager's behaviour prevails.
 
 **Synopsis**: Command to install a package to the system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      {
@@ -331,8 +373,8 @@ package manager's behaviour prevails.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This command should install a package when appended with the package
 reference id, formed using the `package_name_convention`, using the
@@ -343,7 +385,7 @@ repository containing the package.
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_arch_regex`
 
@@ -354,10 +396,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: Regular expression with one backreference to extract
 package architecture string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      
@@ -367,8 +409,8 @@ package architecture string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is for use when extracting architecture from the name of the
 promiser, when the architecture is not specified using the
@@ -378,15 +420,15 @@ exactly one parenthesized back reference which marks the location in the
 portion of the string (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). If no
 architecture is specified for the given package manager, then do not
-define this. \
+define this.   
 
 `package_changes`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     individual
                     bulk
 ~~~~
@@ -394,10 +436,10 @@ define this. \
 **Synopsis**: Menu option - whether to group packages into a single
 aggregate command
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      
@@ -407,14 +449,14 @@ aggregate command
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  This indicates whether the package manager is capable of handling
 package operations with multiple arguments. If this is set to bulk then
 multiple arguments will be passed to the package commands. If set to
 individual packages will be handled one by one. This might add a
 significant overhead to the operations, and also affect the ability of
-the operating system's package manager to handle dependencies. \
+the operating system's package manager to handle dependencies.   
 
 `package_delete_command`
 
@@ -424,10 +466,10 @@ the operating system's package manager to handle dependencies. \
 
 **Synopsis**: Command to remove a package from the system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      
@@ -437,8 +479,8 @@ the operating system's package manager to handle dependencies. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The command that deletes a package from the system when appended with
 the package reference identifier specified by `package_name_convention`.
@@ -446,7 +488,7 @@ the package reference identifier specified by `package_name_convention`.
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_delete_convention`
 
@@ -457,10 +499,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: This is how the package manager expects the package to be
 referred to in the deletion part of a package update, e.g. \$(name)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method freebsd
      
      {
@@ -471,8 +513,8 @@ referred to in the deletion part of a package update, e.g. \$(name)
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This attribute is used when `package_policy` is delete, or
 `package_policy` is update and `package_file_repositories` is set and
@@ -489,7 +531,7 @@ to expand the first repository containing the package. For example:
 \$(firstrepo)\$(name)-\$(version)-\$(arch).msi.
 
 If this is not defined, it defaults to the value of
-`package_name_convention`. \
+`package_name_convention`.   
 
 `package_file_repositories`
 
@@ -499,10 +541,10 @@ If this is not defined, it defaults to the value of
 
 **Synopsis**: A list of machine-local directories to search for packages
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method filebased
      {
@@ -511,13 +553,13 @@ If this is not defined, it defaults to the value of
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If specified, CFEngine will assume that the package installation occurs
 by filename and will search the named paths for a package matching the
 pattern `package_name_convention`. If found the name will be prefixed to
-the package name in the package commands. \
+the package name in the package commands.   
 
 `package_installed_regex`
 
@@ -528,10 +570,10 @@ the package name in the package commands. \
 **Synopsis**: Regular expression which matches packages that are already
 installed
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method yum
      {
@@ -540,8 +582,8 @@ installed
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This regular expression must match complete lines in the output of the
 list command that are actually installed packages (see [Anchored vs.
@@ -549,7 +591,7 @@ unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). If all
 the lines match then the regex can be set of .\*, however most package
 systems output prefix lines and a variety of human padding that needs to
-be ignored. \
+be ignored.   
 
 `package_default_arch_command`
 
@@ -559,10 +601,10 @@ be ignored. \
 
 **Synopsis**: Command to detect the default packages' architecture
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method dpkg
      {
        package_default_arch_command => "/usr/bin/dpkg --print-architecture";
@@ -571,8 +613,8 @@ be ignored. \
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0, Enterprise 3.0.0 (2012)
 
@@ -582,7 +624,7 @@ lists architectures explicitly for multiarch-enabled packages.
 
 In case this command is not provided, CFEngine treats all packages
 without explicit architecture set as belonging to implicit default
-architecture. \
+architecture.   
 
 `package_list_arch_regex`
 
@@ -593,10 +635,10 @@ architecture. \
 **Synopsis**: Regular expression with one backreference to extract
 package architecture string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      {
@@ -605,8 +647,8 @@ package architecture string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A regular expression that contains exactly one parenthesized back
 reference that marks the location in the listed package at which the
@@ -614,7 +656,7 @@ architecture is specified. The regular expression may match a portion of
 the string (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). If no
 architecture is specified for the given package manager, then do not
-define this regex. \
+define this regex.   
 
 `package_list_command`
 
@@ -624,10 +666,10 @@ define this regex. \
 
 **Synopsis**: Command to obtain a list of available packages
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      
@@ -637,8 +679,8 @@ define this regex. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This command should provide a complete list of the packages installed on
 the system. It might also list packages that are not installed. Those
@@ -647,7 +689,7 @@ should be filtered out using the `package_installed_regex`.
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_list_name_regex`
 
@@ -658,10 +700,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: Regular expression with one backreference to extract
 package name string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      
@@ -671,14 +713,14 @@ package name string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A regular expression that contains exactly one parenthesized back
 reference which marks the name of the package from the package listing.
 The regular expression may match a portion of the string (see [Anchored
 vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `package_list_update_command`
 
@@ -688,10 +730,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 
 **Synopsis**: Command to update the list of available packages (if any)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method xyz
      {
      debian|ubuntu::
@@ -701,12 +743,12 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Not all package managers update their list information from source
 automatically. This command allows a separate update command to be
-executed at intervals determined by `package_list_update_ifelapsed`. \
+executed at intervals determined by `package_list_update_ifelapsed`.   
 
 `package_list_update_ifelapsed`
 
@@ -717,10 +759,10 @@ executed at intervals determined by `package_list_update_ifelapsed`. \
 **Synopsis**: The ifelapsed locking time in between updates of the
 package list
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method xyz
      {
      debian|ubuntu::
@@ -730,12 +772,12 @@ package list
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Not all package managers update their list information from source
 automatically. This command allows a separate update command to be
-executed at intervals determined by `package_list_update_ifelapsed`. \
+executed at intervals determined by `package_list_update_ifelapsed`.   
 
 `package_list_version_regex`
 
@@ -746,10 +788,10 @@ executed at intervals determined by `package_list_update_ifelapsed`. \
 **Synopsis**: Regular expression with one backreference to extract
 package version string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method rpm
      
      {
@@ -758,14 +800,14 @@ package version string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This regular expression should containe exactly one parenthesized
 back-reference that marks the version string of packages listed as
 installed. The regular expression may match a portion of the string (see
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)) \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions))   
 
 `package_name_convention`
 
@@ -776,10 +818,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)) \
 **Synopsis**: This is how the package manager expects the package to be
 referred to, e.g. \$(name).\$(arch)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method rpm
      
      {
@@ -788,8 +830,8 @@ referred to, e.g. \$(name).\$(arch)
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This sets the pattern for naming the package in the way expected by the
 package manager. Three special variables are defined from the extracted
@@ -802,7 +844,7 @@ When `package_policy` is update, and `package_file_repositories` is
 specified, `package_delete_convention` may be used to specify a
 different convention for the delete command.
 
-If this is not defined, it defaults to the value \$(name). \
+If this is not defined, it defaults to the value \$(name).   
 
 `package_name_regex`
 
@@ -813,10 +855,10 @@ If this is not defined, it defaults to the value \$(name). \
 **Synopsis**: Regular expression with one backreference to extract
 package name string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      {
@@ -825,8 +867,8 @@ package name string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This regular expression is only used when the *promiser* contains not
 only the name of the package, but its version and architecture also. In
@@ -834,7 +876,7 @@ that case, this expression should contain a single parenthesized
 back-reference to extract the name of the package from the string. The
 regex may match a portion of the string (see [Anchored vs. unanchored
 regular expressions](#Anchored-vs_002e-unanchored-regular-expressions))
-\
+  
 
 `package_noverify_regex`
 
@@ -844,10 +886,10 @@ regular expressions](#Anchored-vs_002e-unanchored-regular-expressions))
 
 **Synopsis**: Regular expression to match verification failure output
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method xyz
      
      {
@@ -857,14 +899,14 @@ regular expressions](#Anchored-vs_002e-unanchored-regular-expressions))
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A regular expression to match output from a package verification
 command. If the output string matches this expression, the package is
 deemed broken. The regex must match the entire line (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)) \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions))   
 
 `package_noverify_returncode`
 
@@ -875,10 +917,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)) \
 **Synopsis**: Integer return code indicating package verification
 failure
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method xyz
      {
      package_noverify_returncode => "-1";
@@ -886,11 +928,11 @@ failure
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 For use if a package verification command uses the return code as the
-signal for a failed package verification. \
+signal for a failed package verification.   
 
 `package_patch_arch_regex`
 
@@ -901,10 +943,10 @@ signal for a failed package verification. \
 **Synopsis**: Regular expression with one backreference to extract
 update architecture string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method zypper
      {
@@ -913,15 +955,15 @@ update architecture string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A few package managers keep a separate notion of patches, as opposed to
 package updates. OpenSuSE, for example, is one of these. This provides
 an analogous command struct to the packages for patch updates. The
 regular expression must match the entire line (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `package_patch_command`
 
@@ -932,10 +974,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 **Synopsis**: Command to update to the latest patch release of an
 installed package
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method zypper
      
      {
@@ -943,8 +985,8 @@ installed package
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  If the package manager supports patching, this command should patch a
 named package. If only patching of all packages is supported then
 consider running that as a batch operation in `commands`. Alternatively
@@ -954,7 +996,7 @@ interpret as an instruction to not append package names.
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_patch_installed_regex`
 
@@ -965,10 +1007,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: Regular expression which matches packages that are already
 installed
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method zypper
      {
@@ -977,15 +1019,15 @@ installed
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A few package managers keep a separate notion of patches, as opposed to
 package updates. OpenSuSE, for example, is one of these. This provide an
 analogous command struct to the packages for patch updates. The regular
 expression must match the entire string (see [Anchored vs. unanchored
 regular expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
-\
+  
 
 `package_patch_list_command`
 
@@ -995,17 +1037,17 @@ regular expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 
 **Synopsis**: Command to obtain a list of available patches or updates
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
       package_patch_list_command => "/usr/bin/zypper patches";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This command, if it exists at all, is presumed to generate a list of
 patches that are available on the system, in a format analogous to (but
@@ -1016,7 +1058,7 @@ already been installed, CFEngine will ignore them.
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_patch_name_regex`
 
@@ -1027,10 +1069,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: Regular expression with one backreference to extract
 update name string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method zypper
      {
@@ -1038,15 +1080,15 @@ update name string
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A few package managers keep a separate notion of patches, as opposed to
 package updates. OpenSuSE, for example, is one of these. This provides
 an analogous command struct to the packages for patch updates. The
 regular expression may match a partial string (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `package_patch_version_regex`
 
@@ -1057,10 +1099,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 **Synopsis**: Regular expression with one backreference to extract
 update version string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method zypper
      {
@@ -1069,15 +1111,15 @@ update version string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A few package managers keep a separate notion of patches, as opposed to
 package updates. OpenSuSE, for example, is one of these. This provides
 an analogous command struct to the packages for patch updates. The
 regular expression is unanchored, meaning it may match a partial string
 (see [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `package_update_command`
 
@@ -1088,10 +1130,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 **Synopsis**: Command to update to the latest version a currently
 installed package
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method zypper
      {
@@ -1100,8 +1142,8 @@ installed package
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If supported this should be a command that updates the version of a
 single currently installed package. If only bulk updates are supported,
@@ -1112,7 +1154,7 @@ When `package_file_repositories` is specified, the package reference id
 will include the full path to a repository containing the package. If
 `package_policy` is update, and this command is not specified, the
 `package_delete_command` and `package_add_command` will be executed to
-carry out the update. \
+carry out the update.   
 
 `package_verify_command`
 
@@ -1122,10 +1164,10 @@ carry out the update. \
 
 **Synopsis**: Command to verify the correctness of an installed package
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method rpm
      
      {
@@ -1136,8 +1178,8 @@ carry out the update. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If available, this is a command to verify an already installed package.
 It is required only when `package_policy` is verify.
@@ -1155,7 +1197,7 @@ installed, and the verify command must be successful according to
 Package managers generally expect the name of a package to be passed as
 a parameter. However, in some cases we do not need to pass the name of a
 particular package to the command. Ending the command string with \$
-prevents CFEngine from appending the package name to the string. \
+prevents CFEngine from appending the package name to the string.   
 
 `package_version_regex`
 
@@ -1166,10 +1208,10 @@ prevents CFEngine from appending the package name to the string. \
 **Synopsis**: Regular expression with one backreference to extract
 package version string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method rpm
      {
@@ -1178,8 +1220,8 @@ package version string
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the version of a package is not specified separately using
 `package_version`, then this should be a regular expression that
@@ -1187,7 +1229,7 @@ contains exactly one parenthesized back-reference that matches the
 version string in the promiser. The regular expression is unanchored,
 meaning it may match a partial string (see [Anchored vs. unanchored
 regular expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
-\
+  
 
 `package_multiline_start`
 
@@ -1198,10 +1240,10 @@ regular expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 **Synopsis**: Regular expression which matches the start of a new
 package in multiline output
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body package_method solaris (pkgname, spoolfile, adminfile)
      {
@@ -1213,21 +1255,21 @@ package in multiline output
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This pattern is used in determining when a new package record begins. It
 is used when package managers (like the Solaris package manager) use
 multi-line output formats. This pattern matches the first line of a new
-record. \
+record.   
 
 `package_commands_useshell`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -1240,28 +1282,28 @@ record. \
 
 **Default value:** true
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      Fill me in (./bodyparts/package_commands_useshell_example.texinfo)
      ""
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0b1.70bd7ea, Nova 2.3.0.a1.3167b00
 (2012)
 
-~~~~ {.verbatim}
+~~~~
      
      Fill me in (./bodyparts/package_commands_useshell_notes.texinfo)
      ""
 ~~~~
 
-\
+  
 
 `package_version_less_command`
 
@@ -1272,10 +1314,10 @@ record. \
 **Synopsis**: Command to check whether first supplied package version is
 less than second one
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method deb
      {
      ...
@@ -1283,8 +1325,8 @@ less than second one
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.4.0 (2012)
 
 This attribute allows overriding of the built-in CFEngine algorithm for
@@ -1303,7 +1345,7 @@ v2 and non-zero otherwise.
 Note that if package\_version\_equal\_command is not specified, but
 package\_version\_less\_command is, then equality will be tested by
 issuing less comparison twice (v1 equals to v2 if v1 is not less than
-v2, and v2 is not less than v1). \
+v2, and v2 is not less than v1).   
 
 `package_version_equal_command`
 
@@ -1314,10 +1356,10 @@ v2, and v2 is not less than v1). \
 **Synopsis**: Command to check whether first supplied package version is
 equal to second one
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body package_method deb
      {
      ...
@@ -1325,8 +1367,8 @@ equal to second one
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.4.0 (2012)
 
 This attribute allows overriding of the built-in CFEngine algorithm for
@@ -1349,9 +1391,9 @@ v2, and v2 is not less than v1).
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                add
                delete
                reinstall
@@ -1366,10 +1408,10 @@ v2, and v2 is not less than v1).
 **Synopsis**: Criteria for package installation/upgrade on the current
 system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 packages:
 
   "$(match_package)"
@@ -1378,36 +1420,36 @@ packages:
      package_method => xyz;
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This decides what fate is intended for the named package.
 
 add
 
 Ensure that a package is present (this is the default setting from
-3.3.0). \
+3.3.0).   
 
 delete
 
-Ensure that a package is not present. \
+Ensure that a package is not present.   
 
 reinstall
 
-Delete then add package (warning, non-convergent). \
+Delete then add package (warning, non-convergent).   
 
 update
 
-Update the package if an update is available (manager dependent). \
+Update the package if an update is available (manager dependent).   
 
 addupdate
 
 Equivalent to add if the package is not installed, and update if it is
-installed. \
+installed.   
 
 patch
 
-Install one or more patches if available (manager dependent). \
+Install one or more patches if available (manager dependent).   
 
 verify
 
@@ -1419,9 +1461,9 @@ Requires setting `package_verify_command`.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                
                
                ==
@@ -1433,10 +1475,10 @@ Requires setting `package_verify_command`.
 **Synopsis**: A criterion for first acceptable match relative to
 "package\_version"
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 packages:
 
   "$(exact_package)"
@@ -1448,8 +1490,8 @@ packages:
      package_version => "1.2.3-456";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This selects the operator that compares the promiser to the state of the
 system packages currently installed. If the criterion matches, the
@@ -1463,10 +1505,10 @@ policy action is scheduled for promise-keeping.
 
 **Synopsis**: Version reference point for determining promised version
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 packages:
 
   "mypackage"
@@ -1477,8 +1519,8 @@ packages:
      package_version => "1.2.3";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Used for specifying the targeted package version when the version is
 written separately from the name of the command.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-processes-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-processes-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,processes-in-agent-promises]
 
 ### `processes` promises in agent
 
-\
+  
 
 Process promises refer to items in the system process table. Note that
 this is not the same as commands (which are instructions that CFEngine
@@ -29,7 +29,7 @@ However, the process pattern `"cp"` will also match a process containing
 `"scp"`, so take care not to oversimplify your patterns (the PCRE
 pattern anchors `"\b"` and `"\B"` may prove very useful to you).
 
-~~~~ {.smallexample}
+~~~~
      
       processes:
      
@@ -46,7 +46,7 @@ command to restart a process. In CFEngine 3 there is instead a class to
 activate. You must then describe a `command` in that class to restart
 the process.
 
-~~~~ {.verbatim}
+~~~~
 commands:
 
   restart_me::
@@ -66,9 +66,9 @@ execution, but stop commands are executed immediately.
 Note: `process_select` was previously called process `filters` in
 CFEngine 2 and earlier.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {
 processes:
@@ -105,11 +105,11 @@ out_of_range_define => { "any_procs" };
 }
 ~~~~
 
-\
+  
 
 In CFEngine 3 we have
 
-~~~~ {.smallexample}
+~~~~
       processes
       commands
 ~~~~
@@ -126,14 +126,14 @@ kernel instantiation, a quite different object altogether. For example:
 -   A "PID" (which is not an executable) promises to be reminded of a
     signal, e.g.
 
-    ~~~~ {.smallexample}
+    ~~~~
                   kill signal pid
     ~~~~
 
 -   An "command" promises to start or stop itself with a parameterized
     specification.
 
-    ~~~~ {.smallexample}
+    ~~~~
                   exec command argument1 argument2 ...
     ~~~~
 
@@ -149,8 +149,8 @@ attributes associated with these objects.
 Executions lead to processes for the duration of their lifetime, so
 these two issues are related, although the promises themselves are not.
 
-\
- **Services versus processes**: \
+  
+ **Services versus processes**:   
 
 A service is an abstraction that requires processes to run and files to
 be configured. It makes a lot of sense to wrap services in modular
@@ -178,24 +178,24 @@ pids, not to the individual pids concerned. So it becomes the
 responsibility of the execution to locate and interact with the pids
 necessary.
 
-\
+  
 
 If you want to ensure that a service is running, check each in the agent
 control promises individually.
 
-~~~~ {.verbatim}
+~~~~
 bundlesequence => { Update, Service("apache"), Service("nfsd") };
 ~~~~
 
 or
 
-~~~~ {.verbatim}
+~~~~
 bundlesequence => { Update, @(globals.all_services)  };
 ~~~~
 
 The bundle for this can look like this:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent Service(service")
 {
 processes:
@@ -216,7 +216,7 @@ commands:
 
 An alternative would be self-contained:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent Service
 {
 vars:
@@ -268,10 +268,10 @@ out_of_range_define => "$(s)_up";
 
 **Synopsis**: List of classes to define if the matches are in range
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_count example
      {
@@ -280,12 +280,12 @@ out_of_range_define => "$(s)_up";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Classes are defined if the processes that are found in the process table
 satisfy the promised process count, in other words if the promise about
-the number of processes matching the other criteria is kept. \
+the number of processes matching the other criteria is kept.   
 
 `match_range`
 
@@ -296,10 +296,10 @@ the number of processes matching the other criteria is kept. \
 **Synopsis**: Integer range for acceptable number of matches for this
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_count example
      {
@@ -308,12 +308,12 @@ process
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a numerical range for the number of occurrences of the process
 in the process table. As long as it falls within the specified limits,
-the promise is considered kept. \
+the promise is considered kept.   
 
 `out_of_range_define`
 
@@ -323,10 +323,10 @@ the promise is considered kept. \
 
 **Synopsis**: List of classes to define if the matches are out of range
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_count example(s)
      {
@@ -335,8 +335,8 @@ the promise is considered kept. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Classes to activate remedial promises conditional on this promise
 failure to be kept.
@@ -354,10 +354,10 @@ failure to be kept.
 **Synopsis**: Regular expression matching the command/cmd field of a
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      
@@ -369,13 +369,13 @@ process
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This expression should match the entire `COMMAND` field of the process
 table, not just a fragment. This field is usually the last field on the
 line, so it thus starts with the first non-space character and ends with
-the end of line. \
+the end of line.   
 
 `pid`
 
@@ -385,10 +385,10 @@ the end of line. \
 
 **Synopsis**: Range of integers matching the process id of a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -398,9 +398,9 @@ the end of line. \
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `pgid`
 
@@ -411,10 +411,10 @@ the end of line. \
 **Synopsis**: Range of integers matching the parent group id of a
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -424,9 +424,9 @@ process
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `ppid`
 
@@ -437,10 +437,10 @@ process
 **Synopsis**: Range of integers matching the parent process id of a
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -450,9 +450,9 @@ process
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `priority`
 
@@ -463,10 +463,10 @@ process
 **Synopsis**: Range of integers matching the priority field (PRI/NI) of
 a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -475,9 +475,9 @@ a process
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `process_owner`
 
@@ -487,10 +487,10 @@ a process
 
 **Synopsis**: List of regexes matching the user of a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -499,13 +499,13 @@ a process
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Regular expression should match a legal user name on the system. The
 regex is anchored, meaning it must match the entire name (see [Anchored
 vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `process_result`
 
@@ -517,10 +517,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 **Synopsis**: Boolean class expression returning the logical combination
 of classes set by a process selection test
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select proc_finder(p)
      
@@ -534,12 +534,12 @@ of classes set by a process selection test
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A logical combination of the process selection classifiers. The syntax
 is the same as that for class expressions. There should be no spaces in
-the expressions. \
+the expressions.   
 
 `rsize`
 
@@ -550,10 +550,10 @@ the expressions. \
 **Synopsis**: Range of integers matching the resident memory size of a
 process, in kilobytes
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select
      {
@@ -563,9 +563,9 @@ process, in kilobytes
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `status`
 
@@ -575,10 +575,10 @@ process, in kilobytes
 
 **Synopsis**: Regular expression matching the status field of a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -587,11 +587,11 @@ process, in kilobytes
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 For instance, characters in the set NRSsl+... Windows processes do not
-have status fields. \
+have status fields.   
 
 `stime_range`
 
@@ -601,10 +601,10 @@ have status fields. \
 
 **Synopsis**: Range of integers matching the start time of a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -613,12 +613,12 @@ have status fields. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The calculation of time from process table entries is sensitive to
 Daylight Savings Time (Summer/Winter Time) so calculations could be an
-hour off. This is for now a bug to be fixed. \
+hour off. This is for now a bug to be fixed.   
 
 `ttime_range`
 
@@ -629,10 +629,10 @@ hour off. This is for now a bug to be fixed. \
 **Synopsis**: Range of integers matching the total elapsed time of a
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -641,10 +641,10 @@ process
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This is total accumulated time for a process. \
+This is total accumulated time for a process.   
 
 `tty`
 
@@ -654,10 +654,10 @@ This is total accumulated time for a process. \
 
 **Synopsis**: Regular expression matching the tty field of a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -666,11 +666,11 @@ This is total accumulated time for a process. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Windows processes are not regarded as attached to any terminal, so they
-all have tty '?'. \
+all have tty '?'.   
 
 `threads`
 
@@ -681,10 +681,10 @@ all have tty '?'. \
 **Synopsis**: Range of integers matching the threads (NLWP) field of a
 process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -693,9 +693,9 @@ process
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `vsize`
 
@@ -706,10 +706,10 @@ process
 **Synopsis**: Range of integers matching the virtual memory size of a
 process, in kilobytes
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body process_select example
      {
@@ -718,8 +718,8 @@ process, in kilobytes
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 On Windows, the virtual memory size is the amount of memory that cannot
 be shared with other processes. In Task Manager, this is called Commit
@@ -733,10 +733,10 @@ Size (Windows 2008), or VM Size (Windows XP).
 
 **Synopsis**: A command used to stop a running process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 processes:
 
  "snmpd"
@@ -745,8 +745,8 @@ processes:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 As an alternative to sending a termination or kill signal to a process,
 one may call a \`stop script' to perform a graceful shutdown.
@@ -760,10 +760,10 @@ one may call a \`stop script' to perform a graceful shutdown.
 **Synopsis**: A class to be defined globally if the process is not
 running, so that a command: rule can be referred to restart the process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 processes:
 
    "cf-serverd"
@@ -777,8 +777,8 @@ commands:
     "/var/cfengine/bin/cf-serverd";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a signal to restart a process that should be running, if it is
 not running. Processes are signaled first and then restarted later, at
@@ -796,9 +796,9 @@ information.
 
 **Type**: (option list)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                hup
                int
                trap
@@ -819,10 +819,10 @@ information.
 **Synopsis**: A list of menu options representing signals to be sent to
 a process
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 processes:
 
  cfservd_out_of_control::
@@ -840,8 +840,8 @@ processes:
    
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Signals are presented as an ordered list to the process. On Windows,
 only the kill signal is supported, which terminates the process.

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-replace_005fpatterns-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-replace_005fpatterns-in-edit_005fline-promises.markdown
@@ -9,12 +9,12 @@ tags: [Bundles-for-agent,replace_005fpatterns-in-edit_005fline-promises]
 
 ### `replace_patterns` promises in edit\_line
 
-\
+  
 
 This promise refers to arbitrary text patterns in a file. The pattern is
 expressed as a PCRE regular expression.
 
-~~~~ {.smallexample}
+~~~~
      
        replace_patterns:
      
@@ -25,9 +25,9 @@ expressed as a PCRE regular expression.
      
 ~~~~
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line upgrade_cfexecd
 {
   replace_patterns:
@@ -44,7 +44,7 @@ occurrences => "all";
 }
 ~~~~
 
-\
+  
 
 This is a straightforward search and replace function. Only the portion
 of the line that matches the pattern in the promise will be replaced;
@@ -69,9 +69,9 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     all
                     first
 ~~~~
@@ -81,10 +81,10 @@ the latter is non-convergent)
 
 **Default value:** all
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body replace_with example
      {
@@ -93,15 +93,15 @@ the latter is non-convergent)
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A policy for string replacement.
 
 Using "first" is generally unwise, as it will change a different
 matching string each time the promise is executed, and may not "catch
 up" with whatever external action is altering the text the promise
-applies to. \
+applies to.   
 
 `replace_value`
 
@@ -111,10 +111,10 @@ applies to. \
 
 **Synopsis**: Value used to replace regular expression matches in search
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body replace_with example(s)
      {
@@ -123,5 +123,5 @@ applies to. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-services-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-services-in-agent-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,services-in-agent-promises]
 
 ### `services` promises in agent
 
-\
+  
  A service is a set of zero or more processes. It can be zero if the
 service is not currently running. Services run in the background, and do
 not require user intervention.
@@ -38,9 +38,9 @@ CFEngine also allows for the concept of dependencies between services,
 and can automatically start or stop these, if desired. Parameters can be
 passed to services that are started by CFEngine.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {
 services:
@@ -62,7 +62,7 @@ body service_method winmethod
 }
 ~~~~
 
-\
+  
 
 Services promises for Windows are only available in CFEngine Nova and
 above. Windows Vista/Server 2008 and later introduced new complications
@@ -77,7 +77,7 @@ systems and are merely as a convenient front-end to `processes` and
 `commands`. If nothing else is specified, CFEngine looks for an special
 reserved agent bundle called
 
-~~~~ {.verbatim}
+~~~~
 bundle agent standard_services(service,state)
 {
 ...
@@ -94,7 +94,7 @@ service bundle, so this is merely a front-end.
 
 The standard bundle can be replaced with another, as follows:
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -152,9 +152,9 @@ variable is only defined for services promises.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                start
                stop
                disable
@@ -164,18 +164,18 @@ variable is only defined for services promises.
 
 **Synopsis**: Policy for cfengine service status
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 services:
   
   "Telnet"
      service_policy => "disable";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If set to `start`, CFEngine Nova will keep the service in a running
 state, while `stop` means that the service is kept in a stopped state.
@@ -192,10 +192,10 @@ changing file permissions).
 **Synopsis**: A list of services on which the named service abstraction
 depends
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 services:
   
   "ftp"
@@ -203,8 +203,8 @@ services:
     service_dependencies => { "network", "logging" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of services that must be running before the service can be
 started. These dependencies can be started automatically by CFEngine
@@ -231,10 +231,10 @@ list.
 
 **Synopsis**: Parameters for starting the service as command
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body service_method example
      {
@@ -243,8 +243,8 @@ list.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 These arguments will only be passed if CFEngine Nova starts the service.
 Thus, set `service_autostart_policy` to `none` to ensure that the
@@ -252,15 +252,15 @@ arguments are always passed.
 
 Escaped quotes can be used to pass an argument containing spaces as a
 single argument, e.g. "-f \\"file name.conf\\"". Passing arguments is
-optional. \
+optional.   
 
 `service_autostart_policy`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     none
                     boot_time
                     on_demand
@@ -268,10 +268,10 @@ optional. \
 
 **Synopsis**: Should the service be started automatically by the OS
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body service_method example
      {
@@ -280,8 +280,8 @@ optional. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Defaults to `none`, which means that the service is not registered for
 automatic startup by the operating system in any way. It must be `none`
@@ -290,19 +290,19 @@ started at boot time, while `on_demand` means that the service is
 dispatched once it is being used.
 
 `on_demand` is not supported by Windows, and is implemented through
-inetd or xinetd on Unix. \
+inetd or xinetd on Unix.   
 
 `service_bundle`
 
-**Type**: (ext bundle) (Separate Bundle) \
+**Type**: (ext bundle) (Separate Bundle)   
 
 `service_dependence_chain`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     ignore
                     start_parent_services
                     stop_child_services
@@ -311,10 +311,10 @@ inetd or xinetd on Unix. \
 
 **Synopsis**: How to handle dependencies and dependent services
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body service_method example
      {
@@ -323,8 +323,8 @@ inetd or xinetd on Unix. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The service dependencies include both the dependencies defined by the
 operating system and in `service_dependencies`, as described there.
@@ -345,25 +345,25 @@ depends on C. If we want to start B, we must first make sure A is
 running. If `start_parent_services` or `all_related` is set, CFEngine
 Nova will start A, if it is not running. On the other hand, if we want
 to stop B, C needs to be stopped first. `stop_child_services` or
-`all_related` means that CFEngine Nova will stop C, if it is running. \
+`all_related` means that CFEngine Nova will stop C, if it is running.   
 
 `service_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     windows
                     generic
 ~~~~
 
 **Synopsis**: Service abstraction type
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body service_method example
      {
@@ -372,8 +372,8 @@ to stop B, C needs to be stopped first. `stop_child_services` or
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 On Windows this defaults to, and must be `windows`. Unix systems can
 however have multiple means of registering services, but the choice must

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005fattribute-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005fattribute-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,set_005fattribute-in-edit_005fxml-promises]
 
 ### `set_attribute` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that an
 attribute, with the given name and value, will be present in the
@@ -21,9 +21,9 @@ attribute value are each determined by body-attributes. The promise
 object referred to is a literal string representation of the name of the
 attribute to be set.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   set_attribute:
@@ -34,7 +34,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically only a single attribute, within a single selected
 node, is set in each `set_attribute` promise. You may of course have
@@ -52,15 +52,15 @@ multiple promises that each set an attribute.
 **Synopsis**: Value of the attribute to be inserted into the XPath node
 of the XML file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body attribute_value example(s)
 {
 attribute_value => "$(s)";
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005ftext-in-edit_005fxml-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-agent,set_005ftext-in-edit_005fxml-promises]
 
 ### `set_text` promises in edit\_xml
 
-\
+  
 
 This promise is part of the XML-editing model. It assures that a
 matching value string will be present in the specified node within the
@@ -18,9 +18,9 @@ default promise is to replace the existing value string, within the
 specified node. The specified node is determined by body-attributes. The
 promise object referred to is a literal string of text.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_xml example
   {
   set_text:
@@ -30,7 +30,7 @@ bundle edit_xml example
   }
 ~~~~
 
-\
+  
 
 Note that typically only a single value string, within a single selected
 node, is set in each `set_text` promise. You may of course have multiple

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-storage-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-storage-in-agent-promises.markdown
@@ -9,11 +9,11 @@ tags: [Bundles-for-agent,storage-in-agent-promises]
 
 ### `storage` promises in agent
 
-\
+  
 
 Storage promises refer to disks and filesystem properties.
 
-~~~~ {.smallexample}
+~~~~
      
       storage:
      
@@ -29,9 +29,9 @@ and `misc_mounts` types. The old mount-models for binary and home
 servers has been deprecated and removed from CFEngine 3. Users who use
 these models can reconstruct them from the low-level tools.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent storage
 
 {
@@ -63,7 +63,7 @@ edit_fstab => "true";
 }
 ~~~~
 
-\
+  
 
 -   [mount in storage](#mount-in-storage)
 -   [volume in storage](#volume-in-storage)
@@ -76,9 +76,9 @@ edit_fstab => "true";
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -92,10 +92,10 @@ edit_fstab => "true";
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body mount example
      {
@@ -104,18 +104,18 @@ edit_fstab => "true";
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-The default behaviour is to not place edits in the file system table. \
+The default behaviour is to not place edits in the file system table.   
 
 `mount_type`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     nfs
                     nfs2
                     nfs3
@@ -124,10 +124,10 @@ The default behaviour is to not place edits in the file system table. \
 
 **Synopsis**: Protocol type of remote file system
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body mount example
      {
@@ -136,10 +136,10 @@ The default behaviour is to not place edits in the file system table. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This field is mainly for future extensions. \
+This field is mainly for future extensions.   
 
 `mount_source`
 
@@ -149,10 +149,10 @@ This field is mainly for future extensions. \
 
 **Synopsis**: Path of remote file system to mount
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body mount example
      {
@@ -161,10 +161,10 @@ This field is mainly for future extensions. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This is the location on the remote device, server, SAN etc. \
+This is the location on the remote device, server, SAN etc.   
 
 `mount_server`
 
@@ -174,10 +174,10 @@ This is the location on the remote device, server, SAN etc. \
 
 **Synopsis**: Hostname or IP or remote file system server
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body mount example
      {
@@ -186,10 +186,10 @@ This is the location on the remote device, server, SAN etc. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-Hostname or IP address, this could be on a SAN. \
+Hostname or IP address, this could be on a SAN.   
 
 `mount_options`
 
@@ -200,10 +200,10 @@ Hostname or IP address, this could be on a SAN. \
 **Synopsis**: List of option strings to add to the file system table
 ("fstab")
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body mount example
      {
      mount_options => { "rw", "acls" };
@@ -211,19 +211,19 @@ Hostname or IP address, this could be on a SAN. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This list is concatenated in a form appropriate for the filesystem. The
-options must be legal options for the system mount commands. \
+options must be legal options for the system mount commands.   
 
 `unmount`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -236,10 +236,10 @@ options must be legal options for the system mount commands. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body mount example
      {
@@ -248,8 +248,8 @@ options must be legal options for the system mount commands. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 #### `volume` (body template)
 
@@ -259,9 +259,9 @@ options must be legal options for the system mount commands. \
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -275,10 +275,10 @@ system on this host
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume example
      
@@ -289,13 +289,13 @@ system on this host
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 CFEngine will not normally perform sanity checks on filesystems that are
 not local to the host. If `true` it will ignore a partition's network
 location and ask the current host to verify storage located physically
-on other systems. \
+on other systems.   
 
 `freespace`
 
@@ -306,10 +306,10 @@ on other systems. \
 **Synopsis**: Absolute or percentage minimum disk space that should be
 available before warning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume example1
      {
@@ -323,15 +323,15 @@ available before warning
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The amount of freespace that is promised on a storage device. Once this
 promise is found not to be kept (that is, if the free space falls below
 the promised value), warnings are generated. You may also want to use
 the results of this promise to control other promises.
 
-See: [classes in \*](#classes-in-_002a). \
+See: [classes in \*](#classes-in-_002a).   
 
 `sensible_size`
 
@@ -342,10 +342,10 @@ See: [classes in \*](#classes-in-_002a). \
 **Synopsis**: Minimum size in bytes that should be used on a
 sensible-looking storage device
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume example
      {
@@ -354,10 +354,10 @@ sensible-looking storage device
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume control
      {
@@ -366,7 +366,7 @@ sensible-looking storage device
      
 ~~~~
 
-\
+  
 
 `sensible_count`
 
@@ -377,10 +377,10 @@ sensible-looking storage device
 **Synopsis**: Minimum number of files that should be defined on a
 sensible-looking storage device
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume example
      {
@@ -389,19 +389,19 @@ sensible-looking storage device
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Files must be readable by the agent. In other words, it is assumed that
-the agent has privileges on volumes being checked. \
+the agent has privileges on volumes being checked.   
 
 `scan_arrivals`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -415,10 +415,10 @@ distribution
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body volume example
      {
@@ -427,8 +427,8 @@ distribution
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This operation should not be left \`on' for more than a single run
 (maximum once per week). It causes CFEngine to perform an extensive disk

--- a/bundles-logs-functions-variables/Bundles-for-common-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0.markdown
@@ -10,7 +10,7 @@ tags: [Bundles-for-common]
 Bundles of `common`
 -------------------
 
-\
+  
 
 Common bundles may only contain the promise types that are common to all
 bodies. Their main function is to define cross-component global
@@ -20,9 +20,9 @@ Common bundles are observed by every agent, whereas the agent specific
 bundle types are ignored by components other than the intended
 recipient.
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      bundle common globals
      {

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-Miscellaneous-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-Miscellaneous-in-common-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-common,Miscellaneous-in-common-promises]
 
 ### `*` promises
 
-\
+  
 
 Whereas most promise types are specific to a particular kind of
 interpretation that requires a typed interpreter (the bundle type), a
@@ -33,9 +33,9 @@ promises. The specific promise attributes are listed below.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     fix
                     warn
                     nop
@@ -43,12 +43,12 @@ promises. The specific promise attributes are listed below.
 
 **Synopsis**: Whether to repair or report about non-kept promises
 
-**Example**:\
- \
+**Example**:  
+   
 
 The following example shows a simple use of transaction control:
 
-~~~~ {.verbatim}
+~~~~
      
      body action warn_only {
      action_policy => "warn";
@@ -57,8 +57,8 @@ The following example shows a simple use of transaction control:
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The `action` settings allow general transaction control to be
 implemented on promise verification. Action bodies place limits on how
@@ -70,7 +70,7 @@ bundles, and that promises within these do not inherit action settings
 at higher levels. Thus, in the following example there are two levels of
 action setting:
 
-~~~~ {.verbatim}
+~~~~
      ########################################################
      #
      # Warn if line matched
@@ -122,18 +122,18 @@ modelling of the file will only warn about changes rather than
 committing them to the memory model. This makes little difference to the
 end result, but it means that CFEngine will report
 
-~~~~ {.smallexample}
+~~~~
           Need to delete line - ... - but only a warning was promised
 ~~~~
 
 Instead of
 
-~~~~ {.smallexample}
+~~~~
           Deleting the promised line ... Need to save file - but only a warning was promised
 ~~~~
 
 In either case, no changes will be made to the disk, but the messages
-given by `cf-agent` will differ. \
+given by `cf-agent` will differ.   
 
 `ifelapsed`
 
@@ -146,10 +146,10 @@ promise
 
 **Default value:** control body value
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      #local
      
@@ -168,8 +168,8 @@ promise
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This overrides the global settings. Promises which take a long time to
 verify should usually be protected with a long value for this parameter.
@@ -177,7 +177,7 @@ This serves as a resource \`spam' protection. A CFEngine check could
 easily run every 5 minutes provided resource intensive operations are
 not performed on every run. Using time classes such as `Hr12` is one
 part of this strategy; using `ifelapsed` is another, which is not tied
-to a specific time. \
+to a specific time.   
 
 `expireafter`
 
@@ -190,10 +190,10 @@ and retried
 
 **Default value:** control body value
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body action example
      {
      ifelapsed   => "120";  # 2 hours
@@ -201,11 +201,11 @@ and retried
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The locking time after which CFEngine will attempt to kill and restart
-its attempt to keep a promise. \
+its attempt to keep a promise.   
 
 `log_string`
 
@@ -216,10 +216,10 @@ its attempt to keep a promise. \
 **Synopsis**: A message to be written to the log when a promise
 verification leads to a repair
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.example}
+~~~~
           
           promise-type:
           
@@ -237,8 +237,8 @@ verification leads to a repair
           
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The `log_string` works together with `log_repair`, `log_kept` etc, to
 define a string for logging to one of the named files depending on
@@ -252,15 +252,15 @@ Hint: the promise handle \$(this.handle) can be a useful referent in a
 log message, indicating the origin of the message. In CFEngine Nova and
 above, every promise has a default handle, which is based on the
 filename and line number (specifying your own handle will probably be
-more mnemonic). \
+more mnemonic).   
 
 `log_level`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     inform
                     verbose
                     error
@@ -269,10 +269,10 @@ more mnemonic). \
 
 **Synopsis**: The reporting level sent to syslog
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action example
      {
@@ -281,8 +281,8 @@ more mnemonic). \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Use this as an alternative to auditing if you wish to use the syslog
 mechanism to centralize or manage messaging from CFEngine. A backup of
@@ -291,7 +291,7 @@ these messages will still be kept in WORKDIR/outputs if you are using
 
 On the native Windows version of CFEngine (Nova or above), using verbose
 will include a message when the promise is kept or repaired in the event
-log. \
+log.   
 
 `log_kept`
 
@@ -302,10 +302,10 @@ log. \
 **Synopsis**: This should be the filename of a file to which log\_string
 will be saved, and if undefined it goes to the system logger
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action logme(x)
      {
@@ -317,8 +317,8 @@ will be saved, and if undefined it goes to the system logger
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this option is specified together with `log_string`, the current
 promise will log promise-kept status using the log string to this named
@@ -336,7 +336,7 @@ the log, of one of the following special values:
 stdout
 
 Send the log message to the standard output, prefixed with an L: to
-indicate a log message. \
+indicate a log message.   
 
 udp\_syslog
 
@@ -344,15 +344,15 @@ Attempt to connect to the `syslog_server` defined in body common control
 and log the message there, assuming the server is configured to receive
 the request.
 
-\
+  
 
 `log_priority`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     emergency
                     alert
                     critical
@@ -366,20 +366,20 @@ the request.
 **Synopsis**: The priority level of the log message, as interpreted by a
 syslog server
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body action low_priority
      {
      log_priority => "info";
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This determines the importance of messages from CFEngine. \
+This determines the importance of messages from CFEngine.   
 
 `log_repaired`
 
@@ -390,10 +390,10 @@ This determines the importance of messages from CFEngine. \
 **Synopsis**: This should be filename of a file to which log\_string
 will be saved, if undefined it goes to the system logger
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      bundle agent test
      {
@@ -425,8 +425,8 @@ will be saved, if undefined it goes to the system logger
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This may be the name of a log to which the `log_string` is written if a
 promise is repaired. It should be the full path to a text file which
@@ -435,7 +435,7 @@ will contain the log, of one of the following special values:
 stdout
 
 Send the log message to the standard output, prefixed with an L: to
-indicate a log message. \
+indicate a log message.   
 
 udp\_syslog
 
@@ -443,7 +443,7 @@ Attempt to connect to the `syslog_server` defined in body common control
 and log the message there, assuming the server is configured to receive
 the request.
 
-\
+  
 
 `log_failed`
 
@@ -454,10 +454,10 @@ the request.
 **Synopsis**: This should be the filename of a file to which log\_string
 will be saved, and if undefined it goes to the system logger
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      bundle agent test
      {
@@ -485,8 +485,8 @@ will be saved, and if undefined it goes to the system logger
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this option is specified together with `log_string`, the current
 promise will log promise-kept status using the log string to this named
@@ -503,7 +503,7 @@ one of the following special values:
 stdout
 
 Send the log message to the standard output, prefixed with an L: to
-indicate a log message. \
+indicate a log message.   
 
 udp\_syslog
 
@@ -511,7 +511,7 @@ Attempt to connect to the `syslog_server` defined in body common control
 and log the message there, assuming the server is configured to receive
 the request.
 
-\
+  
 
 `value_kept`
 
@@ -521,10 +521,10 @@ the request.
 
 **Synopsis**: A real number value attributed to keeping this promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action mydef
      {
@@ -536,12 +536,12 @@ the request.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If nothing is specified, the default value is +1.0. However, nothing is
 logged unless the agent control body switched on track\_value = "true".
-\
+  
 
 `value_repaired`
 
@@ -551,10 +551,10 @@ logged unless the agent control body switched on track\_value = "true".
 
 **Synopsis**: A real number value attributed to repairing this promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action mydef
      {
@@ -566,12 +566,12 @@ logged unless the agent control body switched on track\_value = "true".
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If nothing is specified, the default value is 0.5. However, nothing is
 logged unless the agent control body switched on track\_value = "true".
-\
+  
 
 `value_notkept`
 
@@ -582,10 +582,10 @@ logged unless the agent control body switched on track\_value = "true".
 **Synopsis**: A real number value (possibly negative) attributed to not
 keeping this promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action mydef
      {
@@ -597,20 +597,20 @@ keeping this promise
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If nothing is specified, the default value is -1.0. However, nothing is
 logged unless the agent control body switched on track\_value = "true".
-\
+  
 
 `audit`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -624,10 +624,10 @@ promise
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action example
      {
@@ -638,21 +638,21 @@ promise
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this is set, CFEngine will perform auditing on this specific promise.
 This means that all details surrounding the verification of the current
 promise will be recorded in the audit database. The database may be
-inspected with `cf-report`, or `cfshow` in CFEngine 2. \
+inspected with `cf-report`, or `cfshow` in CFEngine 2.   
 
 `background`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -665,10 +665,10 @@ inspected with `cf-report`, or `cfshow` in CFEngine 2. \
 
 **Default value:** false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action example
      {
@@ -677,8 +677,8 @@ inspected with `cf-report`, or `cfshow` in CFEngine 2. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If possible, perform the verification of the current promise in the
 background. This is advantageous only if the verification might take a
@@ -690,15 +690,15 @@ want to wait for a particular command to finish execution before
 checking the next promise. This is particular for the Windows platform
 because there is no way that a program can start itself in the
 background here; in other words, fork off a child process. However, file
-operations can not be performed in the background on windows. \
+operations can not be performed in the background on windows.   
 
 `report_level`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     inform
                     verbose
                     error
@@ -709,10 +709,10 @@ operations can not be performed in the background on windows. \
 
 **Default value:** none
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body action example
      {
@@ -721,8 +721,8 @@ operations can not be performed in the background on windows. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 cf-agent can be run in verbose mode (-v), inform mode (-I) and just
 print errors (no arguments). This attribute allows to set these three
@@ -730,7 +730,7 @@ output levels on a per promise basis, allowing the promise to be more
 verbose than the global setting (but not less).
 
 In CFEngine 2 one would say inform=true or syslog=true, and so on. This
-replaces these levels since they act as encapsulating super-sets. \
+replaces these levels since they act as encapsulating super-sets.   
 
 `measurement_class`
 
@@ -741,10 +741,10 @@ replaces these levels since they act as encapsulating super-sets. \
 **Synopsis**: If set performance will be measured and recorded under
 this identifier
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      
      body action measure
@@ -754,15 +754,15 @@ this identifier
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 By setting this string you switch on performance measurement for the
 current promise, and also give the measurement a name. The identifier
 forms a partial identity for optional performance scanning of promises
 of the form:
 
-~~~~ {.example}
+~~~~
           ID:promise-type:promiser.
 ~~~~
 
@@ -781,10 +781,10 @@ generated file performance.html.
 
 **Synopsis**: A list of classes to be defined globally
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -793,8 +793,8 @@ generated file performance.html.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If a promise is \`repaired' it means that a corrective action had to be
 taken to keep the promise.
@@ -810,7 +810,7 @@ you promise to create and file and change its permissions, when the file
 exists with incorrect permissions, `cf-agent` will report that the
 promise\_kept for the file existence, but promise\_repaired for the
 permissions. If you need separate reports, you should code two separate
-promises rather than \`overloading' a single one. \
+promises rather than \`overloading' a single one.   
 
 `repair_failed`
 
@@ -820,10 +820,10 @@ promises rather than \`overloading' a single one. \
 
 **Synopsis**: A list of classes to be defined globally
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -832,14 +832,14 @@ promises rather than \`overloading' a single one. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A promise could not be repaired because the corrective action failed for
 some reason.
 
 Any strings passed to this list are automatically canonified, so it is
-unnecessary to call a canonify function on such inputs. \
+unnecessary to call a canonify function on such inputs.   
 
 `repair_denied`
 
@@ -849,10 +849,10 @@ unnecessary to call a canonify function on such inputs. \
 
 **Synopsis**: A list of classes to be defined globally
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -861,13 +861,13 @@ unnecessary to call a canonify function on such inputs. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A promise could not be kept because access to a key resource was denied.
 
 Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs. \
+so it is unnecessary to call a canonify function on such inputs.   
 
 `repair_timeout`
 
@@ -877,10 +877,10 @@ so it is unnecessary to call a canonify function on such inputs. \
 
 **Synopsis**: A list of classes to be defined globally
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -889,11 +889,11 @@ so it is unnecessary to call a canonify function on such inputs. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A promise maintenance repair timed-out waiting for some dependent
-resource. \
+resource.   
 
 `promise_kept`
 
@@ -903,10 +903,10 @@ resource. \
 
 **Synopsis**: A list of classes to be defined globally
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -915,8 +915,8 @@ resource. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This class is set if no action was necessary by `cf-agent` because the
 promise concerned was already kept without further action required.
@@ -932,7 +932,7 @@ you promise to create and file and change its permissions, when the file
 exists with incorrect permissions, `cf-agent` will report that the
 promise\_kept for the file existence, but promise\_repaired for the
 permissions. If you need separate reports, you should code two separate
-promises rather than \`overloading' a single one. \
+promises rather than \`overloading' a single one.   
 
 `cancel_kept`
 
@@ -942,10 +942,10 @@ promises rather than \`overloading' a single one. \
 
 **Synopsis**: A list of classes to be canceled if the promise is kept
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -954,8 +954,8 @@ promises rather than \`overloading' a single one. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the promise was already kept and nothing was done, cancel (undefine)
 any of the listed classes so that they are no longer defined.
@@ -964,7 +964,7 @@ Note that any strings passed to this list are automatically canonified,
 so it is unnecessary to call a canonify function on such inputs.
 
 **History**: This attribute was introduced in CFEngine version 3.0.4
-(2010) \
+(2010)   
 
 `cancel_repaired`
 
@@ -975,10 +975,10 @@ so it is unnecessary to call a canonify function on such inputs.
 **Synopsis**: A list of classes to be canceled if the promise is
 repaired
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -987,8 +987,8 @@ repaired
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the promise was repaired and changes were made to the system, cancel
 (undefine) any of the listed classes so that they are no longer defined.
@@ -997,7 +997,7 @@ Note that any strings passed to this list are automatically canonified,
 so it is unnecessary to call a canonify function on such inputs.
 
 **History**: This attribute was introduced in CFEngine version 3.0.4
-(2010) \
+(2010)   
 
 `cancel_notkept`
 
@@ -1008,10 +1008,10 @@ so it is unnecessary to call a canonify function on such inputs.
 **Synopsis**: A list of classes to be canceled if the promise is not
 kept for any reason
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -1020,8 +1020,8 @@ kept for any reason
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the promise was not kept but nothing could be done, cancel (undefine)
 any of the listed classes so that they are no longer defined.
@@ -1030,7 +1030,7 @@ Note that any strings passed to this list are automatically canonified,
 so it is unnecessary to call a canonify function on such inputs.
 
 **History**: This attribute was introduced in CFEngine version 3.0.4
-(2010) \
+(2010)   
 
 `kept_returncodes`
 
@@ -1041,10 +1041,10 @@ so it is unnecessary to call a canonify function on such inputs.
 **Synopsis**: A list of return codes indicating a kept command-related
 promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      bundle agent cmdtest
      {
      commands:
@@ -1063,8 +1063,8 @@ promise
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of integer return codes indicating that a command-related promise
 has been kept. This can in turn be used to define classes using the
@@ -1087,7 +1087,7 @@ Note that the return codes may overlap, so multiple classes may be set
 from one return code. In Unix systems the possible return codes are
 usually in the range from 0 to 255.
 
-*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010) \
+*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
 `repaired_returncodes`
 
@@ -1098,10 +1098,10 @@ usually in the range from 0 to 255.
 **Synopsis**: A list of return codes indicating a repaired
 command-related promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      bundle agent cmdtest
      {
      commands:
@@ -1120,8 +1120,8 @@ command-related promise
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of integer return codes indicating that a command-related promise
 has been repaired. This can in turn be used to define classes using the
@@ -1144,7 +1144,7 @@ Note that the return codes may overlap, so multiple classes may be set
 from one return code. In Unix systems the possible return codes are
 usually in the range from 0 to 255.
 
-*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010) \
+*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
 `failed_returncodes`
 
@@ -1155,10 +1155,10 @@ usually in the range from 0 to 255.
 **Synopsis**: A list of return codes indicating a failed command-related
 promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body common control
      {
      bundlesequence => { "cmdtest" };
@@ -1192,8 +1192,8 @@ promise
      } 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A list of integer return codes indicating that a command-related promise
 has failed. This can in turn be used to define classes using the
@@ -1216,7 +1216,7 @@ Note that the return codes may overlap, so multiple classes may be set
 from one return code. In Unix systems the possible return codes are
 usually in the range from 0 to 255.
 
-*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010) \
+*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
 `persist_time`
 
@@ -1227,10 +1227,10 @@ usually in the range from 0 to 255.
 **Synopsis**: A number of minutes the specified classes should remain
 active
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -1239,20 +1239,20 @@ active
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 By default classes are ephemeral entities that disappear when `cf-agent`
 terminates. By setting a persistence time, they can last even when the
-agent is not running. \
+agent is not running.   
 
 `timer_policy`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     absolute
                     reset
 ~~~~
@@ -1262,10 +1262,10 @@ rediscovered
 
 **Default value:** reset
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body classes example
      {
@@ -1274,8 +1274,8 @@ rediscovered
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In most cases resetting a timer will give a more honest appraisal of
 which classes are currently important, but if we want to activate a
@@ -1290,15 +1290,15 @@ is useful.
 
 **Synopsis**: A comment about the real intention of the promise
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 comment => "This comment follows the data for reference ...",
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Comments written in code follow the program, they are not merely
 discarded. They appear in reports and error messages.
@@ -1312,10 +1312,10 @@ discarded. They appear in reports and error messages.
 **Synopsis**: A list of promise handles that this promise builds on or
 depends on somehow
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "one"  };
@@ -1337,8 +1337,8 @@ reports:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a list of promise handles for whom this promise is a promisee.
 In other words, we acknowledge that this promise will be affected by the
@@ -1362,10 +1362,10 @@ Handles in other namespaces may be referred to by namespace:handle.
 **Synopsis**: A unique id-tag string for referring to this as a promisee
 elsewhere
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 access:
 
   "/source"
@@ -1374,8 +1374,8 @@ access:
     admit   => { "127.0.0.1" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A promise handle is like a \`goto' label. It allows you to refer to a
 promise as the promisee of `depends_on` client of another promise.
@@ -1400,12 +1400,12 @@ rather than its content.
 
 **Synopsis**: Extended classes ANDed with context
 
-**Example**:\
- \
+**Example**:  
+   
 
 The generic example has the form:
 
-~~~~ {.example}
+~~~~
      
      promise-type:
      
@@ -1417,7 +1417,7 @@ The generic example has the form:
 
 A specific example would be:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -1437,8 +1437,8 @@ commands:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is an additional class expression that will be evaluated after the
 class:: classes have selected promises. It is provided in order to
@@ -1450,7 +1450,7 @@ variable classes.
 This function is provided so that one can form expressions that link
 variables and classes. For example:
 
-~~~~ {.verbatim}
+~~~~
 # Check that all components are running
 
 vars:
@@ -1480,10 +1480,10 @@ the same algorithm that CFEngine uses.
 
 **Synopsis**: User-data associated with policy, e.g. key=value strings
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 files:
 
   "/etc/special_file"
@@ -1494,8 +1494,8 @@ files:
     meta => { "owner=John",  "version=2.0" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-classes-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-classes-in-common-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-common,classes-in-common-promises]
 
 ### `classes` promises in \*
 
-\
+  
  Classes promises refer to the classification of different run-contexts.
 These are not related to object oriented classes, but are more like tag
 labels representing different properties of the environment.
@@ -22,9 +22,9 @@ classes in all other bundles are local.
 
 Note: The words class and context are sometimes used interchangeably.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle common g
 {
 classes:
@@ -57,10 +57,10 @@ to be ANDed together, this list form is more convenient than providing
 an expression. If all of the class expressions listed on the right-hand
 side match, then the class on the left-hand side is defined.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "compound_class" and => { classmatch("host[0-9].*"), "Monday", "Hr02" };
@@ -78,10 +78,10 @@ Assign one generic class ('always') and one additional class, randomly
 weighted on a probability distribution. This was previous called a
 strategy in CFEngine 2.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "my_dist"  
@@ -93,7 +93,7 @@ Referring to the the sum of `10+20+40+50 = 120` in the example above,
 when generating the distribution, CFEngine picks a number between
 `1-120`. This will generate the following classes:
 
-~~~~ {.smallexample}
+~~~~
      my_dist    (always)
      my_dist_10 (10/120 of the time)
      my_dist_20 (20/120 of the time)
@@ -111,10 +111,10 @@ when generating the distribution, CFEngine picks a number between
 
 A way of aliasing class combinations.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "class_name" expression => "solaris|(linux.specialclass)";
@@ -133,10 +133,10 @@ The class on the left-hand side will be defined if any one (or more) of
 the class expressions on the right-hand side are true. This is useful
 construction for writing expressions that contain special functions.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
     "compound_test" 
@@ -158,10 +158,10 @@ calculations on each invocation. This is useful if a class discovered is
 essentially constant or only slowly varying, such as a hostname or alias
 from a non-standard naming facility.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle common setclasses
 {
 classes:
@@ -180,7 +180,7 @@ classes:
 For example, to create a conditional inclusion of costly class
 definitions, put them into a separate bundle in a file classes.cf.
 
-~~~~ {.verbatim}
+~~~~
 # promises.cf
 
 body common control 
@@ -211,7 +211,7 @@ reports:
 
 Then create classes.cf
 
-~~~~ {.verbatim}
+~~~~
 # classes.cf
 
 bundle common setclasses
@@ -241,10 +241,10 @@ This negates the effect of the promiser-pattern regular expression. The
 class on the left-hand side will only be defined if the class expression
 on the right-hand side is false.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
    "others"  not => "linux|solaris";
@@ -272,10 +272,10 @@ The class is chosen deterministically (not randomly) but it is not
 possible to say which host will end up in which class in advance. Only
 that hosts will always end up in the same class every time.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle common g
 {
 classes:
@@ -303,10 +303,10 @@ This behaves as the XOR operation on class expressions. It can be used
 to define a class if exactly one of the class expressions on the
 right-hand side matches.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
  "another_global" xor => { "any", "linux", "solaris"};

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-defaults-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-defaults-in-common-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-common,defaults-in-common-promises]
 
 ### `defaults` promises in \*
 
-\
+  
 
 Defaults promises are related to variables. If a variable or parameter
 in a promise bundle is undefined, or its value is defined to be invalid,
@@ -23,7 +23,7 @@ Some variables might be defined but still contain unresolved variables.
 To handle this you will need to match the `$(abc)` form of the
 variables.
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "main" };
@@ -56,7 +56,7 @@ reports:
 
 Another example:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -106,7 +106,7 @@ reports:
 }
 ~~~~
 
-\
+  
 
 -   [if\_match\_regex in defaults](#if_005fmatch_005fregex-in-defaults)
 -   [string in defaults](#string-in-defaults)
@@ -125,10 +125,10 @@ If a parameter or variable is already defined in the current context,
 and the value matches this regular expression, it will be deemed invalid
 and replaced with the default value.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent mymethod(a,b)
 {
 defaults:
@@ -150,10 +150,10 @@ In previous versions of CFEngine lists were represented (as in the
 shell) using separated scalars; similar to the PATH variable. In
 CFEngine 3 lists are kept as an independent type.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    string => "Some literal string...";
@@ -176,10 +176,10 @@ variable substitution and
 expansion](#List-variable-substitution-and-expansion), and [policy in
 vars](#policy-in-vars)).
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    slist  => {  "literal1",  "literal2" };

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-meta-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-meta-in-common-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-common,meta-in-common-promises]
 
 ### `meta` promises in \*
 
-\
+  
 
 Meta-data promises have no internal function. They are intended to be
 used to represent arbitrary information about promise bundles. Formally,
@@ -17,9 +17,9 @@ meta promises are implemented as variables, and the values map to a
 variable context called bundlename\_meta, and therefore the values can
 be used as variables and will appear in Enterprise variable reports.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -38,7 +38,7 @@ reports:
 }
 ~~~~
 
-\
+  
 
 -   [string in meta](#string-in-meta)
 -   [slist in meta](#slist-in-meta)
@@ -55,10 +55,10 @@ In previous versions of CFEngine lists were represented (as in the
 shell) using separated scalars; similar to the PATH variable. In
 CFEngine 3 lists are kept as an independent type.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    string => "Some literal string...";
@@ -81,10 +81,10 @@ variable substitution and
 expansion](#List-variable-substitution-and-expansion), and [policy in
 vars](#policy-in-vars)).
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    slist  => {  "literal1",  "literal2" };

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-reports-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-reports-in-common-promises.markdown
@@ -9,13 +9,13 @@ tags: [Bundles-for-common,reports-in-common-promises]
 
 ### `reports` promises in \*
 
-\
+  
 
 Reports promises simply print messages. Outputting a message without
 qualification can be a \`dangerous' operation. In a large installation
 it could unleash an avalanche of messaging.
 
-~~~~ {.smallexample}
+~~~~
      
       reports:
      
@@ -32,9 +32,9 @@ to distinguish them from other output; for example from `commands`.
 In CFEngine 2 reporting was performed with `alerts`. In CFEngine3 this
 has been replaced by `reports`.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent report
 {
 reports:
@@ -50,7 +50,7 @@ reports:
 }
 ~~~~
 
-\
+  
 
 -   [friend\_pattern in reports](#friend_005fpattern-in-reports)
 -   [intermittency in reports](#intermittency-in-reports)
@@ -73,10 +73,10 @@ report list
 This regular expression should match hosts we want to exclude from
 friend reports.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
   linux::
@@ -98,8 +98,8 @@ reports:
 **Synopsis**: Real number threshold [0,1] of intermittency about current
 peers, report above
 
-**Example**:\
- \
+**Example**:  
+   
 
 #### `lastseen`
 
@@ -121,12 +121,12 @@ This generates a separate file for each each host that connects to the
 current host. For central hubs this can result is a huge number of
 files.
 
-**Example**:\
- \
+**Example**:  
+   
 
 In control:
 
-~~~~ {.verbatim}
+~~~~
 body agent control
 {
 lastseen => "false";
@@ -135,7 +135,7 @@ lastseen => "false";
 
 See also in reports:
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
   "Comment"
@@ -158,10 +158,10 @@ output
 
 Include part of a file in a report.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body printfile example
      {
@@ -171,7 +171,7 @@ Include part of a file in a report.
      
 ~~~~
 
-\
+  
 
 `number_of_lines`
 
@@ -184,10 +184,10 @@ file
 
 Include the first 'x' number of lines of a file in a report.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body printfile example
      {
@@ -208,10 +208,10 @@ Append the output of the report to the named file instead of standard
 output. If the file cannot be opened for writing then the report
 defaults to the standard output.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 {
 reports:
@@ -234,10 +234,10 @@ reports:
 the caller can accept as a result for this bundle; in other words, a
 return value with array index defined by this attribute.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -277,8 +277,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Return values are limited to scalars.
 
@@ -291,10 +291,10 @@ Return values are limited to scalars.
 **Synopsis**: List of services about which status reports should be
 reported to standard output
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 reports:
   cfengine::
 
@@ -303,222 +303,222 @@ reports:
       showstate => {"www_in", "ssh_out", "otherprocs" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The basic list of services is:
 
 users
 
-Users logged in \
+Users logged in   
 
 rootprocs
 
-Privileged system processes \
+Privileged system processes   
 
 otherprocs
 
-Non-privileged process \
+Non-privileged process   
 
 diskfree
 
-Free disk on / partition \
+Free disk on / partition   
 
 loadavg
 
-% kernel load utilization \
+% kernel load utilization   
 
 netbiosns\_in
 
-netbios name lookups (in) \
+netbios name lookups (in)   
 
 netbiosns\_out
 
-netbios name lookups (out) \
+netbios name lookups (out)   
 
 netbiosdgm\_in
 
-netbios name datagrams (in) \
+netbios name datagrams (in)   
 
 netbiosdgm\_out
 
-netbios name datagrams (out) \
+netbios name datagrams (out)   
 
 netbiosssn\_in
 
-netbios name sessions (in) \
+netbios name sessions (in)   
 
 netbiosssn\_out
 
-netbios name sessions (out) \
+netbios name sessions (out)   
 
 irc\_in
 
-IRC connections (in) \
+IRC connections (in)   
 
 irc\_out
 
-IRC connections (out) \
+IRC connections (out)   
 
 cfengine\_in
 
-CFEngine connections (in) \
+CFEngine connections (in)   
 
 cfengine\_out
 
-CFEngine connections (out) \
+CFEngine connections (out)   
 
 nfsd\_in
 
-nfs connections (in) \
+nfs connections (in)   
 
 nfsd\_out
 
-nfs connections (out) \
+nfs connections (out)   
 
 smtp\_in
 
-smtp connections (in) \
+smtp connections (in)   
 
 smtp\_out
 
-smtp connections (out) \
+smtp connections (out)   
 
 www\_in
 
-www connections (in) \
+www connections (in)   
 
 www\_out
 
-www connections (out) \
+www connections (out)   
 
 ftp\_in
 
-ftp connections (in) \
+ftp connections (in)   
 
 ftp\_out
 
-ftp connections (out) \
+ftp connections (out)   
 
 ssh\_in
 
-ssh connections (in) \
+ssh connections (in)   
 
 ssh\_out
 
-ssh connections (out) \
+ssh connections (out)   
 
 wwws\_in
 
-wwws connections (in) \
+wwws connections (in)   
 
 wwws\_out
 
-wwws connections (out) \
+wwws connections (out)   
 
 icmp\_in
 
-ICMP packets (in) \
+ICMP packets (in)   
 
 icmp\_out
 
-ICMP packets (out) \
+ICMP packets (out)   
 
 udp\_in
 
-UDP dgrams (in) \
+UDP dgrams (in)   
 
 udp\_out
 
-UDP dgrams (out) \
+UDP dgrams (out)   
 
 dns\_in
 
-DNS requests (in) \
+DNS requests (in)   
 
 dns\_out
 
-DNS requests (out) \
+DNS requests (out)   
 
 tcpsyn\_in
 
-TCP sessions (in) \
+TCP sessions (in)   
 
 tcpsyn\_out
 
-TCP sessions (out) \
+TCP sessions (out)   
 
 tcpack\_in
 
-TCP acks (in) \
+TCP acks (in)   
 
 tcpack\_out
 
-TCP acks (out) \
+TCP acks (out)   
 
 tcpfin\_in
 
-TCP finish (in) \
+TCP finish (in)   
 
 tcpfin\_out
 
-TCP finish (out) \
+TCP finish (out)   
 
 tcpmisc\_in
 
-TCP misc (in) \
+TCP misc (in)   
 
 tcpmisc\_out
 
-TCP misc (out) \
+TCP misc (out)   
 
 webaccess
 
-Webserver hits \
+Webserver hits   
 
 weberrors
 
-Webserver errors \
+Webserver errors   
 
 syslog
 
-New log entries (Syslog) \
+New log entries (Syslog)   
 
 messages
 
-New log entries (messages) \
+New log entries (messages)   
 
 temp0
 
-CPU Temperature 0 \
+CPU Temperature 0   
 
 temp1
 
-CPU Temperature 1 \
+CPU Temperature 1   
 
 temp2
 
-CPU Temperature 2 \
+CPU Temperature 2   
 
 temp3
 
-CPU Temperature 3 \
+CPU Temperature 3   
 
 cpu
 
-%CPU utilization (all) \
+%CPU utilization (all)   
 
 cpu0
 
-%CPU utilization 0 \
+%CPU utilization 0   
 
 cpu1
 
-%CPU utilization 1 \
+%CPU utilization 1   
 
 cpu2
 
-%CPU utilization 2 \
+%CPU utilization 2   
 
 cpu3
 

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-vars-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-vars-in-common-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-common,vars-in-common-promises]
 
 ### `vars` promises in \*
 
-\
+  
 
 Variables in CFEngine are defined as promises that an identifier
 represents a particular value. Variables in CFEngine are dynamically
@@ -19,9 +19,9 @@ also possible.
 Arrays are `associative` and use square brackets [] to enclose an
 arbitrary key.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -45,7 +45,7 @@ reports:
 
 ~~~~
 
-\
+  
 
 -   [string in vars](#string-in-vars)
 -   [int in vars](#int-in-vars)
@@ -63,10 +63,10 @@ reports:
 
 **Synopsis**: A scalar string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    string => "Some literal string...";
@@ -74,8 +74,8 @@ vars:
  "yyy"    string => readfile( "/home/mark/tmp/testfile" , "33" );
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In previous versions of CFEngine lists were represented (as in the
 shell) using separated scalars; similar to the PATH variable. In
@@ -89,10 +89,10 @@ CFEngine 3 lists are kept as an independent type.
 
 **Synopsis**: A scalar integer
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "scalar" int    => "16k";
@@ -102,8 +102,8 @@ vars:
  "dim_array" int =>  readstringarray("array_name","/etc/passwd","#[^\n]*",":",10,4000);
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Int variables are strings that are expected to be used as integer
 numbers. The typing in CFEngine is dynamic, so the variable types are
 interchangeable. However, when you declare a variable to be type `int`,
@@ -115,27 +115,27 @@ must only have an integer numeric part (e.g. 1.5M is not allowed).
 
 k
 
-The value multiplied by 1000. \
+The value multiplied by 1000.   
 
 K
 
-The value multiplied by 1024. \
+The value multiplied by 1024.   
 
 m
 
-The value multiplied by 1000 \* 1000. \
+The value multiplied by 1000 \* 1000.   
 
 M
 
-The value multiplied by 1024 \* 1024. \
+The value multiplied by 1024 \* 1024.   
 
 g
 
-The value multiplied by 1000 \* 1000 \* 1000. \
+The value multiplied by 1000 \* 1000 \* 1000.   
 
 G
 
-The value multiplied by 1024 \* 1024 \* 1024. \
+The value multiplied by 1024 \* 1024 \* 1024.   
 
 %
 
@@ -151,17 +151,17 @@ The value inf may also be used to represent an unlimited positive value.
 
 **Synopsis**: A scalar real number
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
    
  "scalar" real   => "0.5";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Real variables are strings that are expected to be used as real
 numbers. The typing in CFEngine is dynamic, so the variable types are
 interchangeable, but when you declare a variable to be type `real`,
@@ -179,10 +179,10 @@ useful for representing probabilities and performance data.
 
 **Synopsis**: A list of scalar strings
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"    slist  => {  "literal1",  "literal2" };
@@ -201,8 +201,8 @@ vars:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Some functions return `slist`s (see [Introduction to
 functions](#Introduction-to-functions)), and an `slist` may contain the
 values copied from another `slist`, `rlist`, or `ilist` (see [List
@@ -218,10 +218,10 @@ vars](#policy-in-vars)).
 
 **Synopsis**: A list of integers
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "variable_id"
@@ -229,8 +229,8 @@ vars:
        ilist => { "10", "11", "12" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Integer lists are lists of strings that are expected to be treated as
 integers. The typing in CFEngine is dynamic, so the variable types are
@@ -253,17 +253,17 @@ vars](#policy-in-vars)).
 
 **Synopsis**: A list of real numbers
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "varid" rlist => { "0.1", "0.2", "0.3" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Real lists are lists of strings that are expected to be used as real
 numbers. The typing in CFEngine is dynamic, so the variable types are
 interchangeable, but when you declare a variable to be type `rlist`,
@@ -281,9 +281,9 @@ vars](#policy-in-vars)).
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                free
                overridable
                constant
@@ -292,18 +292,18 @@ vars](#policy-in-vars)).
 
 **Synopsis**: The policy for (dis)allowing (re)definition of variables
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "varid" string => "value...",
           policy => "constant";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Variables can either be allowed to change their value dynamically (be
 redefined) or they can be constant. The use of private variable spaces
@@ -319,7 +319,7 @@ or undefined lists are dropped. The default behaviour is otherwise to
 retain this value as an indicator of the failure to quench the variable
 reference, for example:
 
-~~~~ {.verbatim}
+~~~~
    
     "one" slist => { "1", "2", "3" };
 
@@ -333,7 +333,7 @@ to @(two) would disappear. This is useful for combining lists,
 \`inheritance-style' where one can extend a base with special cases if
 they are defined.
 
-**Default value**:\
- \
+**Default value**:  
+   
 
 `policy = constant`

--- a/bundles-logs-functions-variables/Bundles-for-knowledge-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge-0.markdown
@@ -10,9 +10,9 @@ tags: [Bundles-for-knowledge]
 Bundles of `knowledge`
 ----------------------
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      bundle knowledge system
      
@@ -32,7 +32,7 @@ Bundles of `knowledge`
      
 ~~~~
 
-\
+  
 
 Knowledge bundles describe topic maps, i.e. Topics, Associations and
 Occurrences (of topics in documents). This is for knowledge modeling and

--- a/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-inferences-in-knowledge-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-inferences-in-knowledge-promises.markdown
@@ -9,11 +9,11 @@ tags: [Bundles-for-knowledge,inferences-in-knowledge-promises]
 
 ### `inferences` promises in knowledge
 
-\
+  
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 inferences:
 
   "is close to" 
@@ -27,7 +27,7 @@ inferences:
          qualifier => { "is close to" };
 ~~~~
 
-\
+  
 
 *History*: Was introduced in version 3.1.0
 
@@ -40,7 +40,7 @@ i.e. the conclusion to be drawn from combining two knowledge assertions.
 The body specifies what existing associations must be in place between
 topics in order to draw the conclusion between the start and the end.
 
-~~~~ {.smallexample}
+~~~~
      
                  precedent                 qualifier
        TOPIC 1 -------------- TOPIC 2 --------------- TOPIC 3
@@ -52,7 +52,7 @@ topics in order to draw the conclusion between the start and the end.
 
 For example,
 
-~~~~ {.smallexample}
+~~~~
      
               is mother to          is married to
        ALICE -------------- BOB ----------------- CAROL
@@ -79,10 +79,10 @@ to match multiple instances.
 
 **Synopsis**: The foundational vector for a trinary inference
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 inferences:
 
   "is far from" 
@@ -91,8 +91,8 @@ inferences:
          qualifier => { "is close to", "is far from" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.0b3,Nova 2.0.0b1 (2010)
 
@@ -107,10 +107,10 @@ so as to make the promise unique.
 
 **Synopsis**: The second vector in a trinary inference
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 inferences:
 
   "is far from" 
@@ -119,8 +119,8 @@ inferences:
          qualifier => { "is close to|is far from" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.0 (2010)
 

--- a/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-occurrences-in-knowledge-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-occurrences-in-knowledge-promises.markdown
@@ -9,14 +9,14 @@ tags: [Bundles-for-knowledge,occurrences-in-knowledge-promises]
 
 ### `occurrences` promises in knowledge
 
-\
+  
 
 Occurrences are documents or information resources that discuss topics.
 An occurrence promise asserts that a particular document of text
 resource in fact represents information about one or more topics. This
 is used to construct references to actual information in a topic map.
 
-~~~~ {.smallexample}
+~~~~
      
       occurrences:
      
@@ -29,9 +29,9 @@ is used to construct references to actual information in a topic map.
      
 ~~~~
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
  Mark_Burgess::
 
      "http://www.iu.hio.no/~mark"
@@ -50,7 +50,7 @@ is used to construct references to actual information in a topic map.
 
 ~~~~
 
-\
+  
 
 Occurrences are pointers to information about topics. This might be a
 literal text string or a URL reference to an external document.
@@ -67,18 +67,18 @@ literal text string or a URL reference to an external document.
 
 **Synopsis**: List of topics that the document or resource addresses
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  "/docs/SpecialTopic_RBAC.html#tag"
 
      represents => { "Text section" }, 
    about_topics => { "defining roles" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -98,10 +98,10 @@ covered by a document.
 **Synopsis**: List of explanations for what relationship this document
 has to the topics it is about
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 occurrences:
 
   Promise_Theory::
@@ -112,8 +112,8 @@ occurrences:
       representation => "literal";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The sub-topic or occurrence-type represented by the document reference
 in a knowledge base. This string is intended as an annotation to the
@@ -128,9 +128,9 @@ reference as a url to be reached when the image is clicked on.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                literal
                url
                db
@@ -143,10 +143,10 @@ reference as a url to be reached when the image is clicked on.
 **Synopsis**: How to interpret the promiser string (e.g. actual data or
 reference to data)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 occurrences:
 
   Promise_Theory::
@@ -158,8 +158,8 @@ occurrences:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a form of knowledge representation in a topic map occurrence
 reference. If the type `portal` is used it assumes that a new website

--- a/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-things-in-knowledge-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-things-in-knowledge-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-knowledge,things-in-knowledge-promises]
 
 ### `things` promises in knowledge
 
-\
+  
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
@@ -24,9 +24,9 @@ much more concretely than we do with abstract topics.
 To make it simpler to talk about things, `things` promises were
 introduced.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 body knowledge TheRealWorld
 {
 things:
@@ -42,7 +42,7 @@ things:
 }
 ~~~~
 
-\
+  
 
 Things promises are in every way equivalent to the more general topics
 promises. Things can be extended as topics. The contexts are
@@ -83,17 +83,17 @@ regular worldly things.
 **Synopsis**: A list of words to be treated as equivalents in the
 defined context
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  mathematics::
 
    "tree" synonyms => { "DAG", "directed acyclic graph" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.3a1,Nova 2.0.2a1 (2010)
 
@@ -109,17 +109,17 @@ searches.
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
    "The Moon"   affects => {  "surf", "tides" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
 #### `belongs_to`
@@ -131,10 +131,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "router-123" 
@@ -143,8 +143,8 @@ things:
         belongs_to => { "company::cfengine" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
@@ -157,10 +157,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle knowledge test
 {
 things:
@@ -171,8 +171,8 @@ things:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2.0, Nova 2.1.0 (2011)
 
@@ -182,9 +182,9 @@ The complement of \`is\_caused\_by' for convenience.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                certain
                uncertain
                possible
@@ -193,10 +193,10 @@ The complement of \`is\_caused\_by' for convenience.
 **Synopsis**: Selects the level of certainty for the proposed knowledge,
 for use in inferential reasoning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle knowledge test
 {
 things:
@@ -209,8 +209,8 @@ things:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1 (2011)
 
@@ -228,18 +228,18 @@ the relationships between things. For example, the certain relationship
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "router one" determines => { "network connectivity" },
                 certainty => "uncertain";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1 (2011)
 
@@ -252,10 +252,10 @@ things:
 **Synopsis**: A list of words to be treated as super-sets for the
 current topic, used when reasoning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  topics:
 
   persons::
@@ -267,8 +267,8 @@ current topic, used when reasoning
      "10.10.10.10/24" generalizations => { "network", "CIDR format" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
@@ -288,18 +288,18 @@ about issues, when searching for diagnostic explanations.
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
    "my promise"  
               implements => { "my goal" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0
 
@@ -312,10 +312,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
    "desired state"
@@ -327,8 +327,8 @@ things:
                   };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -341,10 +341,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle knowledge test
 {
 things:
@@ -355,8 +355,8 @@ things:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2.0, Nova 2.1.0 (2011)
 
@@ -371,10 +371,10 @@ The complement of \`causes' for convenience of expression.
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
  networks::
@@ -390,8 +390,8 @@ things:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1.0 (2011)
 
@@ -404,17 +404,17 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "why" is_determined_by => { "bodyparts::comment", "Semantic commentary" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -429,10 +429,10 @@ This is the inverse of `determines`.
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "Installing CFEngine"
@@ -440,8 +440,8 @@ things:
     is_followed_by => { "bootstrapping", "policy editing" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -454,18 +454,18 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
    "my goal"  
               is_implemented_by => { "my promise" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0
 
@@ -478,10 +478,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
  countries::
@@ -493,8 +493,8 @@ things:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
@@ -507,10 +507,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
  service_measurements::
@@ -518,8 +518,8 @@ things:
   "login services" is_measured_by => { "ssh_in" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.4.0, Enterprise 3.0
 
 #### `is_part_of`
@@ -531,17 +531,17 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "host 1" is_part_of => { "123.456.789.0/24" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1 (2011)
 
@@ -554,10 +554,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "disk failure"
@@ -566,8 +566,8 @@ things:
          certainty => "possible";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -580,10 +580,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
  service_measurements::
@@ -592,8 +592,8 @@ things:
                measures => { "ssh" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0, Enterprise 3.0
 
@@ -606,10 +606,10 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "rack 123"     needs => { "power", "cooling" };
@@ -618,8 +618,8 @@ things:
              certainty => "possible";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1 (2011)
 
@@ -632,17 +632,17 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
    "host 23" provides => { "www", "email" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 
@@ -655,16 +655,16 @@ things:
 **Synopsis**: Special fixed relation for describing topics that are
 things
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 things:
 
   "apache 2.3" uses => { "mysql 4.5" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)

--- a/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-topics-in-knowledge-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge/Bundles-for-knowledge-0-topics-in-knowledge-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-knowledge,topics-in-knowledge-promises]
 
 ### `topics` promises in knowledge
 
-\
+  
 
 Topic promises are part of the knowledge management engine. A topic is
 any string that refers to a concept or subject that we wish to include
@@ -17,7 +17,7 @@ in a knowledge base. If a topic has a very long name, it is best to made
 the promiser object a short name and use the `comment` field to add the
 long explanation (e.g. unique acronym and full text).
 
-~~~~ {.smallexample}
+~~~~
      
       topics:
      
@@ -40,9 +40,9 @@ uses it as a type-label. This is used for disambiguation of subject-area
 in searches rather than for disambiguation of rules between physical
 environments.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle knowledge example
 {
 topics:
@@ -53,7 +53,7 @@ topics:
 }
 ~~~~
 
-\
+  
 
 Topics are basically identifiers, where the comment field here is a long
 form of the subject string. Associations form semantic links between
@@ -77,10 +77,10 @@ associations.
 **Synopsis**: Name of forward association between promiser topic and
 associates
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body association example
      {
@@ -89,9 +89,9 @@ associates
      
 ~~~~
 
-**Notes**:\
- \
- \
+**Notes**:  
+   
+   
 
 `backward_relationship`
 
@@ -102,10 +102,10 @@ associates
 **Synopsis**: Name of backward/inverse association from associates to
 promiser topic
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      body association example
      {
      # ..
@@ -114,11 +114,11 @@ promiser topic
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Denotes the inverse name which is used for \`moralizing' the association
-graph. \
+graph.   
 
 `associates`
 
@@ -128,10 +128,10 @@ graph. \
 
 **Synopsis**: List of associated topics by this forward relationship
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body association example(literal,scalar,list)
      
@@ -142,8 +142,8 @@ graph. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 An element of an association that is a list of topics to which the
 current topic is associated.
@@ -157,17 +157,17 @@ current topic is associated.
 **Synopsis**: A list of words to be treated as equivalents in the
 defined context
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  mathematics::
 
    "tree" synonyms => { "DAG", "directed acyclic graph" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.3a1,Nova 2.0.2a1 (2010)
 
@@ -183,10 +183,10 @@ searches.
 **Synopsis**: A list of words to be treated as super-sets for the
 current topic, used when reasoning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  topics:
 
   persons::
@@ -198,8 +198,8 @@ current topic, used when reasoning
      "10.10.10.10/24" generalizations => { "network", "CIDR format" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.2, Nova 2.1 (2011)
 

--- a/bundles-logs-functions-variables/Bundles-for-monitor-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-monitor-0.markdown
@@ -10,9 +10,9 @@ tags: [Bundles-for-monitor]
 Bundles of `monitor`
 --------------------
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      bundle monitor example
      {
@@ -37,7 +37,7 @@ Bundles of `monitor`
 Monitor bundles contain user defined promises for system discovery and
 monitoring.
 
-\
+  
 
 -   [classes in common promises](#classes-in-common-promises):
 -   [defaults in common promises](#defaults-in-common-promises):

--- a/bundles-logs-functions-variables/Bundles-for-monitor/Bundles-for-monitor-0-measurements-in-monitor-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-monitor/Bundles-for-monitor-0-measurements-in-monitor-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-monitor,measurements-in-monitor-promises]
 
 ### `measurements` promises in monitor
 
-\
+  
 
 *These features are available only in Enterprise versions of CFEngine.*
 
@@ -31,7 +31,7 @@ destined for the agent concerned (however, you do not need to add them
 to the `bundlesequence` they are executed by `cf-monitord` because they
 are bundles of type `monitor`). In this case:
 
-~~~~ {.verbatim}
+~~~~
 bundle monitor watch
 
 {
@@ -50,9 +50,9 @@ in a special variable context called mon, analogous to the system
 variables in sys. Thus the values may be used in other promises in the
 form `$(mon.handle)`.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
   # Follow a special process over time
   # using CFEngine's process cache to avoid resampling
 
@@ -97,7 +97,7 @@ extraction_regex => "(.*)";
 
 ~~~~
 
-\
+  
 
 **Notes:**
 
@@ -185,24 +185,24 @@ into agent variables in the `$(mon.`name`)` context.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                pipe
                file
 ~~~~
 
 **Synopsis**: The datatype being collected.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 stream_type => "pipe";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 CFEngine treats all input using a stream abstraction. The preferred
 interface is files, since they can be read without incurring the cost of
@@ -212,9 +212,9 @@ a process. However pipes from executed commands may also be invoked.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                counter
                int
                real
@@ -224,10 +224,10 @@ a process. However pipes from executed commands may also be invoked.
 
 **Synopsis**: The datatype being collected.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
   "/bin/df"
 
       handle => "free_disk_watch",
@@ -242,8 +242,8 @@ a process. However pipes from executed commands may also be invoked.
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 When CFEngine (Nova) observes data, such as the attached partitions in
 the example above, the datatype determines how that data will be
@@ -258,9 +258,9 @@ be selected.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                weekly
                scalar
                static
@@ -270,10 +270,10 @@ be selected.
 **Synopsis**: Whether the data can be seen as a time-series or just an
 isolated value
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  "/proc/meminfo"
 
       handle => "free_memory_watch",
@@ -284,23 +284,23 @@ isolated value
       match_value => free_memory;
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 scalar
 
 A single value, with compressed statistics is retained. The value of the
 data is not expected to change much for the lifetime of the daemon (and
-so will be sampled less often by cf-monitord). \
+so will be sampled less often by cf-monitord).   
 
 static
 
-A synonym for \`scalar'. \
+A synonym for \`scalar'.   
 
 log
 
 The measured value is logged as an infinite time-series in
-\$(sys.workdir)/state. \
+\$(sys.workdir)/state.   
 
 weekly
 
@@ -316,10 +316,10 @@ is retained.
 **Synopsis**: The engineering dimensions of this value or a note about
 its intent used in plots
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
    "/var/cfengine/state/cf_rootprocs"
 
       handle => "monitor_self_watch",
@@ -332,8 +332,8 @@ its intent used in plots
          "root\s+[0-9.]+\s+[0-9.]+\s+[0-9.]+\s+[0-9.]+\s+([0-9]+).*");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is an arbitary string used in documentation only.
 
@@ -349,10 +349,10 @@ This is an arbitary string used in documentation only.
 
 **Synopsis**: Regular expression for matching line location
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      # Editing
      
@@ -370,14 +370,14 @@ This is an arbitary string used in documentation only.
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The expression is anchored, meaning it must match a whole line, and not
 a fragment within a line (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 
-This attribute is mutually exclusive of `select_line_number`. \
+This attribute is mutually exclusive of `select_line_number`.   
 
 `select_line_number`
 
@@ -387,10 +387,10 @@ This attribute is mutually exclusive of `select_line_number`. \
 
 **Synopsis**: Read from the n-th line of the output (fixed format)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body match_value find_line
      {
@@ -399,10 +399,10 @@ This attribute is mutually exclusive of `select_line_number`. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-This is mutually exclusive of `select_line_matching`. \
+This is mutually exclusive of `select_line_matching`.   
 
 `extraction_regex`
 
@@ -413,10 +413,10 @@ This is mutually exclusive of `select_line_matching`. \
 **Synopsis**: Regular expression that should contain a single
 backreference for extracting a value
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body match_value free_memory
      {
@@ -426,22 +426,22 @@ backreference for extracting a value
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 A single parenthesized backreference should be given to lift the value
 to be measured out of the text stream. The regular expression is
 unanchored, meaning it may match a partial string (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 `track_growing_file`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     true
                     false
                     yes
@@ -454,10 +454,10 @@ expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
 read when opening the file, and resets to the start if the file has
 since been truncated
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      bundle monitor watch
      {
      measurements:
@@ -490,8 +490,8 @@ since been truncated
      }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This option applies only to file based input streams. If this is true,
 CFEngine treats the file as if it were a log file, growing continuously.
@@ -500,15 +500,15 @@ each invocation. In this way, the monitor does not count lines in the
 log file redundantly.
 
 This makes a log pattern promise equivalent to something like tail -f
-logfile | grep pattern in Unix parlance. \
+logfile | grep pattern in Unix parlance.   
 
 `select_multiline_policy`
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                     average
                     sum
                     first
@@ -517,10 +517,10 @@ logfile | grep pattern in Unix parlance. \
 
 **Synopsis**: Regular expression for matching line location
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
      
      body match_value myvalue(xxx)
      {
@@ -531,8 +531,8 @@ logfile | grep pattern in Unix parlance. \
      
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.4.0 (2012)
 

--- a/bundles-logs-functions-variables/Bundles-for-server-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server-0.markdown
@@ -10,9 +10,9 @@ tags: [Bundles-for-server]
 Bundles of `server`
 -------------------
 
-\
+  
 
-~~~~ {.smallexample}
+~~~~
      
      bundle server access_rules()
      
@@ -35,7 +35,7 @@ Bundles of `server`
      
 ~~~~
 
-\
+  
 
 Bundles in the server describe access promises on specific file and
 class objects supplied by the server to clients.

--- a/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-access-in-server-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-access-in-server-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-server,access-in-server-promises]
 
 ### `access` promises in server
 
-\
+  
 
 Access promises are conditional promises made by the server about file
 objects. The promise has two consequences. For file copy requests, the
@@ -30,7 +30,7 @@ first-come-first-served basis. Thus file objects (promisers) should be
 listed in order of most-specific file first. In this way, specific
 promises will override less specific ones.
 
-~~~~ {.smallexample}
+~~~~
      
       access:
      
@@ -41,11 +41,11 @@ promises will override less specific ones.
      
 ~~~~
 
-\
+  
 
 Example:
 
-~~~~ {.verbatim}
+~~~~
 #########################################################
 # Server config
 #########################################################
@@ -110,7 +110,7 @@ access:
 }
 ~~~~
 
-\
+  
 
 Entries may be literal addresses of IPv4 or IPv6, or any name registered
 in the POSIX `gethostbyname` service.
@@ -130,10 +130,10 @@ in the POSIX `gethostbyname` service.
 **Synopsis**: List of host names or IP addresses to grant access to file
 objects
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 access:
 
   "/home/mark/LapTop"
@@ -141,8 +141,8 @@ access:
     admit   => { "127.0.0.1", "192.168.0.1/24", ".*\.domain\.tld"  };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Admit promises grant access to file objects on the server. Arguments may
 be IP addresses or hostnames, provided DNS name resolution is active. In
@@ -161,10 +161,10 @@ expressions to match the IP address or name of the connecting host.
 **Synopsis**: List of host names or IP addresses to deny access to file
 objects
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle server access_rules()
 
 {
@@ -177,8 +177,8 @@ access:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Denial is for special exceptions. A better strategy is always to grant
 on a need to know basis. A security policy based on exceptions is a weak
@@ -196,10 +196,10 @@ list, as non-specific matches are too greedy for denial.
 **Synopsis**: List of host names or IP addresses to grant full
 read-privilege on the server
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 access:
 
  "/home"
@@ -212,8 +212,8 @@ access:
      maproot => { "backup_host.example.org" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Normally users authenticated by the server are granted access only to
 files owned by them and no-one else. Even if the `cf-serverd` process
@@ -230,9 +230,9 @@ files if the connecting user does not own the file on the server.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                true
                false
                yes
@@ -246,10 +246,10 @@ files if the connecting user does not own the file on the server.
 **Synopsis**: true/false whether the current file access promise is
 conditional on the connection from the client being encrypted
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 access:
 
    "/path/file"
@@ -258,8 +258,8 @@ access:
     ifencrypted => "true";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If this flag is true a client cannot access the file object unless its
 connection is encrypted.
@@ -268,9 +268,9 @@ connection is encrypted.
 
 **Type**: (menu option)
 
-**Allowed input range**: \
+**Allowed input range**:   
 
-~~~~ {.example}
+~~~~
                path
                literal
                context
@@ -281,10 +281,10 @@ connection is encrypted.
 **Synopsis**: The type of object being granted access (the default
 grants access to files)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 bundle server access_rules()
 
@@ -325,8 +325,8 @@ access:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 By default, access to resources granted by the server are files.
 However, sometimes it is useful to cache `literal` strings, hints and
@@ -351,7 +351,7 @@ host (which for some reason is not available directly through policy on
 the client, e.g. because they have different policies), then you could
 use the following construction:
 
-~~~~ {.verbatim}
+~~~~
 access:
 
   "$(variable_name)"

--- a/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-roles-in-server-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-roles-in-server-promises.markdown
@@ -9,7 +9,7 @@ tags: [Bundles-for-server,roles-in-server-promises]
 
 ### `roles` promises in server
 
-\
+  
 
 Roles promises are server-side decisions about which users are allowed
 to define soft-classes on the server's system during remote invocation
@@ -20,7 +20,7 @@ regular expression is anchored, meaning it must match the entire name
 (see [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 
-~~~~ {.smallexample}
+~~~~
      
       roles:
      
@@ -35,9 +35,9 @@ or modify promise definitions by remote access. At best users may try to
 send classes when using*`cf-runagent`*in order to activate sleeping
 promises. This mechanism limits their ability to do this*.
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 bundle server access_rules()
 
 {
@@ -49,7 +49,7 @@ roles:
 }
 ~~~~
 
-\
+  
 
 In this example user mark is granted permission to remotely activate
 classes matching the regular expression when Mark\_.\* using the
@@ -68,17 +68,17 @@ privileged access on the host directly.
 **Synopsis**: List of public-key user names that are allowed to activate
 the promised class during remote agent activation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 roles:
 
   ".*"  authorize => { "mark", "marks_friend" };
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Part of Role Based Access Control (RBAC) in CFEngine. The users listed
 in this section are granted access to set certain classes by using the

--- a/bundles-logs-functions-variables/Logs-and-records-0.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records-0.markdown
@@ -10,7 +10,7 @@ tags: [Logs-and-records]
 Logs and records
 ----------------
 
-\
+  
 
 CFEngine writes numerous logs and records to its private workspace,
 referred to as WORKDIR. This chapter makes some brief notes about these

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Embedded-Databases.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Embedded-Databases.markdown
@@ -23,22 +23,22 @@ cf\_Audit.tcdb
 A compressed database of auditing information. This file grows very
 large is auditing is switched on. By default, only minor information
 about CFEngine runs are recorded. This file should be archived and
-deleted regularly to avoid choking the system. \
+deleted regularly to avoid choking the system.   
 
 cf\_lastseen.tcdb
 
 A database of hosts that last contacted this host, or were contacted by
-this host, and includes the times at which they were last observed. \
+this host, and includes the times at which they were last observed.   
 
 cf\_classes.tcdb
 
 A database of classes that have been defined on the current host,
-including their relative frequencies, scaled like a probability. \
+including their relative frequencies, scaled like a probability.   
 
 checksum\_digests.tcdb
 
 The database of hash values used in CFEngine's change management
-functions. \
+functions.   
 
 performance.tcdb
 
@@ -46,42 +46,42 @@ A database of last, average and deviation times of jobs recorded by
 `cf-agent`. Most promises take an immeasurably short time to check, but
 longer tasks such as command execution and file copying are measured by
 default. Other checks can be instrumented by setting a
-`measurement_class` in the `action` body of a promise. \
+`measurement_class` in the `action` body of a promise.   
 
 stats.tcdb
 
 A database of external file attributes for change management
-functionality. \
+functionality.   
 
 state/cf\_lock.tcdb
 
 A database of active and inactive locks and their expiry times. Deleting
-this database will reset all lock protections in CFEngine. \
+this database will reset all lock protections in CFEngine.   
 
 state/history.tcdb
 
 Enterprise level versions of CFEngine maintain this long-term trend
-database. \
+database.   
 
 state/cf\_observations.tcdb
 
 This database contains the current state of the observational history of
-the host as recorded by `cf-monitord`. \
+the host as recorded by `cf-monitord`.   
 
 state/promise\_compliance.tcdb
 
 Enterprise CFEngine (Nova and above) database of individual promise
 compliance history. The database is approximate because promise
 references can change as policy is edited. It quickly approaches
-accuracy as a policy goes unchanged for more than a day. \
+accuracy as a policy goes unchanged for more than a day.   
 
 state/cf\_state.tcdb
 
-A database of persistent classes active on this current host. \
+A database of persistent classes active on this current host.   
 
 state/nova\_measures.tcdb
 
-Enterprise CFEngine (Nova and above) database of custom measurables. \
+Enterprise CFEngine (Nova and above) database of custom measurables.   
 
 state/nova\_static.tcdb
 

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-State-information.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-State-information.markdown
@@ -12,7 +12,7 @@ tags: [Logs-and-records,State-information]
 The CFEngine components keep their current process identifier number in
 \`pid files' in the work directory. For example:
 
-~~~~ {.verbatim}
+~~~~
 cf-execd.pid
 cf-serverd.pid
 ~~~~
@@ -24,12 +24,12 @@ state/env\_data
 
 This file contains a list of currently discovered classes and variable
 values that characterize the anomaly alert environment. They are altered
-by the monitor daemon. \
+by the monitor daemon.   
 
 state/all\_classes
 
 A list of all the classes that were defined the last time that CFEngine
-was run. \
+was run.   
 
 state/cf\_\*
 

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Text-logs.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Text-logs.markdown
@@ -12,54 +12,54 @@ tags: [Logs-and-records,Text-logs]
 promise\_summary.log
 
 A time-stamped log of the percentage fraction of promises kept after
-each run. \
+each run.   
 
 cf3.HOSTNAME.runlog
 
 A time-stamped log of when each lock was released. This shows the last
-time each individual promise was verified. \
+time each individual promise was verified.   
 
 cfagent.HOSTNAME.log
 
 Although ambiguously named (for historical reasons) this log contains
 the current list of setuid/setgid programs observed on the system.
 CFEngine warns about new additions to this list. This log has been
-deprecated. \
+deprecated.   
 
 cf\_value.log
 
 A time stamped log of the business value estimated from the execution of
-the automation system. \
+the automation system.   
 
 cf\_notkept.log
 
 A list of promises, with handles and comments, that were not kept. Nova
-enterprise versions only. \
+enterprise versions only.   
 
 cf\_repaired.log
 
 A list of promises, with handles and comments, that were repaired. Nova
-enterprise versions only. \
+enterprise versions only.   
 
 reports/\*
 
 Enterprise versions of CFEngine use this directory as a default place
-for outputting reports. \
+for outputting reports.   
 
 reports/class\_notes
 
-Class data in csv format for export to CMDB. \
+Class data in csv format for export to CMDB.   
 
 state/file\_change.log
 
 A time-stamped log of which files have experienced content changes since
 the last observation, as determined by the hashing algorithms in
-CFEngine. \
+CFEngine.   
 
 state/vars.out
 
 Enterprise level versions of CFEngine use this log to communicate
-variable data. \
+variable data.   
 
 state/\*\_measure.log
 

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-const.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-const.markdown
@@ -9,7 +9,7 @@ tags: [Special-Variables,Variable-context-const]
 
 ### Variable context `const`
 
-\
+  
 
 CFEngine defines a number of variables for embedding unprintable values
 or values with special meanings in strings.
@@ -22,9 +22,9 @@ or values with special meanings in strings.
 
 #### Variable const.dollar
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
   some::
@@ -38,9 +38,9 @@ reports:
 
 #### Variable const.endl
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  cfengine_3::
@@ -51,9 +51,9 @@ reports:
 
 #### Variable const.n
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  cfengine_3::
@@ -64,9 +64,9 @@ reports:
 
 #### Variable const.r
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  cfengine_3::
@@ -76,9 +76,9 @@ reports:
 
 #### Variable const.t
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  cfengine_3::

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-edit.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-edit.markdown
@@ -9,13 +9,13 @@ tags: [Special-Variables,Variable-context-edit]
 
 ### Variable context `edit`
 
-\
+  
 
 This context edit is used to access information about editing promises
 during their execution. It is context dependent and not universally
 meaningful or available. For example:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 {
 files:
@@ -48,7 +48,7 @@ could be different from the files promiser.
 
 #### Variable edit.filename
 
-\
+  
 
 This variable points to the filename of the file currently making an
 edit promise. If the file has been arrived at through a search, this

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-match.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-match.markdown
@@ -9,7 +9,7 @@ tags: [Special-Variables,Variable-context-match]
 
 ### Variable context `match`
 
-\
+  
 
 Each time CFEngine matches a string, these values are assigned to a
 special variable context `$(match.`n`)`. The fragments can be referred
@@ -19,7 +19,7 @@ other is in searching for files.
 
 Consider the examples below:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 
 {
@@ -44,7 +44,7 @@ files:
 
 #### Variable match.0
 
-\
+  
 
 A string matching the complete regular expression whether or not
 back-references were used in the pattern.

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-mon.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-mon.markdown
@@ -9,7 +9,7 @@ tags: [Special-Variables,Variable-context-mon]
 
 ### Variable context `mon`
 
-\
+  
 
 The variables discovered by `cf-monitord` are placed in this monitoring
 context. Monitoring variables are expected to be ephemeral properties,

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-sys.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-sys.markdown
@@ -9,13 +9,13 @@ tags: [Special-Variables,Variable-context-sys]
 
 ### Variable context `sys`
 
-\
+  
 
 System variables are derived from CFEngine's automated discovery of
 system values. They are provided as variables in order to make
 automatically adaptive rules for configuration. For example:
 
-~~~~ {.verbatim}
+~~~~
 files:
 
  any::
@@ -86,32 +86,32 @@ itself is class-specific.
 
 #### Variable sys.arch
 
-\
+  
 
 The variable gives the kernel's short architecture description.
 
-~~~~ {.verbatim}
+~~~~
 # arch = x86_64
 ~~~~
 
 #### Variable sys.cdate
 
-\
+  
 
 The date of the system in canonical form, i.e. in the form of a class.
 
-~~~~ {.verbatim}
+~~~~
 # cdate = Sun_Dec__7_10_39_53_2008_
 ~~~~
 
 #### Variable sys.cf\_promises
 
-\
+  
 
 A variable containing the path to the CFEngine syntax analyxer
 `cf-promises` on the platform you are using.
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "syntax_ok" expression => returnszero("$(sys.cf_promises)");
@@ -119,29 +119,29 @@ classes:
 
 #### Variable sys.cf\_version
 
-\
+  
 
 The variable gives the version of the running CFEngine Community
 Edition.
 
-~~~~ {.verbatim}
+~~~~
 # cf_version = 3.0.5 
 ~~~~
 
 #### Variable sys.class
 
-\
+  
 
 This variable contains the name of the hard-class category for this host
 (i.e. its top level operating system type classification).
 
-~~~~ {.verbatim}
+~~~~
 # class = linux
 ~~~~
 
 #### Variable sys.cpus
 
-\
+  
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
 
@@ -151,7 +151,7 @@ physical, cores. In addition, on a single-core system the class "1\_cpu"
 is set, and on multi-core systems the class "*n*\_cpus" is set, where
 "*n*" is the number of cores identified.
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  cfengine_3::
@@ -164,28 +164,28 @@ reports:
 
 #### Variable sys.crontab
 
-\
+  
 
 The variable gives the location of the current users's master crontab
 directory.
 
-~~~~ {.verbatim}
+~~~~
 # crontab = /var/spool/crontas/root 
 ~~~~
 
 #### Variable sys.date
 
-\
+  
 
 The date of the system as a text string.
 
-~~~~ {.verbatim}
+~~~~
 # date = Sun Dec  7 10:39:53 2008
 ~~~~
 
 #### Variable sys.doc\_root
 
-\
+  
 
 *History*: Was introduced in 3.1.0, Nova 2.0.
 
@@ -194,36 +194,36 @@ the standard web server package.
 
 #### Variable sys.domain
 
-\
+  
 
 The domain name as divined by CFEngine. If the DNS is in use, it could
 be possible to derive the domain name from its DNS regisration, but in
 general there is no way to discover this value automatically. The
 `common control` body permits the ultimate specification of this value.
 
-~~~~ {.verbatim}
+~~~~
 # domain = example.org
  
 ~~~~
 
 #### Variable sys.enterprise\_version
 
-\
+  
 
 *History*: Was introduced in 3.5.0, Enterprise 3.0.0
 
 The variable gives the version of the running CFEngine Enterprise
 Edition.
 
-~~~~ {.verbatim}
+~~~~
 # enterprise_version = 3.0.0
 ~~~~
 
 #### Variable sys.expires
 
-\
+  
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  nova::
@@ -233,18 +233,18 @@ reports:
 
 #### Variable sys.exports
 
-\
+  
 
 The location of the system NFS exports file.
 
-~~~~ {.verbatim}
+~~~~
 # exports = /etc/exports
 # exports = /etc/dfs/dfstab
 ~~~~
 
 #### Variable sys.flavor
 
-\
+  
 
 *History*: Was introduced in 3.2.0, Nova 2.0
 
@@ -258,7 +258,7 @@ This is a synonym for `$(sys.flavour)`.
 
 #### Variable sys.flavour
 
-\
+  
 
 *History*: Was introduced in 3.2.0, Nova 2.0
 
@@ -272,28 +272,28 @@ This is a synonym for `$(sys.flavor)`.
 
 #### Variable sys.fqhost
 
-\
+  
 
 The fully qualified name of the host. In order to compute this value
 properly, the domain name must be defined.
 
-~~~~ {.verbatim}
+~~~~
 # fqhost = host.example.org
 ~~~~
 
 #### Variable sys.fstab
 
-\
+  
 
 The location of the system filesystem (mount) table.
 
-~~~~ {.verbatim}
+~~~~
 # fstab = /etc/fstab
 ~~~~
 
 #### Variable sys.hardware\_addresses
 
-\
+  
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
@@ -302,13 +302,13 @@ system interfaces.
 
 #### Variable sys.hardware\_mac[interface\_name]
 
-\
+  
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
 This contains the MAC address of the named interface. For example:
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
   linux::
@@ -318,28 +318,28 @@ reports:
 
 #### Variable sys.host
 
-\
+  
 
 The name of the current host, according to the kernel. It is undefined
 whether this is qualified or unqualified with a domain name.
 
-~~~~ {.verbatim}
+~~~~
 # host = myhost
 ~~~~
 
 #### Variable sys.interface
 
-\
+  
 
 The assumed (default) name of the main system interface on this host.
 
-~~~~ {.verbatim}
+~~~~
 # interface = eth0
 ~~~~
 
 #### Variable sys.interfaces
 
-\
+  
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
@@ -350,7 +350,7 @@ variables report to a Mission Portal in commercial editions of CFEngine.
 To use this list in a policy, you will need a local copy since only
 local variables can be iterated.
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 {
 vars:
@@ -373,7 +373,7 @@ reports:
 
 #### Variable sys.ip\_addresses
 
-\
+  
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
@@ -384,7 +384,7 @@ Mission Portal in commercial editions of CFEngine.
 To use this list in a policy, you will need a local copy since only
 local variables can be iterated.
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 {
 vars:
@@ -407,11 +407,11 @@ reports:
 
 #### Variable sys.ipv4
 
-\
+  
 
 All four octets of the IPv4 address of the first system interface.
 
-**Note**:\
+**Note**:  
 
 If your system has a single ethernet interface, \$(sys.ipv4) will
 contain your IPv4 address. However, if your system has multiple
@@ -423,12 +423,12 @@ system.
 
 #### Variable sys.ipv4[interface\_name]
 
-\
+  
 
 The full IPv4 address of the system interface named as the associative
 array index, e.g. \$(ipv4[le0]) or \$(ipv4[xr1]).
 
-~~~~ {.verbatim}
+~~~~
 # If the IPv4 address on the interfaces are
 #        le0 = 192.168.1.101
 #    xr1 = 10.12.7.254
@@ -444,7 +444,7 @@ array index, e.g. \$(ipv4[le0]) or \$(ipv4[xr1]).
 #   ipv4[xr1] = 10.12.7.254
 ~~~~
 
-**Note**:\
+**Note**:  
 
 The list of interfaces may be acquired with getindices("sys.ipv4") (or
 from any of the other associative arrays). Only those interfaces which
@@ -452,7 +452,7 @@ are marked as "up" and have an IP address will be listed.
 
 #### Variable sys.ipv4\_1[interface\_name]
 
-\
+  
 
 The first octet of the IPv4 address of the system interface named as the
 associative array index, e.g. \$(ipv4\_1[le0]) or \$(ipv4\_1[xr1]) (See
@@ -461,7 +461,7 @@ sys.ipv4[interface\_name]](#Variable-sys_002eipv4_005binterface_005fname_005d)).
 
 #### Variable sys.ipv4\_2[interface\_name]
 
-\
+  
 
 The first two octets of the IPv4 address of the system interface named
 as the associative array index, e.g. \$(ipv4\_2[le0]) or
@@ -470,7 +470,7 @@ sys.ipv4[interface\_name]](#Variable-sys_002eipv4_005binterface_005fname_005d)).
 
 #### Variable sys.ipv4\_3[interface\_name]
 
-\
+  
 
 The first three octets of the IPv4 address of the system interface named
 as the associative array index, e.g. \$(ipv4\_3[le0]) or
@@ -479,11 +479,11 @@ sys.ipv4[interface\_name]](#Variable-sys_002eipv4_005binterface_005fname_005d)).
 
 #### Variable sys.license\_owner
 
-\
+  
 
 *History*: Was introduced in version 3.1.4,Nova 2.0.2 (2011)
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  nova::
@@ -493,11 +493,11 @@ reports:
 
 #### Variable sys.licenses\_granted
 
-\
+  
 
 *History*: Was introduced in version 3.1.4,Nova 2.0.2 (2011)
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  nova::
@@ -507,58 +507,58 @@ reports:
 
 #### Variable sys.long\_arch
 
-\
+  
 
 The long architecture name for this system kernel. This name is
 sometimes quite unwieldy but can be useful for logging purposes.
 
-~~~~ {.verbatim}
+~~~~
 # long_arch = linux_x86_64_2_6_22_19_0_1_default__1_SMP_2008_10_14_22_17_43__0200
 ~~~~
 
 #### Variable sys.maildir
 
-\
+  
 
 The name of the system email spool directory.
 
-~~~~ {.verbatim}
+~~~~
 # maildir = /var/spool/mail
 ~~~~
 
 #### Variable sys.nova\_version
 
-\
+  
 
 The variable gives the version of the running CFEngine Nova Edition.
 
-~~~~ {.verbatim}
+~~~~
 # nova_version = 1.1.3
 ~~~~
 
 #### Variable sys.os
 
-\
+  
 
 The name of the operating system according to the kernel.
 
-~~~~ {.verbatim}
+~~~~
 # os = linux
 ~~~~
 
 #### Variable sys.ostype
 
-\
+  
 
 Another name for the operating system.
 
-~~~~ {.verbatim}
+~~~~
 # ostype = linux_x86_64
 ~~~~
 
 #### Variable sys.policy\_hub
 
-\
+  
  Hostname of the machine acting as a policy hub. This value is set
 during bootstrap. In case bootstrap was not performed, it is set to
 undefined.
@@ -566,7 +566,7 @@ undefined.
 **History**: Was introduced in version 3.1.0b1,Nova 2.0.0b1 (2010).
 Available in Community since 3.2.0
 
-~~~~ {.verbatim}
+~~~~
 reports:
 
  "Policy hub is $(sys.policy_hub)";
@@ -574,42 +574,42 @@ reports:
 
 #### Variable sys.release
 
-\
+  
 
 The kernel release of the operating system.
 
-~~~~ {.verbatim}
+~~~~
 # release = 2.6.22.19-0.1-default
 ~~~~
 
 #### Variable sys.resolv
 
-\
+  
 
 The location of the system resolver file.
 
-~~~~ {.verbatim}
+~~~~
 # resolv = /etc/resolv.conf
 ~~~~
 
 #### Variable sys.uqhost
 
-\
+  
 
 The unqualified name of the current host. See also `sys.fqhost`.
 
-~~~~ {.verbatim}
+~~~~
 # uqhost = myhost
 ~~~~
 
 #### Variable sys.version
 
-\
+  
 
 The version of the running kernel. On Linux, this corresponds to the
 ouput of `uname -v`.
 
-~~~~ {.verbatim}
+~~~~
 # version = #55-Ubuntu SMP Mon Jan 10 23:42:43 UTC 2011
 ~~~~
 
@@ -617,68 +617,68 @@ ouput of `uname -v`.
 
 #### Variable sys.windir
 
-\
+  
 
 On the Windows version of CFEngine Nova, this is the path to the Windows
 directory of this system.
 
-~~~~ {.verbatim}
+~~~~
 # windir = C:\WINDOWS
 ~~~~
 
 #### Variable sys.winprogdir
 
-\
+  
 
 On the Windows version of CFEngine Nova, this is the path to the program
 files directory of the system.
 
-~~~~ {.verbatim}
+~~~~
 # winprogdir = C:\Program Files
 ~~~~
 
 #### Variable sys.winprogdir86
 
-\
+  
 
 On 64 bit Windows versions of CFEngine Nova, this is the path to the 32
 bit (x86) program files directory of the system.
 
-~~~~ {.verbatim}
+~~~~
 # winprogdir86 = C:\Program Files (x86)
 ~~~~
 
 #### Variable sys.winsysdir
 
-\
+  
 
 On the Windows version of CFEngine Nova, this is the path to the Windows
 system directory.
 
-~~~~ {.verbatim}
+~~~~
 # winsysdir = C:\WINDOWS\system32
 ~~~~
 
 #### Variable sys.workdir
 
-\
+  
 
 The location of the CFEngine work directory and cache. For the system
 privileged user this is normally:
 
-~~~~ {.verbatim}
+~~~~
 # workdir = /var/cfengine
 ~~~~
 
 For non-privileged users it is in the user's home directory:
 
-~~~~ {.verbatim}
+~~~~
 # workdir = /home/user/.cfagent
 ~~~~
 
 On the Windows version of CFEngine Nova, it is normally under program
 files (the directory name may change with the language of Windows):
 
-~~~~ {.verbatim}
+~~~~
 # workdir = C:\Program Files\CFEngine
 ~~~~

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-this.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-this.markdown
@@ -9,7 +9,7 @@ tags: [Special-Variables,Variable-context-this]
 
 ### Variable context `this`
 
-\
+  
 
 This context this is used to access information about promises during
 their execution. It is context dependent and not universally meaningful
@@ -17,7 +17,7 @@ or available, but provides a context for variables where one is needed
 (such as when passing the value of a list variable into a parameterized
 `edit_line` promise from a `file` promise). For example:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent resolver(s,n)
 { 
 files:
@@ -74,7 +74,7 @@ pattern matching or `depth_search` that implicitly match multiple
 objects. In that case, `$(this.promiser)` refers to the currently
 identified file that makes the promise. For example:
 
-~~~~ {.verbatim}
+~~~~
 bundle agent find666
 {
 files:
@@ -100,7 +100,7 @@ body file_select world_writeable
 This variable is set to the values of the promise attribute
 `service_policy`. For example:
 
-~~~~ {.verbatim}
+~~~~
 services:
 
   "www"  service_policy => "start";

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accessedbefore.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accessedbefore.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-accessedbefore]
 
 **Synopsis**: accessedbefore(arg1,arg2) returns type **class**
 
-\
- *arg1* : Newer filename, *in the range* "?(/.\*) \
- *arg2* : Older filename, *in the range* "?(/.\*) \
+  
+ *arg1* : Newer filename, *in the range* "?(/.\*)   
+ *arg2* : Older filename, *in the range* "?(/.\*)   
 
 True if arg1 was accessed before arg2 (atime)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -45,13 +45,13 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The function accesses the `atime` fields of a file and makes a
 comparison.
 
-~~~~ {.smallexample}
+~~~~
      
       touch /tmp/reference
       touch /tmp/secretfile

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accumulated.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accumulated.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-accumulated]
 **Synopsis**: accumulated(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
- *arg1* : Years, *in the range* 0,1000 \
- *arg2* : Months, *in the range* 0,1000 \
- *arg3* : Days, *in the range* 0,1000 \
- *arg4* : Hours, *in the range* 0,1000 \
- *arg5* : Minutes, *in the range* 0,1000 \
- *arg6* : Seconds, *in the range* 0,40000 \
+  
+ *arg1* : Years, *in the range* 0,1000   
+ *arg2* : Months, *in the range* 0,1000   
+ *arg3* : Days, *in the range* 0,1000   
+ *arg4* : Hours, *in the range* 0,1000   
+ *arg5* : Minutes, *in the range* 0,1000   
+ *arg6* : Seconds, *in the range* 0,40000   
 
 Convert an accumulated amount of time into a system representation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 
 {
@@ -62,8 +62,8 @@ out_of_range_define => { "any_procs" };
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 In the example we look for processes that have accumulated between 2 and
 20 minutes of total run time.
@@ -79,25 +79,25 @@ for example, accumulated(0,0,0,48,0,0) or accumulated(0,0,0,0,90,0).
 Years
 
 Years of run time. For convenience in conversion, a year of runtime is
-always 365 days (one year equals 31,536,000 seconds). \
+always 365 days (one year equals 31,536,000 seconds).   
 
 Month
 
 Months of run time. For convenience in conversion, a month of runtime is
 always equal to 30 days of runtime (one month equals 2,592,000 seconds).
-\
+  
 
 Day
 
-Days of runtime (one day equals 86,400 seconds) \
+Days of runtime (one day equals 86,400 seconds)   
 
 Hours
 
-Hours of runtime \
+Hours of runtime   
 
 Minutes
 
-Minutes of runtime 0-59 \
+Minutes of runtime 0-59   
 
 Seconds
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ago.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ago.markdown
@@ -11,20 +11,20 @@ tags: [Special-functions,Function-ago]
 
 **Synopsis**: ago(arg1,arg2,arg3,arg4,arg5,arg6) returns type **int**
 
-\
- *arg1* : Years, *in the range* 0,1000 \
- *arg2* : Months, *in the range* 0,1000 \
- *arg3* : Days, *in the range* 0,1000 \
- *arg4* : Hours, *in the range* 0,1000 \
- *arg5* : Minutes, *in the range* 0,1000 \
- *arg6* : Seconds, *in the range* 0,40000 \
+  
+ *arg1* : Years, *in the range* 0,1000   
+ *arg2* : Months, *in the range* 0,1000   
+ *arg3* : Days, *in the range* 0,1000   
+ *arg4* : Hours, *in the range* 0,1000   
+ *arg5* : Minutes, *in the range* 0,1000   
+ *arg6* : Seconds, *in the range* 0,40000   
 
 Convert a time relative to now to an integer system representation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 
 {
@@ -62,8 +62,8 @@ out_of_range_define => { "any_procs" };
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The `ago` function measures time relative to now. Arguments are applied
 in order, so that ago(0,18,55,27,0,0) means "18 months, 55 days, and 27
@@ -76,28 +76,29 @@ ago(0,0,0,72,0,0).
 Years
 
 Years ago. If today is February 29, and "**n** years ago" is not within
-a leap-year, February 28 will be used. \
+a leap-year, February 28 will be used.   
 
 Month
 
 Months ago. If the current month has more days that "**n** months ago",
 the last day of "**n** months ago" will be used (e.g., if today is April
 31 and you compute a date 1 month ago, the resulting date will be March
-30), equal to 30 days of runtime (one month equals 2,592,000 seconds). \
+30), equal to 30 days of runtime (one month equals 2,592,000 seconds).
+  
 
 Day
 
-Days ago (you may, for example, specify 120 days) \
+Days ago (you may, for example, specify 120 days)   
 
 Hours
 
 Hours ago. Since all computation are done using "Epoch time", 1 hour ago
 will alway result in a time 60 minutes in the past, even during the
-transition from Daylight time to Standard time. \
+transition from Daylight time to Standard time.   
 
 Minutes
 
-Minutes ago 0-59 \
+Minutes ago 0-59   
 
 Seconds
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-and.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-and.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-and]
 
 **Synopsis**: and(...) returns type **string**
 
-\
+  
 
 Calculate whether all arguments evaluate to true
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
   "/usr/bin/generate_config $(config)"
     ifvarclass => and(not(fileexists("/etc/config/$(config)")), "generating_configs");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-canonify.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-canonify.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-canonify]
 
 **Synopsis**: canonify(arg1) returns type **string**
 
-\
+  
  *arg1* : String containing non-identifier characters, *in the range*
-.\* \
+.\*   
 
 Convert an arbitrary string into a legal class name
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
 
    "/var/cfengine/bin/$(component)"
@@ -28,8 +28,8 @@ commands:
        ifvarclass => canonify("start_$(component)");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is for use in turning arbitrary text into class data (See [Function
 classify](#Function-classify)).

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-changedbefore.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-changedbefore.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-changedbefore]
 
 **Synopsis**: changedbefore(arg1,arg2) returns type **class**
 
-\
- *arg1* : Newer filename, *in the range* "?(/.\*) \
- *arg2* : Older filename, *in the range* "?(/.\*) \
+  
+ *arg1* : Newer filename, *in the range* "?(/.\*)   
+ *arg2* : Older filename, *in the range* "?(/.\*)   
 
 True if arg1 was changed before arg2 (ctime)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -45,8 +45,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Change times include both file permissions and file contents.
 Comparisons like this are normally used for updating files (like the

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classify.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classify.markdown
@@ -11,23 +11,23 @@ tags: [Special-functions,Function-classify]
 
 **Synopsis**: classify(arg1) returns type **class**
 
-\
- *arg1* : Input string, *in the range* .\* \
+  
+ *arg1* : Input string, *in the range* .\*   
 
 True if the canonicalization of the argument is a currently defined
 class
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
  "i_am_the_policy_host" expression => classify("master.example.org");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function returns true if the canonical form of the argument is
 already a defined class. This is useful for transforming variables into

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classmatch.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classmatch.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-classmatch]
 
 **Synopsis**: classmatch(arg1) returns type **class**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
 
 True if the regular expression matches any currently defined class
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,8 +44,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The regular expression is matched against the current list of defined
 classes. The regular expression must match a complete class for the

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-concat.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-concat.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-concat]
 
 **Synopsis**: concat(...) returns type **string**
 
-\
+  
 
 Concatenate all arguments into string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
   "/usr/bin/generate_config $(config)"
     ifvarclass => concat("have_config_", canonify("$(config)"));
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countclassesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countclassesmatching.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-countclassesmatching]
 
 **Synopsis**: countclassesmatching(arg1) returns type **int**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
 
 Count the number of defined classes matching regex arg1
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {
 vars:
@@ -35,8 +35,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function matches classes, using a regular expression that should
 match the whole line.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countlinesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countlinesmatching.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-countlinesmatching]
 
 **Synopsis**: countlinesmatching(arg1,arg2) returns type **int**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
- *arg2* : Filename, *in the range* "?(/.\*) \
+  
+ *arg1* : Regular expression, *in the range* .\*   
+ *arg2* : Filename, *in the range* "?(/.\*)   
 
 Count the number of lines matching regex arg1 in file arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {     
 vars:
@@ -36,8 +36,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function matches lines in the named file, using a regular
 expression that should match the whole line.
@@ -47,7 +47,7 @@ regex
 A regular expression matching zero or more lines. The regular expression
 is anchored, meaning it must match a complete line (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 filename
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-dirname.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-dirname.markdown
@@ -11,21 +11,21 @@ tags: [Special-functions,Function-dirname]
 
 **Synopsis**: dirname(arg1) returns type **string**
 
-\
- *arg1* : File path, *in the range* .\* \
+  
+ *arg1* : File path, *in the range* .\*   
 
 Return the parent directory name for given path
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
   "apache_dir" string => dirname("/etc/apache2/httpd.conf");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
 This function returns directory name for the argument. If directory name

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-diskfree.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-diskfree.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-diskfree]
 
 **Synopsis**: diskfree(arg1) returns type **int**
 
-\
- *arg1* : File system directory, *in the range* "?(/.\*) \
+  
+ *arg1* : File system directory, *in the range* "?(/.\*)   
 
 Return the free space (in KB) available on the directory's current
 partition (0 if not found)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {     
 vars:
@@ -36,7 +36,7 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Values returned in kilobytes.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-escape.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-escape.markdown
@@ -11,23 +11,23 @@ tags: [Special-functions,Function-escape]
 
 **Synopsis**: escape(arg1) returns type **string**
 
-\
- *arg1* : IP address or string to escape, *in the range* .\* \
+  
+ *arg1* : IP address or string to escape, *in the range* .\*   
 
 Escape regular expression characters in a string
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle server control
 {
 allowconnects         => { "127\.0\.0\.1", escape("192.168.2.1") };
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function is useful for making inputs readable when a regular
 expression is required, but the literal string contains special

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-execresult.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-execresult.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-execresult]
 
 **Synopsis**: execresult(arg1,arg2) returns type **string**
 
-\
- *arg1* : Fully qualified command path, *in the range* "?(/.\*) \
- *arg2* : Shell encapsulation option, *in the range* useshell,noshell \
+  
+ *arg1* : Fully qualified command path, *in the range* "?(/.\*)   
+ *arg2* : Shell encapsulation option, *in the range* useshell,noshell   
 
 Execute named command and assign output to variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -45,8 +45,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The second argument (useshell/noshell) decides whether a shell will be
 used to encapsulate the command. This is necessary in order to combine

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-fileexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-fileexists.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-fileexists]
 
 **Synopsis**: fileexists(arg1) returns type **class**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 True if the named file can be accessed
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,8 +44,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The user must have access permissions to the file for this to work
 faithfully.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesexist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesexist.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-filesexist]
 
 **Synopsis**: filesexist(arg1) returns type **class**
 
-\
+  
  *arg1* : Array identifier containing list, *in the range*
-@[(][a-zA-Z0-9]+[)] \
+@[(][a-zA-Z0-9]+[)]   
 
 True if the named list of files can ALL be accessed
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -55,8 +55,8 @@ reports:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The user must have access permissions to the file for this to work
 faithfully.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesize.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesize.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-filesize]
 
 **Synopsis**: filesize(arg1) returns type **int**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 Returns the size in bytes of the file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {     
 vars:
@@ -37,8 +37,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.3,Nova 2.0.2 (2010)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getenv.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getenv.markdown
@@ -11,18 +11,18 @@ tags: [Special-functions,Function-getenv]
 
 **Synopsis**: getenv(arg1,arg2) returns type **string**
 
-\
+  
  *arg1* : Name of environment variable, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
  *arg2* : Maximum number of characters to read , *in the range*
-0,99999999999 \
+0,99999999999   
 
 Return the environment variable named arg1, truncated at arg2 characters
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 {
 vars:
@@ -46,8 +46,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Returns an empty string if the environment variable is not defined. Arg2
 is used to avoid unexpectedly large return values, which could lead to

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getfields.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getfields.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-getfields]
 
 **Synopsis**: getfields(arg1,arg2,arg3,arg4) returns type **int**
 
-\
- *arg1* : Regular expression to match line, *in the range* .\* \
- *arg2* : Filename to read, *in the range* "?(/.\*) \
- *arg3* : Regular expression to split fields, *in the range* .\* \
- *arg4* : Return array name, *in the range* .\* \
+  
+ *arg1* : Regular expression to match line, *in the range* .\*   
+ *arg2* : Filename to read, *in the range* "?(/.\*)   
+ *arg3* : Regular expression to split fields, *in the range* .\*   
+ *arg4* : Return array name, *in the range* .\*   
 
 Get an array of fields in the lines matching regex arg1 in file arg2,
 split on regex arg3 as array name arg4
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -41,8 +41,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function matches lines (using a regular expression) in the named
 file, and splits the *first* matched line into fields (using a second
@@ -55,16 +55,16 @@ regex
 A regular expression matching one or more lines. The regular expression
 is anchored, meaning it must match the entire line (see [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 filename
 
-The name of the file to be examined. \
+The name of the file to be examined.   
 
 split
 
 A regex pattern that is used to parse the field separator(s) to split up
-the file into items \
+the file into items   
 
 array\_lval
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getgid.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getgid.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-getgid]
 
 **Synopsis**: getgid(arg1) returns type **int**
 
-\
- *arg1* : Group name in text, *in the range* .\* \
+  
+ *arg1* : Group name in text, *in the range* .\*   
 
 Return the integer group id of the named group on this host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,8 +44,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the named group does not exist, the variable will not be defined. On
 Windows, which does not support group ids, the variable will not be

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getindices.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getindices.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-getindices]
 
 **Synopsis**: getindices(arg1) returns type **slist**
 
-\
+  
  *arg1* : Cfengine array identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Get a list of keys to the array whose id is the argument and assign to
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -52,8 +52,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Make sure you specify the correct scope when supplying the name of the
 variable.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getuid.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getuid.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-getuid]
 
 **Synopsis**: getuid(arg1) returns type **int**
 
-\
- *arg1* : User name in text, *in the range* .\* \
+  
+ *arg1* : User name in text, *in the range* .\*   
 
 Return the integer user id of the named user on this host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,8 +44,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the named user is not registered the variable will not be defined. On
 Windows, which does not support user ids, the variable will not be

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getusers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getusers.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-getusers]
 
 **Synopsis**: getusers(arg1,arg2) returns type **slist**
 
-\
- *arg1* : Comma separated list of User names, *in the range* .\* \
- *arg2* : Comma separated list of UserID numbers, *in the range* .\* \
+  
+ *arg1* : Comma separated list of User names, *in the range* .\*   
+ *arg2* : Comma separated list of UserID numbers, *in the range* .\*   
 
 Get a list of all system users defined, minus those names defined in
 arg1 and uids in arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
   "allusers" slist => getusers("zenoss,mysql,at","12,0");
 
@@ -32,8 +32,8 @@ reports:
   "Found user $(allusers)";
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 **History**: Was introduced in version 3.1.0b1,Nova 2.0.0b1 (2010). This
 function is only available on Unix-like systems in the present version.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getvalues.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getvalues.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-getvalues]
 
 **Synopsis**: getvalues(arg1) returns type **slist**
 
-\
+  
  *arg1* : Cfengine array identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Get a list of values corresponding to the right hand sides in an array
 whose id is the argument and assign to variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -52,8 +52,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Make sure you specify the correct scope when supplying the name of the
 variable. If the array contains list elements on the right hand side,

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-grep.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-grep.markdown
@@ -11,18 +11,18 @@ tags: [Special-functions,Function-grep]
 
 **Synopsis**: grep(arg1,arg2) returns type **slist**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
  *arg2* : CFEngine list identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Extract the sub-list if items matching the regular expression in arg1 of
 the list named in arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 
 {
@@ -43,8 +43,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Extracts a sublist of elements matching the regular expression in arg1
 from a list variable specified in arg2. The regex is anchored (See

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-groupexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-groupexists.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-groupexists]
 
 **Synopsis**: groupexists(arg1) returns type **class**
 
-\
- *arg1* : Group name or identifier, *in the range* .\* \
+  
+ *arg1* : Group name or identifier, *in the range* .\*   
 
 True if group or numerical id exists on this host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -49,7 +49,7 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The group may be specified by name or number.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hash.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hash.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-hash]
 
 **Synopsis**: hash(arg1,arg2) returns type **string**
 
-\
- *arg1* : Input text, *in the range* .\* \
+  
+ *arg1* : Input text, *in the range* .\*   
  *arg2* : Hash or digest algorithm, *in the range*
-md5,sha1,sha256,sha512,sha384,crypt \
+md5,sha1,sha256,sha512,sha384,crypt   
 
 Return the hash of arg1, type arg2 and assign to a variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -47,8 +47,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Hash functions are extremely sensitive to input. You should not expect
 to get the same answer from this function as you would from every other

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hashmatch.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hashmatch.markdown
@@ -11,20 +11,20 @@ tags: [Special-functions,Function-hashmatch]
 
 **Synopsis**: hashmatch(arg1,arg2,arg3) returns type **class**
 
-\
- *arg1* : Filename to hash, *in the range* "?(/.\*) \
+  
+ *arg1* : Filename to hash, *in the range* "?(/.\*)   
  *arg2* : Hash or digest algorithm, *in the range*
-md5,sha1,crypt,cf\_sha224,cf\_sha256,cf\_sha384,cf\_sha512 \
+md5,sha1,crypt,cf\_sha224,cf\_sha256,cf\_sha384,cf\_sha512   
  *arg3* : ASCII representation of hash for comparison, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Compute the hash of arg1, of type arg2 and test if it matches the value
 in arg3
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -41,10 +41,10 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (class) hashmatch(file,md5|sha1|crypt,hash-comparison);
      

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-host2ip.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-host2ip.markdown
@@ -11,23 +11,23 @@ tags: [Special-functions,Function-host2ip]
 
 **Synopsis**: host2ip(arg1) returns type **string**
 
-\
- *arg1* : Host name in ascii, *in the range* .\* \
+  
+ *arg1* : Host name in ascii, *in the range* .\*   
 
 Returns the primary name-service IP address for the named host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle server control
 {
 allowconnects         => { escape(host2ip("www.example.com")) };
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Uses whatever configured name service is used by the resolver library to
 translate a hostname into an IP address. It will return an IPv6 address

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostinnetgroup.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostinnetgroup.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-hostinnetgroup]
 
 **Synopsis**: hostinnetgroup(arg1) returns type **class**
 
-\
- *arg1* : Netgroup name, *in the range* .\* \
+  
+ *arg1* : Netgroup name, *in the range* .\*   
 
 True if the current host is in the named netgroup
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "ingroup" expression => hostinnetgroup("my_net_group");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostrange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostrange.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-hostrange]
 
 **Synopsis**: hostrange(arg1,arg2) returns type **class**
 
-\
- *arg1* : Hostname prefix, *in the range* .\* \
- *arg2* : Enumerated range, *in the range* .\* \
+  
+ *arg1* : Hostname prefix, *in the range* .\*   
+ *arg2* : Enumerated range, *in the range* .\*   
 
 True if the current host lies in the range of enumerated hostnames
 specified
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -47,8 +47,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is a pattern matching function for non-regular (enumerated)
 expressions.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostsseen.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostsseen.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-hostsseen]
 
 **Synopsis**: hostsseen(arg1,arg2,arg3) returns type **slist**
 
-\
+  
  *arg1* : Horizon since last seen in hours, *in the range* 0,99999999999
-\
+  
  *arg2* : Complements for selection policy, *in the range*
-lastseen,notseen \
- *arg3* : Type of return value desired, *in the range* name,address \
+lastseen,notseen   
+ *arg3* : Type of return value desired, *in the range* name,address   
 
 Extract the list of hosts last seen/not seen within the last arg1 hours
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 
 {
@@ -40,8 +40,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Finds a list of hosts seen by a CFEngine remote connection on the
 current host within the number of hours specified by argument 1.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostswithclass.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostswithclass.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-hostswithclass]
 
 **Synopsis**: hostswithclass(arg1,arg2) returns type **slist**
 
-\
- *arg1* : Class name to look for, *in the range* [a-zA-Z0-9\_]+ \
- *arg2* : Type of return value desired, *in the range* name,address \
+  
+ *arg1* : Class name to look for, *in the range* [a-zA-Z0-9\_]+   
+ *arg2* : Type of return value desired, *in the range* name,address   
 
 Extract the list of hosts with the given class set from the hub database
 (commercial extension)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -44,8 +44,8 @@ am_policy_hub::
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 On CFEngine Nova hubs, this function can be used to return a list of
 hostnames or ip-addresses of hosts that has the class given as argument
@@ -59,5 +59,5 @@ hub to construct custom configuration files for (classes of) hosts.
 
 Availability: Enterprise editions of CFEngine only.
 
-~~~~ {.verbatim}
+~~~~
 ~~~~

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hubknowledge.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hubknowledge.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-hubknowledge]
 
 **Synopsis**: hubknowledge(arg1) returns type **string**
 
-\
+  
  *arg1* : Variable identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Read global knowledge from the hub host by id (commercial extension)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   guard::
@@ -28,8 +28,8 @@ vars:
    "global_number" string => hubknowledge("number_variable");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function is only available in commercial releases of CFEngine. It
 is intended for use in distributed orchestration. It is recommended that

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ip2host.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ip2host.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-ip2host]
 
 **Synopsis**: ip2host(arg1) returns type **string**
 
-\
- *arg1* : IP address (IPv4 or IPv6), *in the range* .\* \
+  
+ *arg1* : IP address (IPv4 or IPv6), *in the range* .\*   
 
 Returns the primary name-service host name for the IP address
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent reverse_lookup
 {
 vars:
@@ -34,8 +34,8 @@ cfengine_3::
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Uses whatever configured name service is used by the resolver library to
 translate an IP address to a hostname. IPv6 addresses will also resolve,

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-iprange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-iprange.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-iprange]
 
 **Synopsis**: iprange(arg1) returns type **class**
 
-\
- *arg1* : IP address range syntax, *in the range* .\* \
+  
+ *arg1* : IP address range syntax, *in the range* .\*   
 
 True if the current host lies in the range of IP addresses specified
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -48,7 +48,7 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Pattern matching based on IP addresses.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-irange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-irange.markdown
@@ -11,23 +11,23 @@ tags: [Special-functions,Function-irange]
 
 **Synopsis**: irange(arg1,arg2) returns type **irange [int,int]**
 
-\
- *arg1* : Integer, *in the range* -99999999999,9999999999 \
- *arg2* : Integer, *in the range* -99999999999,9999999999 \
+  
+ *arg1* : Integer, *in the range* -99999999999,9999999999   
+ *arg2* : Integer, *in the range* -99999999999,9999999999   
 
 Define a range of integer values for cfengine internal use
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 irange("1","100");
 
 irange(ago(0,0,0,1,30,0), "0");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Used for any scalar attribute which requires an integer range. You can
 generally interchangeably say "1,10" or irange("1","10"). However, if

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isdir.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isdir.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-isdir]
 
 **Synopsis**: isdir(arg1) returns type **class**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 True if the named object is a directory
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -45,8 +45,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The CFEngine process must have access to the object concerned in order
 for this to work.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isexecutable.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isexecutable.markdown
@@ -11,21 +11,21 @@ tags: [Special-functions,Function-isexecutable]
 
 **Synopsis**: isexecutable(arg1) returns type **class**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 True if the named object has execution rights for the current user
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "yes" expression => isexecutable("/bin/ls");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.0b1,Nova 2.0.0b1 (2010)

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isgreaterthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isgreaterthan.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-isgreaterthan]
 
 **Synopsis**: isgreaterthan(arg1,arg2) returns type **class**
 
-\
- *arg1* : Larger string or value, *in the range* .\* \
- *arg2* : Smaller string or value, *in the range* .\* \
+  
+ *arg1* : Larger string or value, *in the range* .\*   
+ *arg2* : Smaller string or value, *in the range* .\*   
 
 True if arg1 is numerically greater than arg2, else compare strings like
 strcmp
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -50,8 +50,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The comparison is made numerically if possible. If the values are
 strings, the result is identical to that of comparing with strcmp().

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islessthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islessthan.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-islessthan]
 
 **Synopsis**: islessthan(arg1,arg2) returns type **class**
 
-\
- *arg1* : Smaller string or value, *in the range* .\* \
- *arg2* : Larger string or value, *in the range* .\* \
+  
+ *arg1* : Smaller string or value, *in the range* .\*   
+ *arg2* : Larger string or value, *in the range* .\*   
 
 True if arg1 is numerically less than arg2, else compare strings like
 NOT strcmp
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -50,8 +50,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The complement of `isgreaterthan`. The comparison is made numerically if
 possible. If the values are strings, the result is identical to that of

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islink.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islink.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-islink]
 
 **Synopsis**: islink(arg1) returns type **class**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 True if the named object is a symbolic link
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,8 +44,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The link node must both exist and be a symbolic link. Hard links cannot
 be detected using this function. A hard link is a regular file or

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isnewerthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isnewerthan.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-isnewerthan]
 
 **Synopsis**: isnewerthan(arg1,arg2) returns type **class**
 
-\
- *arg1* : Newer file name, *in the range* "?(/.\*) \
- *arg2* : Older file name, *in the range* "?(/.\*) \
+  
+ *arg1* : Newer file name, *in the range* "?(/.\*)   
+ *arg2* : Older file name, *in the range* "?(/.\*)   
 
 True if arg1 is newer (modified later) than arg2 (mtime)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -45,8 +45,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function compares the modification time of the file, referring to
 changes of content only.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isplain.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isplain.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-isplain]
 
 **Synopsis**: isplain(arg1) returns type **class**
 
-\
- *arg1* : File object name, *in the range* "?(/.\*) \
+  
+ *arg1* : File object name, *in the range* "?(/.\*)   
 
 True if the named object is a plain/regular file
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -44,5 +44,5 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isvariable.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isvariable.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-isvariable]
 
 **Synopsis**: isvariable(arg1) returns type **class**
 
-\
+  
  *arg1* : Variable identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 True if the named variable is defined
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -49,8 +49,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The variable need only exist. This says nothing about its value. Use
 `regcmp` to check variable values.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-join.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-join.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-join]
 
 **Synopsis**: join(arg1,arg2) returns type **string**
 
-\
- *arg1* : Join glue-string, *in the range* .\* \
+  
+ *arg1* : Join glue-string, *in the range* .\*   
  *arg2* : CFEngine list identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Join the items of arg2 into a string, using the conjunction in arg1
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 
 {
@@ -40,8 +40,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Converts a string of type list into a scalar variable using the join
 string in first argument.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lastnode.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lastnode.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-lastnode]
 
 **Synopsis**: lastnode(arg1,arg2) returns type **string**
 
-\
- *arg1* : Input string, *in the range* .\* \
- *arg2* : Link separator, e.g. /,:, *in the range* .\* \
+  
+ *arg1* : Input string, *in the range* .\*   
+ *arg2* : Link separator, e.g. /,:, *in the range* .\*   
 
 Extract the last of a separated string, e.g. filename from a path
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent yes
 {
 vars:
@@ -42,8 +42,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function returns the final node in a chain, given a regular
 expression to split on. This is mainly useful for finding leaf-names of

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-laterthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-laterthan.markdown
@@ -12,26 +12,26 @@ tags: [Special-functions,Function-laterthan]
 **Synopsis**: laterthan(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **class**
 
-\
- *arg1* : Years, *in the range* 0,1000 \
- *arg2* : Months, *in the range* 0,1000 \
- *arg3* : Days, *in the range* 0,1000 \
- *arg4* : Hours, *in the range* 0,1000 \
- *arg5* : Minutes, *in the range* 0,1000 \
- *arg6* : Seconds, *in the range* 0,40000 \
+  
+ *arg1* : Years, *in the range* 0,1000   
+ *arg2* : Months, *in the range* 0,1000   
+ *arg3* : Days, *in the range* 0,1000   
+ *arg4* : Hours, *in the range* 0,1000   
+ *arg5* : Minutes, *in the range* 0,1000   
+ *arg6* : Seconds, *in the range* 0,40000   
 
 True if the current time is later than the given date
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
   "after_deadline" expression => laterthan(2000,1,1,0,0,0);
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The arguments are standard time (See [Function on](#Function-on)).

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaparray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaparray.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-ldaparray]
 **Synopsis**: ldaparray(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **class**
 
-\
- *arg1* : Array name, *in the range* .\* \
- *arg2* : URI, *in the range* .\* \
- *arg3* : Distinguished name, *in the range* .\* \
- *arg4* : Filter, *in the range* .\* \
- *arg5* : Search scope policy, *in the range* subtree,onelevel,base \
- *arg6* : Security level, *in the range* none,ssl,sasl \
+  
+ *arg1* : Array name, *in the range* .\*   
+ *arg2* : URI, *in the range* .\*   
+ *arg3* : Distinguished name, *in the range* .\*   
+ *arg4* : Filter, *in the range* .\*   
+ *arg5* : Search scope policy, *in the range* subtree,onelevel,base   
+ *arg6* : Security level, *in the range* none,ssl,sasl   
 
 Extract all values from an LDAP record
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
    "gotdata" expression => ldaparray(
@@ -37,10 +37,10 @@ classes:
                                     "none");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (class) ldaparray (array,uri,dn,filter,scope,security)
      
@@ -54,32 +54,32 @@ if there was a match for the search, and false if nothing was retrieved.
 
 array
 
-String name of the array to populate with the result of the search \
+String name of the array to populate with the result of the search   
 
 uri
 
-String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"` \
+String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"`   
 
 dn
 
 Distinguished name, an ldap formatted name built from components, e.g.
-"dc=cfengine,dc=com". \
+"dc=cfengine,dc=com".   
 
 filter
 
-String filter criterion, in ldap search, e.g. "(sn=User)". \
+String filter criterion, in ldap search, e.g. "(sn=User)".   
 
 scope
 
 Menu option, the type of ldap search, from
 
-~~~~ {.smallexample}
+~~~~
               subtree
               onelevel
               base
 ~~~~
 
-\
+  
 
 security
 
@@ -87,7 +87,7 @@ Menu option indicating the encryption and authentication settings for
 communication with the LDAP server. These features might be subject to
 machine and server capabilities.
 
-~~~~ {.smallexample}
+~~~~
                none
                ssl
                sasl

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaplist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaplist.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-ldaplist]
 **Synopsis**: ldaplist(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **slist**
 
-\
- *arg1* : URI, *in the range* .\* \
- *arg2* : Distinguished name, *in the range* .\* \
- *arg3* : Filter, *in the range* .\* \
- *arg4* : Record name, *in the range* .\* \
- *arg5* : Search scope policy, *in the range* subtree,onelevel,base \
- *arg6* : Security level, *in the range* none,ssl,sasl \
+  
+ *arg1* : URI, *in the range* .\*   
+ *arg2* : Distinguished name, *in the range* .\*   
+ *arg3* : Filter, *in the range* .\*   
+ *arg4* : Record name, *in the range* .\*   
+ *arg5* : Search scope policy, *in the range* subtree,onelevel,base   
+ *arg6* : Security level, *in the range* none,ssl,sasl   
 
 Extract all named values from multiple ldap records
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
    # Get all matching values for "uid" - should be a single record match
@@ -40,10 +40,10 @@ vars:
                            );
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (slist) ldaplist(uri,dn,filter,name,scope,security)
      
@@ -56,33 +56,34 @@ identified by the search parameters.
 
 uri
 
-String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"` \
+String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"`   
 
 dn
 
 Distinguished name, an ldap formatted name built from components, e.g.
-"dc=cfengine,dc=com". \
+"dc=cfengine,dc=com".   
 
 filter
 
-String filter criterion, in ldap search, e.g. "(sn=User)". \
+String filter criterion, in ldap search, e.g. "(sn=User)".   
 
 name
 
-String value, the name of a single record to be retrieved, e.g. `uid`. \
+String value, the name of a single record to be retrieved, e.g. `uid`.
+  
 
 scope
 
 Menu option, the type of ldap search, from the specified root. May take
 values:
 
-~~~~ {.smallexample}
+~~~~
               subtree
               onelevel
               base
 ~~~~
 
-\
+  
 
 security
 
@@ -90,7 +91,7 @@ Menu option indicating the encryption and authentication settings for
 communication with the LDAP server. These features might be subject to
 machine and server capabilities.
 
-~~~~ {.smallexample}
+~~~~
                none
                ssl
                sasl

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldapvalue.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldapvalue.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-ldapvalue]
 **Synopsis**: ldapvalue(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **string**
 
-\
- *arg1* : URI, *in the range* .\* \
- *arg2* : Distinguished name, *in the range* .\* \
- *arg3* : Filter, *in the range* .\* \
- *arg4* : Record name, *in the range* .\* \
- *arg5* : Search scope policy, *in the range* subtree,onelevel,base \
- *arg6* : Security level, *in the range* none,ssl,sasl \
+  
+ *arg1* : URI, *in the range* .\*   
+ *arg2* : Distinguished name, *in the range* .\*   
+ *arg3* : Filter, *in the range* .\*   
+ *arg4* : Record name, *in the range* .\*   
+ *arg5* : Search scope policy, *in the range* subtree,onelevel,base   
+ *arg6* : Security level, *in the range* none,ssl,sasl   
 
 Extract the first matching named value from ldap
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
    # Get the first matching value for "uid" in schema
@@ -40,10 +40,10 @@ vars:
                              );
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (string) ldapvalue(uri,dn,filter,name,scope,security)
      
@@ -56,27 +56,28 @@ identified by the search parameters. The first matching value it taken.
 
 uri
 
-String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"` \
+String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"`   
 
 dn
 
 Distinguished name, an ldap formatted name built from components, e.g.
-"dc=cfengine,dc=com". \
+"dc=cfengine,dc=com".   
 
 filter
 
-String filter criterion, in ldap search, e.g. "(sn=User)". \
+String filter criterion, in ldap search, e.g. "(sn=User)".   
 
 name
 
-String value, the name of a single record to be retrieved, e.g. `uid`. \
+String value, the name of a single record to be retrieved, e.g. `uid`.
+  
 
 scope
 
 Menu option, the type of ldap search, from the specified root. May take
 values:
 
-~~~~ {.smallexample}
+~~~~
               subtree
               onelevel
               base

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lsdir.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lsdir.markdown
@@ -11,25 +11,25 @@ tags: [Special-functions,Function-lsdir]
 
 **Synopsis**: lsdir(arg1,arg2,arg3) returns type **slist**
 
-\
- *arg1* : Path to base directory, *in the range* .+ \
+  
+ *arg1* : Path to base directory, *in the range* .+   
  *arg2* : Regular expression to match files or blank, *in the range* .\*
-\
+  
  *arg3* : Include the base path in the list, *in the range*
-true,false,yes,no,on,off \
+true,false,yes,no,on,off   
 
 Return a list of files in a directory matching a regular expression
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
   "listfiles" slist => lsdir("/etc", "(passwd|shadow).*", "true");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 
 This function returns list of files in directory specified in arg1,

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-maplist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-maplist.markdown
@@ -11,18 +11,18 @@ tags: [Special-functions,Function-maplist]
 
 **Synopsis**: maplist(arg1,arg2) returns type **slist**
 
-\
+  
  *arg1* : Pattern based on \$(this) as original text, *in the range* .\*
-\
+  
  *arg2* : The name of the list variable to map, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Return a list with each element modified by a pattern based \$(this)
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 {
 vars:
@@ -36,8 +36,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in 3.3.0, Nova 2.2.0 (2011)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-not.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-not.markdown
@@ -11,20 +11,20 @@ tags: [Special-functions,Function-not]
 
 **Synopsis**: not(arg1) returns type **string**
 
-\
- *arg1* : Class value, *in the range* .\* \
+  
+ *arg1* : Class value, *in the range* .\*   
 
 Calculate whether argument is false
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
   "/usr/bin/generate_config $(config)"
     ifvarclass => not(fileexists("/etc/config/$(config)"));
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-now.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-now.markdown
@@ -11,14 +11,14 @@ tags: [Special-functions,Function-now]
 
 **Synopsis**: now() returns type **int**
 
-\
+  
 
 Convert the current time into system representation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body file_select zero_age
 {
 mtime       => irange(ago(1,0,0,0,0,0),now);
@@ -26,5 +26,5 @@ file_result => "mtime";
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-on.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-on.markdown
@@ -11,20 +11,20 @@ tags: [Special-functions,Function-on]
 
 **Synopsis**: on(arg1,arg2,arg3,arg4,arg5,arg6) returns type **int**
 
-\
- *arg1* : Year, *in the range* 1970,3000 \
- *arg2* : Month, *in the range* 1,12 \
- *arg3* : Day, *in the range* 1,31 \
- *arg4* : Hour, *in the range* 0,23 \
- *arg5* : Minute, *in the range* 0,59 \
- *arg6* : Second, *in the range* 0,59 \
+  
+ *arg1* : Year, *in the range* 1970,3000   
+ *arg2* : Month, *in the range* 1,12   
+ *arg3* : Day, *in the range* 1,31   
+ *arg4* : Hour, *in the range* 0,23   
+ *arg5* : Minute, *in the range* 0,59   
+ *arg6* : Second, *in the range* 0,59   
 
 Convert an exact date/time to an integer system representation
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body file_select zero_age
 {
 mtime       => irange(on(2000,1,1,0,0,0),now);
@@ -32,8 +32,8 @@ file_result => "mtime";
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 An absolute date in the local timezone. Note that in process matching
 dates could be wrong by an hour depending on Daylight Savings Time /
@@ -43,23 +43,23 @@ Summer Time. This is a known bug to be fixed.
 
 Years
 
-The year, e.g. 2009 \
+The year, e.g. 2009   
 
 Month
 
-The Month, 1-12 \
+The Month, 1-12   
 
 Day
 
-The day 1-31 \
+The day 1-31   
 
 Hours
 
-The hour 0-23 \
+The hour 0-23   
 
 Minutes
 
-The minutes 0-59 \
+The minutes 0-59   
 
 Seconds
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-or.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-or.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-or]
 
 **Synopsis**: or(...) returns type **string**
 
-\
+  
 
 Calculate whether any argument evaluates to true
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 commands:
   "/usr/bin/generate_config $(config)"
     ifvarclass => or(not(fileexists("/etc/config/$(config)")), "force_configs");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  *History*: Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parseintarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parseintarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-parseintarray]
 **Synopsis**: parseintarray(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : A string to parse for input data, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : A string to parse for input data, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of integers from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test(f) 
 {
 vars:
@@ -62,8 +62,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parserealarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parserealarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-parserealarray]
 **Synopsis**: parserealarray(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : A string to parse for input data, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : A string to parse for input data, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of real numbers from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test(f) 
 {
 vars:
@@ -62,8 +62,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1.0 (2011)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-parsestringarray]
 **Synopsis**: parsestringarray(arg1,arg2,arg3,arg4,arg5,arg6) returns
 type **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : A string to parse for input data, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : A string to parse for input data, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of strings from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test(f) 
 {
 vars:
@@ -62,8 +62,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1.0 (2011)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarrayidx.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarrayidx.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-parsestringarrayidx]
 **Synopsis**: parsestringarrayidx(arg1,arg2,arg3,arg4,arg5,arg6) returns
 type **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : A string to parse for input data, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : A string to parse for input data, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of strings from a file and assign the dimension to a
 variable with integer indexes
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test(f) 
 {
 vars:
@@ -62,8 +62,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 *History*: Was introduced in version 3.1.5, Nova 2.1.0 (2011)
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleader.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleader.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-peerleader]
 
 **Synopsis**: peerleader(arg1,arg2,arg3) returns type **string**
 
-\
- *arg1* : File name of host list, *in the range* "?(/.\*) \
- *arg2* : Comment regex pattern, *in the range* .\* \
- *arg3* : Peer group size, *in the range* 0,99999999999 \
+  
+ *arg1* : File name of host list, *in the range* "?(/.\*)   
+ *arg2* : Comment regex pattern, *in the range* .\*   
+ *arg3* : Peer group size, *in the range* 0,99999999999   
 
 Get the assigned peer-leader of the partition to which we belong
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent peers
 {
 vars:
@@ -43,10 +43,10 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (string) peerleader(file of hosts,comment pattern,group size);
      
@@ -68,7 +68,7 @@ not belong to the list.
 
 File of hosts
 
-A path to a list of hosts. \
+A path to a list of hosts.   
 
 Comment pattern
 
@@ -76,7 +76,7 @@ A pattern that matches a legal comment in the file. The regex is
 unanchored, meaning it may match a partial line (see [Anchored vs.
 unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
-Comments are stripped as the file is read. \
+Comments are stripped as the file is read.   
 
 Group size
 
@@ -86,7 +86,7 @@ nonsensical promises.
 
 Example file:
 
-~~~~ {.smallexample}
+~~~~
      one
      two
      three # this is a comment

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleaders.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleaders.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-peerleaders]
 
 **Synopsis**: peerleaders(arg1,arg2,arg3) returns type **slist**
 
-\
- *arg1* : File name of host list, *in the range* "?(/.\*) \
- *arg2* : Comment regex pattern, *in the range* .\* \
- *arg3* : Peer group size, *in the range* 0,99999999999 \
+  
+ *arg1* : File name of host list, *in the range* "?(/.\*)   
+ *arg2* : Comment regex pattern, *in the range* .\*   
+ *arg3* : Peer group size, *in the range* 0,99999999999   
 
 Get a list of peer leaders from the named partitioning
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent peers
 {
 vars:
@@ -43,10 +43,10 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (slist) peers(file of hosts,comment pattern,group size);
      
@@ -66,7 +66,7 @@ The current host need not belong to this file.
 
 File of hosts
 
-A path to a list of hosts. \
+A path to a list of hosts.   
 
 Comment pattern
 
@@ -74,7 +74,7 @@ A pattern that matches a legal comment in the file. The regex is
 unanchored, meaning it may match a partial line (see [Anchored vs.
 unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
-Comments are stripped as the file is read. \
+Comments are stripped as the file is read.   
 
 Group size
 
@@ -84,7 +84,7 @@ nonsensical promises.
 
 Example file:
 
-~~~~ {.smallexample}
+~~~~
      one
      two
      three # this is a comment

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peers.markdown
@@ -11,18 +11,18 @@ tags: [Special-functions,Function-peers]
 
 **Synopsis**: peers(arg1,arg2,arg3) returns type **slist**
 
-\
- *arg1* : File name of host list, *in the range* "?(/.\*) \
- *arg2* : Comment regex pattern, *in the range* .\* \
- *arg3* : Peer group size, *in the range* 0,99999999999 \
+  
+ *arg1* : File name of host list, *in the range* "?(/.\*)   
+ *arg2* : Comment regex pattern, *in the range* .\*   
+ *arg3* : Peer group size, *in the range* 0,99999999999   
 
 Get a list of peers (not including ourself) from the partition to which
 we belong
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent peers
 {
 vars:
@@ -44,10 +44,10 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (slist) peers(file of hosts,comment pattern,group size);
      
@@ -69,7 +69,7 @@ not belong to the list.
 
 File of hosts
 
-A path to a list of hosts. \
+A path to a list of hosts.   
 
 Comment pattern
 
@@ -77,7 +77,7 @@ A pattern that matches a legal comment in the file. The regex is
 unanchored, meaning it may match a partial line (see [Anchored vs.
 unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
-Comments are stripped as the file is read. \
+Comments are stripped as the file is read.   
 
 Group size
 
@@ -87,7 +87,7 @@ nonsensical promises.
 
 Example file:
 
-~~~~ {.smallexample}
+~~~~
      one
      two
      three # this is a comment

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-product.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-product.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-product]
 
 **Synopsis**: product(arg1) returns type **real**
 
-\
+  
  *arg1* : A list of arbitrary real values, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Return the product of a list of reals
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 {
 vars:
@@ -38,8 +38,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Of course, you could easily combine `product` with `readstringarray` or
 `readreallist` etc., to collect summary information from a source
 external to CFEngine.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-randomint.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-randomint.markdown
@@ -11,25 +11,25 @@ tags: [Special-functions,Function-randomint]
 
 **Synopsis**: randomint(arg1,arg2) returns type **int**
 
-\
+  
  *arg1* : Lower inclusive bound, *in the range* -99999999999,9999999999
-\
+  
  *arg2* : Upper inclusive bound, *in the range* -99999999999,9999999999
-\
+  
 
 Generate a random integer between the given limits
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "ran"    int => randomint(4,88);
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The limits must be integer values and the resulting numbers are based on
 the entropy of the md5 algorithm.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readfile.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readfile.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-readfile]
 
 **Synopsis**: readfile(arg1,arg2) returns type **string**
 
-\
- *arg1* : File name, *in the range* "?(/.\*) \
+  
+ *arg1* : File name, *in the range* "?(/.\*)   
  *arg2* : Maximum number of bytes to read, *in the range* 0,99999999999
-\
+  
 
 Read max number of bytes from named file and assign to variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "xxx"   
@@ -29,7 +29,7 @@ vars:
     string => readfile( "/home/mark/tmp/testfile" , "33" );
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The file (fragment) is read into a single scalar variable.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-readintarray]
 **Synopsis**: readintarray(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : File name to read, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : File name to read, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of integers from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "dim_array" 
@@ -41,11 +41,11 @@ vars:
 array\_name
 
 The name to be used for the container array (the array is filled by this
-routine). \
+routine).   
 
 filename
 
-The name of a text file containing the text to be split up as a list. \
+The name of a text file containing the text to be split up as a list.   
 
 comment
 
@@ -54,29 +54,29 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no comments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Reads a two dimensional array from a file. One dimension is separated by
 the character specified in the argument, the other by the the lines in
 the file. The first field of the lines names the first array argument.
 
-~~~~ {.smallexample}
+~~~~
      
      1: 5:7:21:13
      2:19:8:14:14
@@ -86,7 +86,7 @@ the file. The first field of the lines names the first array argument.
 
 Results in
 
-~~~~ {.smallexample}
+~~~~
      array_name[1][0]   1
      array_name[1][1]   5
      array_name[1][2]   7

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintlist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintlist.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-readintlist]
 **Synopsis**: readintlist(arg1,arg2,arg3,arg4,arg5) returns type
 **ilist**
 
-\
- *arg1* : File name to read, *in the range* "?(/.\*) \
- *arg2* : Regex matching comments, *in the range* .\* \
- *arg3* : Regex to split data, *in the range* .\* \
+  
+ *arg1* : File name to read, *in the range* "?(/.\*)   
+ *arg2* : Regex matching comments, *in the range* .\*   
+ *arg3* : Regex to split data, *in the range* .\*   
  *arg4* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg5* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg5* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read and assign a list variable from a file of separated ints
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -55,7 +55,7 @@ reports:
 
 filename
 
-The name of a text file containing text to be split up as a list. \
+The name of a text file containing text to be split up as a list.   
 
 comment
 
@@ -64,20 +64,20 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no comments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readrealarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readrealarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-readrealarray]
 **Synopsis**: readrealarray(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : File name to read, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : File name to read, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of real numbers from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "dim_array" 
@@ -41,11 +41,11 @@ vars:
 array\_name
 
 The name to be used for the container array (the array is filled by this
-routine). \
+routine).   
 
 filename
 
-The name of a text file containing the text to be split up as a list. \
+The name of a text file containing the text to be split up as a list.   
 
 comment
 
@@ -54,22 +54,22 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no comments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 For detailed notes, See [Function readintarray](#Function-readintarray).

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readreallist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readreallist.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-readreallist]
 **Synopsis**: readreallist(arg1,arg2,arg3,arg4,arg5) returns type
 **rlist**
 
-\
- *arg1* : File name to read, *in the range* "?(/.\*) \
- *arg2* : Regex matching comments, *in the range* .\* \
- *arg3* : Regex to split data, *in the range* .\* \
+  
+ *arg1* : File name to read, *in the range* "?(/.\*)   
+ *arg2* : Regex matching comments, *in the range* .\*   
+ *arg3* : Regex to split data, *in the range* .\*   
  *arg4* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg5* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg5* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read and assign a list variable from a file of separated real numbers
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -55,7 +55,7 @@ reports:
 
 filename
 
-The name of a text file containing text to be split up as a list. \
+The name of a text file containing text to be split up as a list.   
 
 comment
 
@@ -64,20 +64,20 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no comments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarray.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-readstringarray]
 **Synopsis**: readstringarray(arg1,arg2,arg3,arg4,arg5,arg6) returns
 type **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : File name to read, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : File name to read, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of strings from a file and assign the dimension to a
 variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "dim_array" 
@@ -46,11 +46,11 @@ lines matched). If you only want the fields in the first matching line
 array\_name
 
 The name to be used for the container array (the array is filled by this
-routine). \
+routine).   
 
 filename
 
-The name of a text file containing the text to be split up as a list. \
+The name of a text file containing the text to be split up as a list.   
 
 comment
 
@@ -59,29 +59,29 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no comments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Reads a two dimensional array from a file. One dimension is separated by
 the character specified in the argument, the other by the the lines in
 the file. The first field of the lines names the first array argument.
 
-~~~~ {.smallexample}
+~~~~
      
      at:x:25:25:Batch jobs daemon:/var/spool/atjobs:/bin/bash
      avahi:x:103:105:User for Avahi:/var/run/avahi-daemon:/bin/false    # Disallow login
@@ -95,7 +95,7 @@ the file. The first field of the lines names the first array argument.
 Results in a systematically indexed map of the file. Some samples are
 show below to illustrate the pattern.
 
-~~~~ {.smallexample}
+~~~~
      ...
      array_name[daemon][0]   daemon
      array_name[daemon][1]   x

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarrayidx.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarrayidx.markdown
@@ -12,23 +12,23 @@ tags: [Special-functions,Function-readstringarrayidx]
 **Synopsis**: readstringarrayidx(arg1,arg2,arg3,arg4,arg5,arg6) returns
 type **int**
 
-\
+  
  *arg1* : Array identifier to populate, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : A string to parse for input data, *in the range* "?(/.\*) \
- *arg3* : Regex matching comments, *in the range* .\* \
- *arg4* : Regex to split data, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : A string to parse for input data, *in the range* "?(/.\*)   
+ *arg3* : Regex matching comments, *in the range* .\*   
+ *arg4* : Regex to split data, *in the range* .\*   
  *arg5* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg6* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg6* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read an array of strings from a file and assign the dimension to a
 variable with integer indeces
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
   "dim_array" 
@@ -46,11 +46,11 @@ lines matched). If you only want the fields in the first matching line
 array\_name
 
 The name to be used for the container array (the array is filled by this
-routine). \
+routine).   
 
 filename
 
-The name of a text file containing the text to be split up as a list. \
+The name of a text file containing the text to be split up as a list.   
 
 comment
 
@@ -59,23 +59,23 @@ A regex pattern which specifies comments to be ignored in the file. The
 read, leaving unstripped characters to be split into fields. Using the
 empty string (`""`) indicates no commments. The regex is unanchored (See
 [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Reads a two dimensional array from a file. One dimension is separated by
 the character specified in the argument, the other by the the lines in
@@ -83,7 +83,7 @@ the file. The array arguments are both integer indexes, allowing for
 non-identifiers at first field (e.g. duplicates or names with spaces),
 unlike `readstringarray`.
 
-~~~~ {.smallexample}
+~~~~
      
      at spaced:x:25:25:Batch jobs daemon:/var/spool/atjobs:/bin/bash
      duplicate:x:103:105:User for Avahi:/var/run/avahi-daemon:/bin/false    # Disallow login
@@ -97,7 +97,7 @@ unlike `readstringarray`.
 Results in a systematically indexed map of the file. Some samples are
 show below to illustrate the pattern.
 
-~~~~ {.smallexample}
+~~~~
      array_name[0][0]       at spaced
      array_name[0][1]       x
      array_name[0][2]       25

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringlist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringlist.markdown
@@ -12,20 +12,20 @@ tags: [Special-functions,Function-readstringlist]
 **Synopsis**: readstringlist(arg1,arg2,arg3,arg4,arg5) returns type
 **slist**
 
-\
- *arg1* : File name to read, *in the range* "?(/.\*) \
- *arg2* : Regex matching comments, *in the range* .\* \
- *arg3* : Regex to split data, *in the range* .\* \
+  
+ *arg1* : File name to read, *in the range* "?(/.\*)   
+ *arg2* : Regex matching comments, *in the range* .\*   
+ *arg3* : Regex to split data, *in the range* .\*   
  *arg4* : Maximum number of entries to read, *in the range*
-0,99999999999 \
- *arg5* : Maximum bytes to read, *in the range* 0,99999999999 \
+0,99999999999   
+ *arg5* : Maximum bytes to read, *in the range* 0,99999999999   
 
 Read and assign a list variable from a file of separated strings
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -54,7 +54,7 @@ reports:
 
 filename
 
-The name of a text file containing text to be split up as a list. \
+The name of a text file containing text to be split up as a list.   
 
 comment
 
@@ -65,28 +65,28 @@ is unanchored (See [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)).
 **Note** that the text is not treated as a collection of lines, but is
 read as a single block of `maxsize` characters, and the regex is applied
-to that as a single string. \
+to that as a single string.   
 
 split
 
 A regex pattern which is used to parse the field separator(s) to split
-up the file into items. The `split` regex is also unanchored. \
+up the file into items. The `split` regex is also unanchored.   
 
 maxent
 
-The maximum number of list items to read from the file \
+The maximum number of list items to read from the file   
 
 maxsize
 
 The maximum number of bytes to read from the file
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The following example file would be split into a list of the first ten
 Greek letters (alpha through kappa).
 
-~~~~ {.smallexample}
+~~~~
      
      alpha beta
      gamma # This is a comment

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readtcp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readtcp.markdown
@@ -11,19 +11,20 @@ tags: [Special-functions,Function-readtcp]
 
 **Synopsis**: readtcp(arg1,arg2,arg3,arg4) returns type **string**
 
-\
- *arg1* : Host name or IP address of server socket, *in the range* .\* \
- *arg2* : Port number, *in the range* 0,99999999999 \
- *arg3* : Protocol query string, *in the range* .\* \
+  
+ *arg1* : Host name or IP address of server socket, *in the range* .\*
+  
+ *arg2* : Port number, *in the range* 0,99999999999   
+ *arg3* : Protocol query string, *in the range* .\*   
  *arg4* : Maximum number of bytes to read, *in the range* 0,99999999999
-\
+  
 
 Connect to tcp port, send string and assign result to variable
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent example
 
 {     
@@ -49,15 +50,15 @@ reports:
 
 hostnameip
 
-The host name or IP address of a tcp socket. \
+The host name or IP address of a tcp socket.   
 
 port
 
-The port number to connect to. \
+The port number to connect to.   
 
 sendstring
 
-A string to send to the TCP port to elicit a response \
+A string to send to the TCP port to elicit a response   
 
 maxbytes
 
@@ -67,8 +68,8 @@ Important note: not all Unix TCP read operations respond to signals for
 interruption so poorly formed requests can hang. Always test TCP
 connections fully before deploying.
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 If the send string is empty, no data are sent or received from the
 socket. Then the function only tests whether the TCP port is alive and

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regarray.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-regarray]
 
 **Synopsis**: regarray(arg1,arg2) returns type **class**
 
-\
+  
  *arg1* : Cfengine array identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : Regular expression, *in the range* .\* \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : Regular expression, *in the range* .\*   
 
 True if arg1 matches any item in the associative array with id=arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -57,8 +57,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Tests whether an associative array contains elements matching a certain
 regular expression. The result is a class.
@@ -67,7 +67,7 @@ regular expression. The result is a class.
 
 array\_name
 
-The name of the array, with no \$() surrounding it, etc. \
+The name of the array, with no \$() surrounding it, etc.   
 
 regex
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regcmp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regcmp.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-regcmp]
 
 **Synopsis**: regcmp(arg1,arg2) returns type **class**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
- *arg2* : Match string, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
+ *arg2* : Match string, *in the range* .\*   
 
 True if arg1 is a regular expression matching that matches string arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent subtest(user)
 
 {
@@ -40,8 +40,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Compares a string to a regular expression.
 
@@ -52,7 +52,7 @@ regex
 A regular expression to match the content. The regular expression is
 anchored, meaning it must match the complete content (See [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 string
 
@@ -65,7 +65,7 @@ using either standard regular expression syntax or using the additional
 features of PCRE (where `(?ms)` changes the way that ., \^ and \$
 behave), e.g.
 
-~~~~ {.smallexample}
+~~~~
      
      body common control
      {

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regextract.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regextract.markdown
@@ -11,19 +11,19 @@ tags: [Special-functions,Function-regextract]
 
 **Synopsis**: regextract(arg1,arg2,arg3) returns type **class**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
- *arg2* : Match string, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
+ *arg2* : Match string, *in the range* .\*   
  *arg3* : Identifier for back-references, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 True if the regular expression in arg 1 matches the string in arg2 and
 sets a non-empty array of backreferences named arg3
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 {
 classes:
@@ -44,8 +44,8 @@ reports:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 **Arguments:**
 
@@ -54,11 +54,11 @@ reports:
 A regular expression containing one or more parenthesized back
 references. The regular expression is anchored, meaning it must match
 the entire string (See [Anchored vs. unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 *data*
 
-A string to be matched to the regular expression. \
+A string to be matched to the regular expression.   
 
 *identifier*
 
@@ -66,7 +66,7 @@ The name of an array which (if there are any back reference matches from
 the regular expression) will be populated with the values, in the
 manner:
 
-~~~~ {.example}
+~~~~
           $(identifier[0]) = entire string
           $(identifier[1]) = back reference 1, etc
 ~~~~

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-registryvalue.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-registryvalue.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-registryvalue]
 
 **Synopsis**: registryvalue(arg1,arg2) returns type **string**
 
-\
- *arg1* : Windows registry key, *in the range* .\* \
- *arg2* : Windows registry value-id, *in the range* .\* \
+  
+ *arg1* : Windows registry key, *in the range* .\*   
+ *arg2* : Windows registry value-id, *in the range* .\*   
 
 Returns a value for an MS-Win registry key,value pair
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent reg
 {
 vars:
@@ -36,8 +36,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function applies only to Windows-based systems. It reads a data
 field for the value named in the second argument, which lies within the

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regldap.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regldap.markdown
@@ -12,22 +12,22 @@ tags: [Special-functions,Function-regldap]
 **Synopsis**: regldap(arg1,arg2,arg3,arg4,arg5,arg6,arg7) returns type
 **class**
 
-\
- *arg1* : URI, *in the range* .\* \
- *arg2* : Distinguished name, *in the range* .\* \
- *arg3* : Filter, *in the range* .\* \
- *arg4* : Record name, *in the range* .\* \
- *arg5* : Search scope policy, *in the range* subtree,onelevel,base \
- *arg6* : Regex to match results, *in the range* .\* \
- *arg7* : Security level, *in the range* none,ssl,sasl \
+  
+ *arg1* : URI, *in the range* .\*   
+ *arg2* : Distinguished name, *in the range* .\*   
+ *arg3* : Filter, *in the range* .\*   
+ *arg4* : Record name, *in the range* .\*   
+ *arg5* : Search scope policy, *in the range* subtree,onelevel,base   
+ *arg6* : Regex to match results, *in the range* .\*   
+ *arg7* : Security level, *in the range* none,ssl,sasl   
 
 True if the regular expression in arg6 matches a value item in an LDAP
 search.
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 classes:
 
    "found" expression => regldap(
@@ -41,10 +41,10 @@ classes:
                                 );
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
-~~~~ {.example}
+~~~~
      
      (class) regldap(uri,dn,filter,name,scope,regex,security)
      
@@ -58,33 +58,34 @@ expression. If there is a match, true is returned else false.
 
 uri
 
-String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"` \
+String value of the ldap server. e.g. `"ldap://ldap.cfengine.com.no"`   
 
 dn
 
 Distinguished name, an ldap formatted name built from components, e.g.
-"dc=cfengine,dc=com". \
+"dc=cfengine,dc=com".   
 
 filter
 
-String filter criterion, in ldap search, e.g. "(sn=User)". \
+String filter criterion, in ldap search, e.g. "(sn=User)".   
 
 name
 
-String value, the name of a single record to be retrieved, e.g. `uid`. \
+String value, the name of a single record to be retrieved, e.g. `uid`.
+  
 
 scope
 
 Menu option, the type of ldap search, from the specified root. May take
 values:
 
-~~~~ {.smallexample}
+~~~~
               subtree
               onelevel
               base
 ~~~~
 
-\
+  
 
 regex
 
@@ -92,7 +93,7 @@ A regular expression string to match to the results of an LDAP search.
 The regular expression is anchored, meaning it must match the entire
 named field (See [Anchored vs. unanchored regular
 expressions](#Anchored-vs_002e-unanchored-regular-expressions)). If any
-item matches the regex, the result will be true. \
+item matches the regex, the result will be true.   
 
 security
 
@@ -100,7 +101,7 @@ Menu option indicating the encryption and authentication settings for
 communication with the LDAP server. These features might be subject to
 machine and server capabilities.
 
-~~~~ {.smallexample}
+~~~~
                none
                ssl
                sasl

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regline.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regline.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-regline]
 
 **Synopsis**: regline(arg1,arg2) returns type **class**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
- *arg2* : Filename to search, *in the range* .\* \
+  
+ *arg1* : Regular expression, *in the range* .\*   
+ *arg2* : Filename to search, *in the range* .\*   
 
 True if the regular expression in arg1 matches a line in file arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent testbundle
 
 {
@@ -46,8 +46,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Note that the regular expression must match an entire line of the file
 in order to give a true result. This function is useful for `edit_line`
@@ -55,7 +55,7 @@ applications, where one might want to set a class for detecting the
 presence of a string that does not exactly match one being inserted. For
 example:
 
-~~~~ {.verbatim}
+~~~~
 bundle edit_line upgrade_cfexecd
   {
   classes:

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-reglist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-reglist.markdown
@@ -11,17 +11,18 @@ tags: [Special-functions,Function-reglist]
 
 **Synopsis**: reglist(arg1,arg2) returns type **class**
 
-\
- *arg1* : Cfengine list identifier, *in the range* @[(][a-zA-Z0-9]+[)] \
- *arg2* : Regular expression, *in the range* .\* \
+  
+ *arg1* : Cfengine list identifier, *in the range* @[(][a-zA-Z0-9]+[)]
+  
+ *arg2* : Regular expression, *in the range* .\*   
 
 True if the regular expression in arg2 matches any item in the list
 whose id is arg1
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "nameservers" slist => {
@@ -34,8 +35,8 @@ classes:
   "am_name_server" expression => reglist("@(nameservers)",escape("$(sys.ipv4[eth0])"));
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Matches a list of test strings to a regular expression. In the example
 above, the IP address in `$(sys.ipv4[eth0])` must be `escape`d, because
@@ -46,7 +47,7 @@ regular expression "match any" characters.
 
 list
 
-The list of strings to test with the regular expression. \
+The list of strings to test with the regular expression.   
 
 regex
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remoteclassesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remoteclassesmatching.markdown
@@ -12,25 +12,25 @@ tags: [Special-functions,Function-remoteclassesmatching]
 **Synopsis**: remoteclassesmatching(arg1,arg2,arg3,arg4) returns type
 **class**
 
-\
- *arg1* : Regular expression, *in the range* .\* \
- *arg2* : Server name or address, *in the range* .\* \
- *arg3* : Use encryption, *in the range* true,false,yes,no,on,off \
+  
+ *arg1* : Regular expression, *in the range* .\*   
+ *arg2* : Server name or address, *in the range* .\*   
+ *arg3* : Use encryption, *in the range* true,false,yes,no,on,off   
  *arg4* : Return class prefix, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Read persistent classes matching a regular expression from a remote
 cfengine server and add them into local context with prefix
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
  "succeeded" expression => remoteclassesmatching("regex","server","yes","myprefix");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  This function is only available in Enterprise versions of CFEngine
 (Nova, Enterprise, etc).
 
@@ -46,15 +46,15 @@ with a prefix of your choosing. The arguments are:
 *Regular expression*
 
 This should match a list of *persistent* classes of be returned from the
-server, if the server has granted access to them. \
+server, if the server has granted access to them.   
 
 *Server*
 
-The name or IP address of the remote server. \
+The name or IP address of the remote server.   
 
 *Encryption*
 
-Boolean value, whether or not to encrypt communication. \
+Boolean value, whether or not to encrypt communication.   
 
 *Prefix*
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remotescalar.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remotescalar.markdown
@@ -11,25 +11,25 @@ tags: [Special-functions,Function-remotescalar]
 
 **Synopsis**: remotescalar(arg1,arg2,arg3) returns type **string**
 
-\
+  
  *arg1* : Variable identifier, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
- *arg2* : Hostname or IP address of server, *in the range* .\* \
- *arg3* : Use enryption, *in the range* true,false,yes,no,on,off \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
+ *arg2* : Hostname or IP address of server, *in the range* .\*   
+ *arg3* : Use enryption, *in the range* true,false,yes,no,on,off   
 
 Read a scalar value from a remote cfengine server
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 vars:
 
  "remote" string => remotescalar("test_scalar","127.0.0.1","yes");
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  The remote system's cf-serverd must accept the query for the requested
 variable from the host that is requesting it. An example of this
 configuration follows.
@@ -41,7 +41,7 @@ returned preferentially. If no such variable is found, then the server
 will look for a literal string in a server bundle with a handle that
 matches the requested object.
 
-~~~~ {.verbatim}
+~~~~
 bundle server access
 {
 access:
@@ -61,7 +61,7 @@ needed to resolve the absence of a value can lead to undesirable
 behaviour. As a general rule, users are recommended to refrain from
 relying on the availability of network resources.
 
-~~~~ {.example}
+~~~~
      
      (string) remotescalar(resource handle,host/IP address,encrypt);
      
@@ -75,17 +75,17 @@ CFEngine only.
 
 resource handle
 
-The name of the promise on the server side \
+The name of the promise on the server side   
 
 host or IP address
 
-The location of the server on which the resource resides. \
+The location of the server on which the resource resides.   
 
 encrypt
 
 Whether to encrypt the connection to the server.
 
-~~~~ {.smallexample}
+~~~~
                true
                yes
                false

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-returnszero.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-returnszero.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-returnszero]
 
 **Synopsis**: returnszero(arg1,arg2) returns type **class**
 
-\
- *arg1* : Fully qualified command path, *in the range* "?(/.\*) \
- *arg2* : Shell encapsulation option, *in the range* useshell,noshell \
+  
+ *arg1* : Fully qualified command path, *in the range* "?(/.\*)   
+ *arg2* : Shell encapsulation option, *in the range* useshell,noshell   
 
 True if named shell command has exit status zero
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -45,8 +45,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This is the complement of `execresult`, but it returns a class result
 rather than the output of the command.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-rrange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-rrange.markdown
@@ -11,20 +11,20 @@ tags: [Special-functions,Function-rrange]
 
 **Synopsis**: rrange(arg1,arg2) returns type **rrange [real,real]**
 
-\
- *arg1* : Real number, *in the range* -9.99999E100,9.99999E100 \
- *arg2* : Real number, *in the range* -9.99999E100,9.99999E100 \
+  
+ *arg1* : Real number, *in the range* -9.99999E100,9.99999E100   
+ *arg2* : Real number, *in the range* -9.99999E100,9.99999E100   
 
 Define a range of real numbers for cfengine internal use
 
-**Example**:\
- \
-
-~~~~ {.verbatim}
+**Example**:  
+   
 
 ~~~~
 
-**Notes**:\
- \
+~~~~
+
+**Notes**:  
+   
 
 This is not yet used.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-selectservers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-selectservers.markdown
@@ -12,24 +12,24 @@ tags: [Special-functions,Function-selectservers]
 **Synopsis**: selectservers(arg1,arg2,arg3,arg4,arg5,arg6) returns type
 **int**
 
-\
+  
  *arg1* : The identifier of a cfengine list of hosts or addresses to
-contact, *in the range* @[(][a-zA-Z0-9]+[)] \
- *arg2* : The port number, *in the range* 0,99999999999 \
- *arg3* : A query string, *in the range* .\* \
- *arg4* : A regular expression to match success, *in the range* .\* \
+contact, *in the range* @[(][a-zA-Z0-9]+[)]   
+ *arg2* : The port number, *in the range* 0,99999999999   
+ *arg3* : A query string, *in the range* .\*   
+ *arg4* : A regular expression to match success, *in the range* .\*   
  *arg5* : Maximum number of bytes to read from server, *in the range*
-0,99999999999 \
+0,99999999999   
  *arg6* : Name for array of results, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Select tcp servers which respond correctly to a query and return their
 number, set array of names
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -75,8 +75,8 @@ reports:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 This function selects all the TCP ports that are active and functioning
 from an ordered list and builds an array of their names. This allows us
@@ -84,16 +84,16 @@ to select a current list of failover alternatives that are pretested.
 
 hostlist
 
-A list of host names or IP addresses to attempt to connect to. \
+A list of host names or IP addresses to attempt to connect to.   
 
 port
 
-The port number for the service. \
+The port number for the service.   
 
 sendstr
 
 An optional string to send to the server to elicit a response. If
-`sendstr` is empty, then no query is sent to the server. \
+`sendstr` is empty, then no query is sent to the server.   
 
 regex\_on\_reply
 
@@ -105,11 +105,11 @@ taken to ensure that you match the newlines, too (note the use of `(?s)`
 in the example above, which allows . to also match newlines in the
 multi-line HTTP response). If `regex_on_reply` is empty, then no
 reply-checking is performed (and any server reply is deemed to be
-satisfactory). \
+satisfactory).   
 
 maxbytesread\_reply
 
-The maximum number of bytes to read as the server's reply. \
+The maximum number of bytes to read as the server's reply.   
 
 array\_name
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splayclass.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splayclass.markdown
@@ -11,17 +11,17 @@ tags: [Special-functions,Function-splayclass]
 
 **Synopsis**: splayclass(arg1,arg2) returns type **class**
 
-\
- *arg1* : Input string for classification, *in the range* .\* \
- *arg2* : Splay time policy, *in the range* daily,hourly \
+  
+ *arg1* : Input string for classification, *in the range* .\*   
+ *arg2* : Splay time policy, *in the range* daily,hourly   
 
 True if the first argument's time-slot has arrived, according to a
 policy in arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -46,8 +46,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 The lvalue class evaluates to true if the system clock lies within a
 scheduled time-interval that maps to a hash of the first argument (which

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splitstring.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splitstring.markdown
@@ -11,18 +11,18 @@ tags: [Special-functions,Function-splitstring]
 
 **Synopsis**: splitstring(arg1,arg2,arg3) returns type **slist**
 
-\
- *arg1* : A data string, *in the range* .\* \
- *arg2* : Regex to split on, *in the range* .\* \
- *arg3* : Maximum number of pieces, *in the range* 0,99999999999 \
+  
+ *arg1* : A data string, *in the range* .\*   
+ *arg2* : Regex to split on, *in the range* .\*   
+ *arg3* : Maximum number of pieces, *in the range* 0,99999999999   
 
 Convert a string in arg1 into a list of max arg3 strings by splitting on
 a regular expression in arg2
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 bundle agent test
 
 {
@@ -43,8 +43,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Returns a list of strings from a string.
 
@@ -52,14 +52,14 @@ Returns a list of strings from a string.
 
 string
 
-The string to be split. \
+The string to be split.   
 
 regex
 
 A regex pattern which is used to parse the field separator(s) to split
 up the file into items. The regex is unanchored (See [Anchored vs.
 unanchored regular
-expressions](#Anchored-vs_002e-unanchored-regular-expressions)). \
+expressions](#Anchored-vs_002e-unanchored-regular-expressions)).   
 
 maxent
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-strcmp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-strcmp.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-strcmp]
 
 **Synopsis**: strcmp(arg1,arg2) returns type **class**
 
-\
- *arg1* : String, *in the range* .\* \
- *arg2* : String, *in the range* .\* \
+  
+ *arg1* : String, *in the range* .\*   
+ *arg2* : String, *in the range* .\*   
 
 True if the two strings match exactly
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 
 {
@@ -48,5 +48,5 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-sum.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-sum.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-sum]
 
 **Synopsis**: sum(arg1) returns type **real**
 
-\
+  
  *arg1* : A list of arbitrary real values, *in the range*
-[a-zA-Z0-9\_\$(){}\\[\\].:]+ \
+[a-zA-Z0-9\_\$(){}\\[\\].:]+   
 
 Return the sum of a list of reals
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -45,12 +45,12 @@ reports:
 Because `$(six)` and `$(zero)` are both real numbers, the report that is
 generated will be:
 
-~~~~ {.verbatim}
+~~~~
 six is 6.000000, zero is 0.000000
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
  Of course, you could easily combine `sum` with `readstringarray` or
 `readreallist` etc., to collect summary information from a source
 external to CFEngine.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-translatepath.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-translatepath.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-translatepath]
 
 **Synopsis**: translatepath(arg1) returns type **string**
 
-\
- *arg1* : Unix style path, *in the range* "?(/.\*) \
+  
+ *arg1* : Unix style path, *in the range* "?(/.\*)   
 
 Translate path separators from Unix style to the host's native
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
 {
 bundlesequence => { "test" };
@@ -42,8 +42,8 @@ reports:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Takes a string argument with slashes as path separators and translate
 these to the native format for path separators on the host. For example

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-usemodule.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-usemodule.markdown
@@ -11,16 +11,16 @@ tags: [Special-functions,Function-usemodule]
 
 **Synopsis**: usemodule(arg1,arg2) returns type **class**
 
-\
- *arg1* : Name of module command, *in the range* .\* \
- *arg2* : Argument string for the module, *in the range* .\* \
+  
+ *arg1* : Name of module command, *in the range* .\*   
+ *arg2* : Argument string for the module, *in the range* .\*   
 
 Execute cfengine module script and set class if successful
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 body common control
    {
    any::
@@ -47,8 +47,8 @@ commands:
 }
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Modules must reside in WORKDIR/modules but no longer require a special
 naming convention.
@@ -58,7 +58,7 @@ naming convention.
 Module name
 
 The name of the module without its leading path, since it is assumed to
-be in the registered modules directory. \
+be in the registered modules directory.   
 
 Argument string
 

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-userexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-userexists.markdown
@@ -11,15 +11,15 @@ tags: [Special-functions,Function-userexists]
 
 **Synopsis**: userexists(arg1) returns type **class**
 
-\
- *arg1* : User name or identifier, *in the range* .\* \
+  
+ *arg1* : User name or identifier, *in the range* .\*   
 
 True if user name or numerical id exists on this host
 
-**Example**:\
- \
+**Example**:  
+   
 
-~~~~ {.verbatim}
+~~~~
 
 body common control
 
@@ -49,8 +49,8 @@ reports:
 
 ~~~~
 
-**Notes**:\
- \
+**Notes**:  
+   
 
 Checks whether the user is in the password database for the current
 host. The argument must be a user name or user id.

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Introduction-to-functions.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Introduction-to-functions.markdown
@@ -9,7 +9,7 @@ tags: [Special-functions,Introduction-to-functions]
 
 ### Introduction to Functions
 
-\
+  
  There are a large number of functions built into CFEngine, and finding
 the right one to use can be a daunting task. The following tables are
 designed to make it easier for you to find the function you need, based
@@ -19,96 +19,187 @@ on the value or type that the function returns or processes as inputs.
 
 ##### Functions That Return Class
 
-  ---------------------------------------------------------- -------------------------------------- ------------------------------------------ -------------------------------------- ------------------------------------------
-  [accessedbefore](#Function-accessedbefore)                 [and](#Function-and)                   [changedbefore](#Function-changedbefore)   [classify](#Function-classify)         [classmatch](#Function-classmatch) \
-                                                                                                                                                                                      
-
-  [concat](#Function-concat)                                 [fileexists](#Function-fileexists)     [filesexist](#Function-filesexist)         [groupexists](#Function-groupexists)   [hashmatch](#Function-hashmatch) \
-                                                                                                                                                                                      
-
-  [hostinnetgroup](#Function-hostinnetgroup)                 [hostrange](#Function-hostrange)       [iprange](#Function-iprange)               [isdir](#Function-isdir)               [isexecutable](#Function-isexecutable) \
-                                                                                                                                                                                      
-
-  [isgreaterthan](#Function-isgreaterthan)                   [islessthan](#Function-islessthan)     [islink](#Function-islink)                 [isnewerthan](#Function-isnewerthan)   [isplain](#Function-isplain) \
-                                                                                                                                                                                      
-
-  [isvariable](#Function-isvariable)                         [ldaparray](#Function-ldaparray)       [or](#Function-or)                         [not](#Function-not)                   [regarray](#Function-regarray) \
-                                                                                                                                                                                      
-
-  [regcmp](#Function-regcmp)                                 [regextract](#Function-regextract)     [regldap](#Function-regldap)               [regline](#Function-regline)           [reglist](#Function-reglist) \
-                                                                                                                                                                                      
-
-  [remoteclassesmatching](#Function-remoteclassesmatching)   [returnszero](#Function-returnszero)   [splayclass](#Function-splayclass)         [strcmp](#Function-strcmp)             [usemodule](#Function-usemodule) \
-                                                                                                                                                                                      
-
-  [userexists](#Function-userexists) \
-  ---------------------------------------------------------- -------------------------------------- ------------------------------------------ -------------------------------------- ------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-accessedbefore">accessedbefore</a></td>
+<td align="left"><a href="#Function-and">and</a></td>
+<td align="left"><a href="#Function-changedbefore">changedbefore</a></td>
+<td align="left"><a href="#Function-classify">classify</a></td>
+<td align="left"><a href="#Function-classmatch">classmatch</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-concat">concat</a></td>
+<td align="left"><a href="#Function-fileexists">fileexists</a></td>
+<td align="left"><a href="#Function-filesexist">filesexist</a></td>
+<td align="left"><a href="#Function-groupexists">groupexists</a></td>
+<td align="left"><a href="#Function-hashmatch">hashmatch</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-hostinnetgroup">hostinnetgroup</a></td>
+<td align="left"><a href="#Function-hostrange">hostrange</a></td>
+<td align="left"><a href="#Function-iprange">iprange</a></td>
+<td align="left"><a href="#Function-isdir">isdir</a></td>
+<td align="left"><a href="#Function-isexecutable">isexecutable</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-isgreaterthan">isgreaterthan</a></td>
+<td align="left"><a href="#Function-islessthan">islessthan</a></td>
+<td align="left"><a href="#Function-islink">islink</a></td>
+<td align="left"><a href="#Function-isnewerthan">isnewerthan</a></td>
+<td align="left"><a href="#Function-isplain">isplain</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-isvariable">isvariable</a></td>
+<td align="left"><a href="#Function-ldaparray">ldaparray</a></td>
+<td align="left"><a href="#Function-or">or</a></td>
+<td align="left"><a href="#Function-not">not</a></td>
+<td align="left"><a href="#Function-regarray">regarray</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-regcmp">regcmp</a></td>
+<td align="left"><a href="#Function-regextract">regextract</a></td>
+<td align="left"><a href="#Function-regldap">regldap</a></td>
+<td align="left"><a href="#Function-regline">regline</a></td>
+<td align="left"><a href="#Function-reglist">reglist</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-remoteclassesmatching">remoteclassesmatching</a></td>
+<td align="left"><a href="#Function-returnszero">returnszero</a></td>
+<td align="left"><a href="#Function-splayclass">splayclass</a></td>
+<td align="left"><a href="#Function-strcmp">strcmp</a></td>
+<td align="left"><a href="#Function-usemodule">usemodule</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-userexists">userexists</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Return (i,r,s)List
 
-  ---------------------------------------- -------------------------------- -------------------------------------- ---------------------------------------- ----------------------------------------------
-  [getindices](#Function-getindices)       [getusers](#Function-getusers)   [grep](#Function-grep)                 [ldaplist](#Function-ldaplist)           [maplist](#Function-maplist) \
-                                                                                                                                                            
-
-  [peerleaders](#Function-peerleaders)     [peers](#Function-peers)         [readintlist](#Function-readintlist)   [readreallist](#Function-readreallist)   [readstringlist](#Function-readstringlist) \
-                                                                                                                                                            
-
-  [splitstring](#Function-splitstring) \
-  ---------------------------------------- -------------------------------- -------------------------------------- ---------------------------------------- ----------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-getindices">getindices</a></td>
+<td align="left"><a href="#Function-getusers">getusers</a></td>
+<td align="left"><a href="#Function-grep">grep</a></td>
+<td align="left"><a href="#Function-ldaplist">ldaplist</a></td>
+<td align="left"><a href="#Function-maplist">maplist</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-peerleaders">peerleaders</a></td>
+<td align="left"><a href="#Function-peers">peers</a></td>
+<td align="left"><a href="#Function-readintlist">readintlist</a></td>
+<td align="left"><a href="#Function-readreallist">readreallist</a></td>
+<td align="left"><a href="#Function-readstringlist">readstringlist</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-splitstring">splitstring</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Return Int
 
-  ---------------------------------------- ------------------------------------------ ---------------------------------------------------- ---------------------------------------------------- --------------------------------------------
-  [accumulated](#Function-accumulated)     [ago](#Function-ago)                       [countlinesmatching](#Function-countlinesmatching)   [diskfree](#Function-diskfree)                       [getfields](#Function-getfields) \
-                                                                                                                                                                                                
-
-  [getgid](#Function-getgid)               [getuid](#Function-getuid)                 [now](#Function-now)                                 [on](#Function-on)                                   [randomint](#Function-randomint) \
-                                                                                                                                                                                                
-
-  [readintarray](#Function-readintarray)   [readrealarray](#Function-readrealarray)   [readstringarray](#Function-readstringarray)         [readstringarrayidx](#Function-readstringarrayidx)   [selectservers](#Function-selectservers) \
-                                                                                                                                                                                                
-  ---------------------------------------- ------------------------------------------ ---------------------------------------------------- ---------------------------------------------------- --------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-accumulated">accumulated</a></td>
+<td align="left"><a href="#Function-ago">ago</a></td>
+<td align="left"><a href="#Function-countlinesmatching">countlinesmatching</a></td>
+<td align="left"><a href="#Function-diskfree">diskfree</a></td>
+<td align="left"><a href="#Function-getfields">getfields</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-getgid">getgid</a></td>
+<td align="left"><a href="#Function-getuid">getuid</a></td>
+<td align="left"><a href="#Function-now">now</a></td>
+<td align="left"><a href="#Function-on">on</a></td>
+<td align="left"><a href="#Function-randomint">randomint</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-readintarray">readintarray</a></td>
+<td align="left"><a href="#Function-readrealarray">readrealarray</a></td>
+<td align="left"><a href="#Function-readstringarray">readstringarray</a></td>
+<td align="left"><a href="#Function-readstringarrayidx">readstringarrayidx</a></td>
+<td align="left"><a href="#Function-selectservers">selectservers</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Return (i,r)Range
 
-  ---------------------------- ------------------------------
-  [irange](#Function-irange)   [rrange](#Function-rrange) \
-                               
-  ---------------------------- ------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-irange">irange</a></td>
+<td align="left"><a href="#Function-rrange">rrange</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Return Real
 
-  ------------------------------ ------------------------
-  [product](#Function-product)   [sum](#Function-sum) \
-                                 
-  ------------------------------ ------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-product">product</a></td>
+<td align="left"><a href="#Function-sum">sum</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Return String
 
-  -------------------------------------------- ---------------------------------- ------------------------------------ ------------------------------------------ ------------------------------------------
-  [canonify](#Function-canonify)               [escape](#Function-escape)         [execresult](#Function-execresult)   [getenv](#Function-getenv)                 [hash](#Function-hash) \
-                                                                                                                                                                  
-
-  [host2ip](#Function-host2ip)                 [hostsseen](#Function-hostsseen)   [join](#Function-join)               [lastnode](#Function-lastnode)             [ldapvalue](#Function-ldapvalue) \
-                                                                                                                                                                  
-
-  [peerleader](#Function-peerleader)           [readfile](#Function-readfile)     [readtcp](#Function-readtcp)         [registryvalue](#Function-registryvalue)   [remotescalar](#Function-remotescalar) \
-                                                                                                                                                                  
-
-  [translatepath](#Function-translatepath) \
-  -------------------------------------------- ---------------------------------- ------------------------------------ ------------------------------------------ ------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-canonify">canonify</a></td>
+<td align="left"><a href="#Function-escape">escape</a></td>
+<td align="left"><a href="#Function-execresult">execresult</a></td>
+<td align="left"><a href="#Function-getenv">getenv</a></td>
+<td align="left"><a href="#Function-hash">hash</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-host2ip">host2ip</a></td>
+<td align="left"><a href="#Function-hostsseen">hostsseen</a></td>
+<td align="left"><a href="#Function-join">join</a></td>
+<td align="left"><a href="#Function-lastnode">lastnode</a></td>
+<td align="left"><a href="#Function-ldapvalue">ldapvalue</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-peerleader">peerleader</a></td>
+<td align="left"><a href="#Function-readfile">readfile</a></td>
+<td align="left"><a href="#Function-readtcp">readtcp</a></td>
+<td align="left"><a href="#Function-registryvalue">registryvalue</a></td>
+<td align="left"><a href="#Function-remotescalar">remotescalar</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-translatepath">translatepath</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions That Fill Arrays
 
 The following functions all fill arrays, although they return values
 that depend on the number of items processed.
 
-  -------------------------------------- ---------------------------------------- ------------------------------------------ ---------------------------------------------- ------------------------------------------------------
-  [getfields](#Function-getfields)       [readintarray](#Function-readintarray)   [readrealarray](#Function-readrealarray)   [readstringarray](#Function-readstringarray)   [readstringarrayidx](#Function-readstringarrayidx) \
-                                                                                                                                                                            
-
-  [regextract](#Function-regextract) \
-  -------------------------------------- ---------------------------------------- ------------------------------------------ ---------------------------------------------- ------------------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-getfields">getfields</a></td>
+<td align="left"><a href="#Function-readintarray">readintarray</a></td>
+<td align="left"><a href="#Function-readrealarray">readrealarray</a></td>
+<td align="left"><a href="#Function-readstringarray">readstringarray</a></td>
+<td align="left"><a href="#Function-readstringarrayidx">readstringarrayidx</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-regextract">regextract</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions That Read Large Data
 
@@ -118,151 +209,267 @@ arrays, etc.).
 
 ##### Functions That Read Arrays
 
-  -------------------------------------- ----------------------------------
-  [getindices](#Function-getindices) \
-
-  [getvalues](#Function-getvalues)       [regarray](#Function-regarray) \
-                                         
-  -------------------------------------- ----------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-getindices">getindices</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-getvalues">getvalues</a></td>
+<td align="left"><a href="#Function-regarray">regarray</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read Disk Data
 
-  ----------------------------------
-  [diskfree](#Function-diskfree) \
-  ----------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-diskfree">diskfree</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read From a Remote-CFEngine
 
-  ---------------------------------------------------------- ------------------------------------------
-  [remoteclassesmatching](#Function-remoteclassesmatching)   [remotescalar](#Function-remotescalar) \
-                                                             
-  ---------------------------------------------------------- ------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-remoteclassesmatching">remoteclassesmatching</a></td>
+<td align="left"><a href="#Function-remotescalar">remotescalar</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read Classes
 
-  ---------------------- -------------------------------- ------------------------------------ ---------------------------- ------------------------
-  [and](#Function-and)   [classify](#Function-classify)   [classmatch](#Function-classmatch)   [concat](#Function-concat)   [not](#Function-not) \
-                                                                                                                            
-
-  [or](#Function-or) \
-  ---------------------- -------------------------------- ------------------------------------ ---------------------------- ------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-and">and</a></td>
+<td align="left"><a href="#Function-classify">classify</a></td>
+<td align="left"><a href="#Function-classmatch">classmatch</a></td>
+<td align="left"><a href="#Function-concat">concat</a></td>
+<td align="left"><a href="#Function-not">not</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-or">or</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read Command Output
 
-  ------------------------------------ -------------------------------------- ------------------------------------
-  [execresult](#Function-execresult)   [returnszero](#Function-returnszero)   [usemodule](#Function-usemodule) \
-                                                                              
-  ------------------------------------ -------------------------------------- ------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-execresult">execresult</a></td>
+<td align="left"><a href="#Function-returnszero">returnszero</a></td>
+<td align="left"><a href="#Function-usemodule">usemodule</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read the Environment
 
-  ------------------------------
-  [getenv](#Function-getenv) \
-  ------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-getenv">getenv</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read Files
 
-  ---------------------------------------------------- ---------------------------------------- ---------------------------------------------- ---------------------------------------------------- ----------------------------------------------
-  [countlinesmatching](#Function-countlinesmatching)   [getfields](#Function-getfields)         [getusers](#Function-getusers)                 [hashmatch](#Function-hashmatch)                     [peerleader](#Function-peerleader) \
-                                                                                                                                                                                                    
-
-  [peerleaders](#Function-peerleaders)                 [peers](#Function-peers)                 [readfile](#Function-readfile)                 [readintarray](#Function-readintarray)               [readintlist](#Function-readintlist) \
-                                                                                                                                                                                                    
-
-  [readrealarray](#Function-readrealarray)             [readreallist](#Function-readreallist)   [readstringarray](#Function-readstringarray)   [readstringarrayidx](#Function-readstringarrayidx)   [readstringlist](#Function-readstringlist) \
-                                                                                                                                                                                                    
-
-  [regline](#Function-regline) \
-  ---------------------------------------------------- ---------------------------------------- ---------------------------------------------- ---------------------------------------------------- ----------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-countlinesmatching">countlinesmatching</a></td>
+<td align="left"><a href="#Function-getfields">getfields</a></td>
+<td align="left"><a href="#Function-getusers">getusers</a></td>
+<td align="left"><a href="#Function-hashmatch">hashmatch</a></td>
+<td align="left"><a href="#Function-peerleader">peerleader</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-peerleaders">peerleaders</a></td>
+<td align="left"><a href="#Function-peers">peers</a></td>
+<td align="left"><a href="#Function-readfile">readfile</a></td>
+<td align="left"><a href="#Function-readintarray">readintarray</a></td>
+<td align="left"><a href="#Function-readintlist">readintlist</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-readrealarray">readrealarray</a></td>
+<td align="left"><a href="#Function-readreallist">readreallist</a></td>
+<td align="left"><a href="#Function-readstringarray">readstringarray</a></td>
+<td align="left"><a href="#Function-readstringarrayidx">readstringarrayidx</a></td>
+<td align="left"><a href="#Function-readstringlist">readstringlist</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-regline">regline</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read LDAP Data
 
-  ---------------------------------- -------------------------------- ---------------------------------- --------------------------------
-  [ldaparray](#Function-ldaparray)   [ldaplist](#Function-ldaplist)   [ldapvalue](#Function-ldapvalue)   [regldap](#Function-regldap) \
-                                                                                                         
-  ---------------------------------- -------------------------------- ---------------------------------- --------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-ldaparray">ldaparray</a></td>
+<td align="left"><a href="#Function-ldaplist">ldaplist</a></td>
+<td align="left"><a href="#Function-ldapvalue">ldapvalue</a></td>
+<td align="left"><a href="#Function-regldap">regldap</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read From the Network
 
-  ------------------------------ --------------------------------------------
-  [readtcp](#Function-readtcp)   [selectservers](#Function-selectservers) \
-                                 
-  ------------------------------ --------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-readtcp">readtcp</a></td>
+<td align="left"><a href="#Function-selectservers">selectservers</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read the Windows Registry
 
-  --------------------------------------------
-  [registryvalue](#Function-registryvalue) \
-  --------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-registryvalue">registryvalue</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read (i,r,s)Lists
 
-  -------------------------------- --------------------------
-  [grep](#Function-grep)           [join](#Function-join) \
-                                   
-
-  [product](#Function-product) \
-
-  [reglist](#Function-reglist) \
-
-  [sum](#Function-sum) \
-  -------------------------------- --------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-grep">grep</a></td>
+<td align="left"><a href="#Function-join">join</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-product">product</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-reglist">reglist</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-sum">sum</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 ##### Functions That Read Strings
 
-  ---------------------------- -------------------------------------------- ---------------------------- ------------------------------------ ----------------------------------------
-  [hash](#Function-hash)       [lastnode](#Function-lastnode)               [regcmp](#Function-regcmp)   [regextract](#Function-regextract)   [splitstring](#Function-splitstring) \
-                                                                                                                                              
-
-  [strcmp](#Function-strcmp)   [translatepath](#Function-translatepath) \
-                               
-  ---------------------------- -------------------------------------------- ---------------------------- ------------------------------------ ----------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-hash">hash</a></td>
+<td align="left"><a href="#Function-lastnode">lastnode</a></td>
+<td align="left"><a href="#Function-regcmp">regcmp</a></td>
+<td align="left"><a href="#Function-regextract">regextract</a></td>
+<td align="left"><a href="#Function-splitstring">splitstring</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-strcmp">strcmp</a></td>
+<td align="left"><a href="#Function-translatepath">translatepath</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions That Look at File Metadata
 
 The following functions examine file metadata, but don't use the
 contents of the file.
 
-  -------------------------------------------- ------------------------------------------ ------------------------------------ ------------------------------------ ----------------------------
-  [accessedbefore](#Function-accessedbefore)   [changedbefore](#Function-changedbefore)   [fileexists](#Function-fileexists)   [filesexist](#Function-filesexist)   [isdir](#Function-isdir) \
-                                                                                                                                                                    
-
-  [islink](#Function-islink)                   [isnewerthan](#Function-isnewerthan)       [isplain](#Function-isplain) \
-                                                                                          
-  -------------------------------------------- ------------------------------------------ ------------------------------------ ------------------------------------ ----------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-accessedbefore">accessedbefore</a></td>
+<td align="left"><a href="#Function-changedbefore">changedbefore</a></td>
+<td align="left"><a href="#Function-fileexists">fileexists</a></td>
+<td align="left"><a href="#Function-filesexist">filesexist</a></td>
+<td align="left"><a href="#Function-isdir">isdir</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-islink">islink</a></td>
+<td align="left"><a href="#Function-isnewerthan">isnewerthan</a></td>
+<td align="left"><a href="#Function-isplain">isplain</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions That Look at Variables
 
-  ------------------------------------------ ------------------------------------ --------------------------------------
-  [isgreaterthan](#Function-isgreaterthan)   [islessthan](#Function-islessthan)   [isvariable](#Function-isvariable) \
-                                                                                  
-  ------------------------------------------ ------------------------------------ --------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-isgreaterthan">isgreaterthan</a></td>
+<td align="left"><a href="#Function-islessthan">islessthan</a></td>
+<td align="left"><a href="#Function-isvariable">isvariable</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions Involving Date or Time
 
 The following functions all do date or time computation
 
-  -------------------------------------------- -------------------------------------- -------------------------------------- ------------------------------------------ ----------------------------------------
-  [accessedbefore](#Function-accessedbefore)   [accumulated](#Function-accumulated)   [ago](#Function-ago)                   [changedbefore](#Function-changedbefore)   [isnewerthan](#Function-isnewerthan) \
-                                                                                                                                                                        
-
-  [now](#Function-now)                         [on](#Function-on)                     [splayclass](#Function-splayclass) \
-                                                                                      
-  -------------------------------------------- -------------------------------------- -------------------------------------- ------------------------------------------ ----------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-accessedbefore">accessedbefore</a></td>
+<td align="left"><a href="#Function-accumulated">accumulated</a></td>
+<td align="left"><a href="#Function-ago">ago</a></td>
+<td align="left"><a href="#Function-changedbefore">changedbefore</a></td>
+<td align="left"><a href="#Function-isnewerthan">isnewerthan</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-now">now</a></td>
+<td align="left"><a href="#Function-on">on</a></td>
+<td align="left"><a href="#Function-splayclass">splayclass</a> <br /></td>
+</tr>
+</tbody>
+</table>
 
 #### Functions That Work With or On Regular Expressions
 
-  ---------------------------------------------------- ---------------------------------------------------- ------------------------------------------ ---------------------------------------- ------------------------------------------------
-  [classmatch](#Function-classmatch)                   [countlinesmatching](#Function-countlinesmatching)   [escape](#Function-escape)                 [getfields](#Function-getfields)         [grep](#Function-grep) \
-                                                                                                                                                                                                
-
-  [readintarray](#Function-readintarray)               [readintlist](#Function-readintlist)                 [readrealarray](#Function-readrealarray)   [readreallist](#Function-readreallist)   [readstringarray](#Function-readstringarray) \
-                                                                                                                                                                                                
-
-  [readstringarrayidx](#Function-readstringarrayidx)   [readstringlist](#Function-readstringlist)           [regarray](#Function-regarray)             [regcmp](#Function-regcmp)               [regextract](#Function-regextract) \
-                                                                                                                                                                                                
-
-  [regldap](#Function-regldap)                         [regline](#Function-regline)                         [reglist](#Function-reglist)               [splitstring](#Function-splitstring) \
-                                                                                                                                                       
-  ---------------------------------------------------- ---------------------------------------------------- ------------------------------------------ ---------------------------------------- ------------------------------------------------
+<table>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="#Function-classmatch">classmatch</a></td>
+<td align="left"><a href="#Function-countlinesmatching">countlinesmatching</a></td>
+<td align="left"><a href="#Function-escape">escape</a></td>
+<td align="left"><a href="#Function-getfields">getfields</a></td>
+<td align="left"><a href="#Function-grep">grep</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-readintarray">readintarray</a></td>
+<td align="left"><a href="#Function-readintlist">readintlist</a></td>
+<td align="left"><a href="#Function-readrealarray">readrealarray</a></td>
+<td align="left"><a href="#Function-readreallist">readreallist</a></td>
+<td align="left"><a href="#Function-readstringarray">readstringarray</a> <br /></td>
+</tr>
+<tr class="odd">
+<td align="left"><a href="#Function-readstringarrayidx">readstringarrayidx</a></td>
+<td align="left"><a href="#Function-readstringlist">readstringlist</a></td>
+<td align="left"><a href="#Function-regarray">regarray</a></td>
+<td align="left"><a href="#Function-regcmp">regcmp</a></td>
+<td align="left"><a href="#Function-regextract">regextract</a> <br /></td>
+</tr>
+<tr class="even">
+<td align="left"><a href="#Function-regldap">regldap</a></td>
+<td align="left"><a href="#Function-regline">regline</a></td>
+<td align="left"><a href="#Function-reglist">reglist</a></td>
+<td align="left"><a href="#Function-splitstring">splitstring</a> <br /></td>
+</tr>
+</tbody>
+</table>
 


### PR DESCRIPTION
Modified scripts/chapterparser.py to produce more strict markdown. This required the installation of a non-repo version of pandoc, from the cabal tool, which is part of the haskell platform. This commit includes the output based on those modifications in subdirectoru bundles-logs-functions-variables.
