### PR TITLE
Fix note about concatenation of search_mode in file_select

### DIFF
--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
@@ -2639,7 +2639,7 @@ of appropriate regular expressions.
    
 
 The mode may be specified in symbolic or numerical form with + and -
-constraints. Concatenation `ug+s` implies `u` OR `g`, and `u+g,u+s`
+constraints. Concatenation `ug+s` implies `u` OR `g`, and `u+s,g+s`
 implies `u` AND `g`.   
 
 `search_size`


### PR DESCRIPTION
closes redmine #2593
https://cfengine.com/dev/issues/2593
