### PR TITLE
Remove references to exclamation control in agent

### DIFF
--- a/components/cf-agent/agent_control_promises.markdown
+++ b/components/cf-agent/agent_control_promises.markdown
@@ -582,35 +582,6 @@ e.g.
 
 
 
-## `exclamation`
-
-**Type**: (menu option)
-
-**Allowed input range**:
-
-       true
-       false
-       yes
-       no
-       on
-       off
-
-**Default value:** true
-
-**Synopsis**: true/false print exclamation marks during security
-warnings
-
-    body agent control
-    {
-    exclamation => "false";
-    }
-
-**Notes**:
-
-This affects only the output format of warnings.
-
-
-
 ## `expireafter`
 
 **Type**: int


### PR DESCRIPTION
It has been deprecated.
