### PR TITLE
Made metadata of markdown files more human friendly

### DIFF
--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fline-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Miscellaneous-in-edit_005fline-promises
-categories: [Bundles-for-agent,Miscellaneous-in-edit_005fline-promises]
+title: Miscellaneous in edit fline promises
+categories: [Bundles-for-agent,Miscellaneous-in-edit-fline-promises]
 published: true
-alias: Bundles-for-agent-Miscellaneous-in-edit_005fline-promises.html
-tags: [Bundles-for-agent,Miscellaneous-in-edit_005fline-promises]
+alias: Bundles-for-agent-Miscellaneous-in-edit-fline-promises.html
+tags: [Bundles for agent,Miscellaneous in edit fline promises]
 ---
 
 ### Miscelleneous in `edit_line` promises

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-Miscellaneous-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Miscellaneous-in-edit_005fxml-promises
-categories: [Bundles-for-agent,Miscellaneous-in-edit_005fxml-promises]
+title: Miscellaneous in edit fxml promises
+categories: [Bundles-for-agent,Miscellaneous-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-Miscellaneous-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,Miscellaneous-in-edit_005fxml-promises]
+alias: Bundles-for-agent-Miscellaneous-in-edit-fxml-promises.html
+tags: [Bundles for agent,Miscellaneous in edit fxml promises]
 ---
 
 ### Miscelleneous in `edit_xml` promises

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-build_005fxpath-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-build_005fxpath-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: build_005fxpath-in-edit_005fxml-promises
-categories: [Bundles-for-agent,build_005fxpath-in-edit_005fxml-promises]
+title: build fxpath in edit fxml promises
+categories: [Bundles-for-agent,build-fxpath-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-build_005fxpath-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,build_005fxpath-in-edit_005fxml-promises]
+alias: Bundles-for-agent-build-fxpath-in-edit-fxml-promises.html
+tags: [Bundles for agent,build fxpath in edit fxml promises]
 ---
 
 ### `build_xpath` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-commands-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-commands-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: commands-in-agent-promises
+title: commands in agent promises
 categories: [Bundles-for-agent,commands-in-agent-promises]
 published: true
 alias: Bundles-for-agent-commands-in-agent-promises.html
-tags: [Bundles-for-agent,commands-in-agent-promises]
+tags: [Bundles for agent,commands in agent promises]
 ---
 
 ### `commands` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-databases-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-databases-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: databases-in-agent-promises
+title: databases in agent promises
 categories: [Bundles-for-agent,databases-in-agent-promises]
 published: true
 alias: Bundles-for-agent-databases-in-agent-promises.html
-tags: [Bundles-for-agent,databases-in-agent-promises]
+tags: [Bundles for agent,databases in agent promises]
 ---
 
 ### `databases` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005fattribute-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005fattribute-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: delete_005fattribute-in-edit_005fxml-promises
-categories: [Bundles-for-agent,delete_005fattribute-in-edit_005fxml-promises]
+title: delete fattribute in edit fxml promises
+categories: [Bundles-for-agent,delete-fattribute-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-delete_005fattribute-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,delete_005fattribute-in-edit_005fxml-promises]
+alias: Bundles-for-agent-delete-fattribute-in-edit-fxml-promises.html
+tags: [Bundles for agent,delete fattribute in edit fxml promises]
 ---
 
 ### `delete_attribute` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005flines-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005flines-in-edit_005fline-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: delete_005flines-in-edit_005fline-promises
-categories: [Bundles-for-agent,delete_005flines-in-edit_005fline-promises]
+title: delete flines in edit fline promises
+categories: [Bundles-for-agent,delete-flines-in-edit-fline-promises]
 published: true
-alias: Bundles-for-agent-delete_005flines-in-edit_005fline-promises.html
-tags: [Bundles-for-agent,delete_005flines-in-edit_005fline-promises]
+alias: Bundles-for-agent-delete-flines-in-edit-fline-promises.html
+tags: [Bundles for agent,delete flines in edit fline promises]
 ---
 
 ### `delete_lines` promises in edit\_line

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftext-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: delete_005ftext-in-edit_005fxml-promises
-categories: [Bundles-for-agent,delete_005ftext-in-edit_005fxml-promises]
+title: delete ftext in edit fxml promises
+categories: [Bundles-for-agent,delete-ftext-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-delete_005ftext-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,delete_005ftext-in-edit_005fxml-promises]
+alias: Bundles-for-agent-delete-ftext-in-edit-fxml-promises.html
+tags: [Bundles for agent,delete ftext in edit fxml promises]
 ---
 
 ### `delete_text` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftree-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-delete_005ftree-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: delete_005ftree-in-edit_005fxml-promises
-categories: [Bundles-for-agent,delete_005ftree-in-edit_005fxml-promises]
+title: delete ftree in edit fxml promises
+categories: [Bundles-for-agent,delete-ftree-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-delete_005ftree-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,delete_005ftree-in-edit_005fxml-promises]
+alias: Bundles-for-agent-delete-ftree-in-edit-fxml-promises.html
+tags: [Bundles for agent,delete ftree in edit fxml promises]
 ---
 
 ### `delete_tree` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-field_005fedits-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-field_005fedits-in-edit_005fline-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: field_005fedits-in-edit_005fline-promises
-categories: [Bundles-for-agent,field_005fedits-in-edit_005fline-promises]
+title: field fedits in edit fline promises
+categories: [Bundles-for-agent,field-fedits-in-edit-fline-promises]
 published: true
-alias: Bundles-for-agent-field_005fedits-in-edit_005fline-promises.html
-tags: [Bundles-for-agent,field_005fedits-in-edit_005fline-promises]
+alias: Bundles-for-agent-field-fedits-in-edit-fline-promises.html
+tags: [Bundles for agent,field fedits in edit fline promises]
 ---
 
 ### `field_edits` promises in edit\_line

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-files-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: files-in-agent-promises
+title: files in agent promises
 categories: [Bundles-for-agent,files-in-agent-promises]
 published: true
 alias: Bundles-for-agent-files-in-agent-promises.html
-tags: [Bundles-for-agent,files-in-agent-promises]
+tags: [Bundles for agent,files in agent promises]
 ---
 
 ### `files` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-guest_005fenvironments-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-guest_005fenvironments-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: guest_005fenvironments-in-agent-promises
-categories: [Bundles-for-agent,guest_005fenvironments-in-agent-promises]
+title: guest fenvironments in agent promises
+categories: [Bundles-for-agent,guest-fenvironments-in-agent-promises]
 published: true
-alias: Bundles-for-agent-guest_005fenvironments-in-agent-promises.html
-tags: [Bundles-for-agent,guest_005fenvironments-in-agent-promises]
+alias: Bundles-for-agent-guest-fenvironments-in-agent-promises.html
+tags: [Bundles for agent,guest fenvironments in agent promises]
 ---
 
 ### `guest_environments` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005flines-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005flines-in-edit_005fline-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: insert_005flines-in-edit_005fline-promises
-categories: [Bundles-for-agent,insert_005flines-in-edit_005fline-promises]
+title: insert flines in edit fline promises
+categories: [Bundles-for-agent,insert-flines-in-edit-fline-promises]
 published: true
-alias: Bundles-for-agent-insert_005flines-in-edit_005fline-promises.html
-tags: [Bundles-for-agent,insert_005flines-in-edit_005fline-promises]
+alias: Bundles-for-agent-insert-flines-in-edit-fline-promises.html
+tags: [Bundles for agent,insert flines in edit fline promises]
 ---
 
 ### `insert_lines` promises in edit\_line

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftext-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: insert_005ftext-in-edit_005fxml-promises
-categories: [Bundles-for-agent,insert_005ftext-in-edit_005fxml-promises]
+title: insert ftext in edit fxml promises
+categories: [Bundles-for-agent,insert-ftext-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-insert_005ftext-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,insert_005ftext-in-edit_005fxml-promises]
+alias: Bundles-for-agent-insert-ftext-in-edit-fxml-promises.html
+tags: [Bundles for agent,insert ftext in edit fxml promises]
 ---
 
 ### `insert_text` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftree-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-insert_005ftree-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: insert_005ftree-in-edit_005fxml-promises
-categories: [Bundles-for-agent,insert_005ftree-in-edit_005fxml-promises]
+title: insert ftree in edit fxml promises
+categories: [Bundles-for-agent,insert-ftree-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-insert_005ftree-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,insert_005ftree-in-edit_005fxml-promises]
+alias: Bundles-for-agent-insert-ftree-in-edit-fxml-promises.html
+tags: [Bundles for agent,insert ftree in edit fxml promises]
 ---
 
 ### `insert_tree` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-interfaces-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-interfaces-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: interfaces-in-agent-promises
+title: interfaces in agent promises
 categories: [Bundles-for-agent,interfaces-in-agent-promises]
 published: true
 alias: Bundles-for-agent-interfaces-in-agent-promises.html
-tags: [Bundles-for-agent,interfaces-in-agent-promises]
+tags: [Bundles for agent,interfaces in agent promises]
 ---
 
 ### `interfaces` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-methods-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-methods-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: methods-in-agent-promises
+title: methods in agent promises
 categories: [Bundles-for-agent,methods-in-agent-promises]
 published: true
 alias: Bundles-for-agent-methods-in-agent-promises.html
-tags: [Bundles-for-agent,methods-in-agent-promises]
+tags: [Bundles for agent,methods in agent promises]
 ---
 
 ### `methods` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-outputs-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-outputs-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: outputs-in-agent-promises
+title: outputs in agent promises
 categories: [Bundles-for-agent,outputs-in-agent-promises]
 published: true
 alias: Bundles-for-agent-outputs-in-agent-promises.html
-tags: [Bundles-for-agent,outputs-in-agent-promises]
+tags: [Bundles for agent,outputs in agent promises]
 ---
 
 ### `outputs` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-packages-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-packages-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: packages-in-agent-promises
+title: packages in agent promises
 categories: [Bundles-for-agent,packages-in-agent-promises]
 published: true
 alias: Bundles-for-agent-packages-in-agent-promises.html
-tags: [Bundles-for-agent,packages-in-agent-promises]
+tags: [Bundles for agent,packages in agent promises]
 ---
 
 ### `packages` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-processes-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-processes-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: processes-in-agent-promises
+title: processes in agent promises
 categories: [Bundles-for-agent,processes-in-agent-promises]
 published: true
 alias: Bundles-for-agent-processes-in-agent-promises.html
-tags: [Bundles-for-agent,processes-in-agent-promises]
+tags: [Bundles for agent,processes in agent promises]
 ---
 
 ### `processes` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-replace_005fpatterns-in-edit_005fline-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-replace_005fpatterns-in-edit_005fline-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: replace_005fpatterns-in-edit_005fline-promises
-categories: [Bundles-for-agent,replace_005fpatterns-in-edit_005fline-promises]
+title: replace fpatterns in edit fline promises
+categories: [Bundles-for-agent,replace-fpatterns-in-edit-fline-promises]
 published: true
-alias: Bundles-for-agent-replace_005fpatterns-in-edit_005fline-promises.html
-tags: [Bundles-for-agent,replace_005fpatterns-in-edit_005fline-promises]
+alias: Bundles-for-agent-replace-fpatterns-in-edit-fline-promises.html
+tags: [Bundles for agent,replace fpatterns in edit fline promises]
 ---
 
 ### `replace_patterns` promises in edit\_line

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-services-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-services-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: services-in-agent-promises
+title: services in agent promises
 categories: [Bundles-for-agent,services-in-agent-promises]
 published: true
 alias: Bundles-for-agent-services-in-agent-promises.html
-tags: [Bundles-for-agent,services-in-agent-promises]
+tags: [Bundles for agent,services in agent promises]
 ---
 
 ### `services` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005fattribute-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005fattribute-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: set_005fattribute-in-edit_005fxml-promises
-categories: [Bundles-for-agent,set_005fattribute-in-edit_005fxml-promises]
+title: set fattribute in edit fxml promises
+categories: [Bundles-for-agent,set-fattribute-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-set_005fattribute-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,set_005fattribute-in-edit_005fxml-promises]
+alias: Bundles-for-agent-set-fattribute-in-edit-fxml-promises.html
+tags: [Bundles for agent,set fattribute in edit fxml promises]
 ---
 
 ### `set_attribute` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005ftext-in-edit_005fxml-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-set_005ftext-in-edit_005fxml-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: set_005ftext-in-edit_005fxml-promises
-categories: [Bundles-for-agent,set_005ftext-in-edit_005fxml-promises]
+title: set ftext in edit fxml promises
+categories: [Bundles-for-agent,set-ftext-in-edit-fxml-promises]
 published: true
-alias: Bundles-for-agent-set_005ftext-in-edit_005fxml-promises.html
-tags: [Bundles-for-agent,set_005ftext-in-edit_005fxml-promises]
+alias: Bundles-for-agent-set-ftext-in-edit-fxml-promises.html
+tags: [Bundles for agent,set ftext in edit fxml promises]
 ---
 
 ### `set_text` promises in edit\_xml

--- a/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-storage-in-agent-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-agent/Bundles-for-agent-0-storage-in-agent-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: storage-in-agent-promises
+title: storage in agent promises
 categories: [Bundles-for-agent,storage-in-agent-promises]
 published: true
 alias: Bundles-for-agent-storage-in-agent-promises.html
-tags: [Bundles-for-agent,storage-in-agent-promises]
+tags: [Bundles for agent,storage in agent promises]
 ---
 
 ### `storage` promises in agent

--- a/bundles-logs-functions-variables/Bundles-for-common-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Bundles-for-common]
 published: true
 alias: Bundles-for-common.html
-tags: [Bundles-for-common]
+tags: [Bundles for common]
 ---
 
 Bundles of `common`

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-Miscellaneous-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-Miscellaneous-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Miscellaneous-in-common-promises
+title: Miscellaneous in common promises
 categories: [Bundles-for-common,Miscellaneous-in-common-promises]
 published: true
 alias: Bundles-for-common-Miscellaneous-in-common-promises.html
-tags: [Bundles-for-common,Miscellaneous-in-common-promises]
+tags: [Bundles for common,Miscellaneous in common promises]
 ---
 
 ### `*` promises

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-classes-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-classes-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: classes-in-common-promises
+title: classes in common promises
 categories: [Bundles-for-common,classes-in-common-promises]
 published: true
 alias: Bundles-for-common-classes-in-common-promises.html
-tags: [Bundles-for-common,classes-in-common-promises]
+tags: [Bundles for common,classes in common promises]
 ---
 
 ### `classes` promises in \*

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-defaults-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-defaults-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: defaults-in-common-promises
+title: defaults in common promises
 categories: [Bundles-for-common,defaults-in-common-promises]
 published: true
 alias: Bundles-for-common-defaults-in-common-promises.html
-tags: [Bundles-for-common,defaults-in-common-promises]
+tags: [Bundles for common,defaults in common promises]
 ---
 
 ### `defaults` promises in \*

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-meta-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-meta-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: meta-in-common-promises
+title: meta in common promises
 categories: [Bundles-for-common,meta-in-common-promises]
 published: true
 alias: Bundles-for-common-meta-in-common-promises.html
-tags: [Bundles-for-common,meta-in-common-promises]
+tags: [Bundles for common,meta in common promises]
 ---
 
 ### `meta` promises in \*

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-reports-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-reports-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: reports-in-common-promises
+title: reports in common promises
 categories: [Bundles-for-common,reports-in-common-promises]
 published: true
 alias: Bundles-for-common-reports-in-common-promises.html
-tags: [Bundles-for-common,reports-in-common-promises]
+tags: [Bundles for common,reports in common promises]
 ---
 
 ### `reports` promises in \*

--- a/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-vars-in-common-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-common/Bundles-for-common-0-vars-in-common-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: vars-in-common-promises
+title: vars in common promises
 categories: [Bundles-for-common,vars-in-common-promises]
 published: true
 alias: Bundles-for-common-vars-in-common-promises.html
-tags: [Bundles-for-common,vars-in-common-promises]
+tags: [Bundles for common,vars in common promises]
 ---
 
 ### `vars` promises in \*

--- a/bundles-logs-functions-variables/Bundles-for-knowledge-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-knowledge-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Bundles-for-knowledge]
 published: true
 alias: Bundles-for-knowledge.html
-tags: [Bundles-for-knowledge]
+tags: [Bundles for knowledge]
 ---
 
 Bundles of `knowledge`

--- a/bundles-logs-functions-variables/Bundles-for-monitor-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-monitor-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Bundles-for-monitor]
 published: true
 alias: Bundles-for-monitor.html
-tags: [Bundles-for-monitor]
+tags: [Bundles for monitor]
 ---
 
 Bundles of `monitor`

--- a/bundles-logs-functions-variables/Bundles-for-monitor/Bundles-for-monitor-0-measurements-in-monitor-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-monitor/Bundles-for-monitor-0-measurements-in-monitor-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: measurements-in-monitor-promises
+title: measurements in monitor promises
 categories: [Bundles-for-monitor,measurements-in-monitor-promises]
 published: true
 alias: Bundles-for-monitor-measurements-in-monitor-promises.html
-tags: [Bundles-for-monitor,measurements-in-monitor-promises]
+tags: [Bundles for monitor,measurements in monitor promises]
 ---
 
 ### `measurements` promises in monitor

--- a/bundles-logs-functions-variables/Bundles-for-server-0.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Bundles-for-server]
 published: true
 alias: Bundles-for-server.html
-tags: [Bundles-for-server]
+tags: [Bundles for server]
 ---
 
 Bundles of `server`

--- a/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-access-in-server-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-access-in-server-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: access-in-server-promises
+title: access in server promises
 categories: [Bundles-for-server,access-in-server-promises]
 published: true
 alias: Bundles-for-server-access-in-server-promises.html
-tags: [Bundles-for-server,access-in-server-promises]
+tags: [Bundles for server,access in server promises]
 ---
 
 ### `access` promises in server

--- a/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-roles-in-server-promises.markdown
+++ b/bundles-logs-functions-variables/Bundles-for-server/Bundles-for-server-0-roles-in-server-promises.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: roles-in-server-promises
+title: roles in server promises
 categories: [Bundles-for-server,roles-in-server-promises]
 published: true
 alias: Bundles-for-server-roles-in-server-promises.html
-tags: [Bundles-for-server,roles-in-server-promises]
+tags: [Bundles for server,roles in server promises]
 ---
 
 ### `roles` promises in server

--- a/bundles-logs-functions-variables/Logs-and-records-0.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Logs-and-records]
 published: true
 alias: Logs-and-records.html
-tags: [Logs-and-records]
+tags: [Logs and records]
 ---
 
 Logs and records

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Additional-reports-in-commercical-CFEngine-versions.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Additional-reports-in-commercical-CFEngine-versions.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Additional-reports-in-commercical-CFEngine-versions
+title: Additional reports in commercical CFEngine versions
 categories: [Logs-and-records,Additional-reports-in-commercical-CFEngine-versions]
 published: true
 alias: Logs-and-records-Additional-reports-in-commercical-CFEngine-versions.html
-tags: [Logs-and-records,Additional-reports-in-commercical-CFEngine-versions]
+tags: [Logs and records,Additional reports in commercical CFEngine versions]
 ---
 
 ### Additional reports in commercial CFEngine versions

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Embedded-Databases.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Embedded-Databases.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Embedded-Databases
+title: Embedded Databases
 categories: [Logs-and-records,Embedded-Databases]
 published: true
 alias: Logs-and-records-Embedded-Databases.html
-tags: [Logs-and-records,Embedded-Databases]
+tags: [Logs and records,Embedded Databases]
 ---
 
 ### Embedded Databases

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Reports-in-outputs.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Reports-in-outputs.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Reports-in-outputs
+title: Reports in outputs
 categories: [Logs-and-records,Reports-in-outputs]
 published: true
 alias: Logs-and-records-Reports-in-outputs.html
-tags: [Logs-and-records,Reports-in-outputs]
+tags: [Logs and records,Reports in outputs]
 ---
 
 ### Reports in outputs

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-State-information.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-State-information.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: State-information
+title: State information
 categories: [Logs-and-records,State-information]
 published: true
 alias: Logs-and-records-State-information.html
-tags: [Logs-and-records,State-information]
+tags: [Logs and records,State information]
 ---
 
 ### State information

--- a/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Text-logs.markdown
+++ b/bundles-logs-functions-variables/Logs-and-records/Logs-and-records-0-Text-logs.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Text-logs
+title: Text logs
 categories: [Logs-and-records,Text-logs]
 published: true
 alias: Logs-and-records-Text-logs.html
-tags: [Logs-and-records,Text-logs]
+tags: [Logs and records,Text logs]
 ---
 
 ### Text logs

--- a/bundles-logs-functions-variables/Special-Variables-0.markdown
+++ b/bundles-logs-functions-variables/Special-Variables-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Special-Variables]
 published: true
 alias: Special-Variables.html
-tags: [Special-Variables]
+tags: [Special Variables]
 ---
 
 Special Variables

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-const.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-const.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-const
+title: Variable context const
 categories: [Special-Variables,Variable-context-const]
 published: true
 alias: Special-Variables-Variable-context-const.html
-tags: [Special-Variables,Variable-context-const]
+tags: [Special Variables,Variable context const]
 ---
 
 ### Variable context `const`

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-edit.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-edit.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-edit
+title: Variable context edit
 categories: [Special-Variables,Variable-context-edit]
 published: true
 alias: Special-Variables-Variable-context-edit.html
-tags: [Special-Variables,Variable-context-edit]
+tags: [Special Variables,Variable context edit]
 ---
 
 ### Variable context `edit`

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-match.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-match.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-match
+title: Variable context match
 categories: [Special-Variables,Variable-context-match]
 published: true
 alias: Special-Variables-Variable-context-match.html
-tags: [Special-Variables,Variable-context-match]
+tags: [Special Variables,Variable context match]
 ---
 
 ### Variable context `match`

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-mon.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-mon.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-mon
+title: Variable context mon
 categories: [Special-Variables,Variable-context-mon]
 published: true
 alias: Special-Variables-Variable-context-mon.html
-tags: [Special-Variables,Variable-context-mon]
+tags: [Special Variables,Variable context mon]
 ---
 
 ### Variable context `mon`

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-sys.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-sys.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-sys
+title: Variable context sys
 categories: [Special-Variables,Variable-context-sys]
 published: true
 alias: Special-Variables-Variable-context-sys.html
-tags: [Special-Variables,Variable-context-sys]
+tags: [Special Variables,Variable context sys]
 ---
 
 ### Variable context `sys`

--- a/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-this.markdown
+++ b/bundles-logs-functions-variables/Special-Variables/Special-Variables-0-Variable-context-this.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Variable-context-this
+title: Variable context this
 categories: [Special-Variables,Variable-context-this]
 published: true
 alias: Special-Variables-Variable-context-this.html
-tags: [Special-Variables,Variable-context-this]
+tags: [Special Variables,Variable context this]
 ---
 
 ### Variable context `this`

--- a/bundles-logs-functions-variables/Special-functions-0.markdown
+++ b/bundles-logs-functions-variables/Special-functions-0.markdown
@@ -4,7 +4,7 @@ title:
 categories: [Special-functions]
 published: true
 alias: Special-functions.html
-tags: [Special-functions]
+tags: [Special functions]
 ---
 
 Special functions

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accessedbefore.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accessedbefore.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-accessedbefore
+title: Function accessedbefore
 categories: [Special-functions,Function-accessedbefore]
 published: true
 alias: Special-functions-Function-accessedbefore.html
-tags: [Special-functions,Function-accessedbefore]
+tags: [Special functions,Function accessedbefore]
 ---
 
 ### Function accessedbefore

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accumulated.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-accumulated.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-accumulated
+title: Function accumulated
 categories: [Special-functions,Function-accumulated]
 published: true
 alias: Special-functions-Function-accumulated.html
-tags: [Special-functions,Function-accumulated]
+tags: [Special functions,Function accumulated]
 ---
 
 ### Function accumulated

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ago.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ago.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-ago
+title: Function ago
 categories: [Special-functions,Function-ago]
 published: true
 alias: Special-functions-Function-ago.html
-tags: [Special-functions,Function-ago]
+tags: [Special functions,Function ago]
 ---
 
 ### Function ago

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-and.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-and.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-and
+title: Function and
 categories: [Special-functions,Function-and]
 published: true
 alias: Special-functions-Function-and.html
-tags: [Special-functions,Function-and]
+tags: [Special functions,Function and]
 ---
 
 ### Function and

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-canonify.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-canonify.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-canonify
+title: Function canonify
 categories: [Special-functions,Function-canonify]
 published: true
 alias: Special-functions-Function-canonify.html
-tags: [Special-functions,Function-canonify]
+tags: [Special functions,Function canonify]
 ---
 
 ### Function canonify

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-changedbefore.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-changedbefore.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-changedbefore
+title: Function changedbefore
 categories: [Special-functions,Function-changedbefore]
 published: true
 alias: Special-functions-Function-changedbefore.html
-tags: [Special-functions,Function-changedbefore]
+tags: [Special functions,Function changedbefore]
 ---
 
 ### Function changedbefore

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classify.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classify.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-classify
+title: Function classify
 categories: [Special-functions,Function-classify]
 published: true
 alias: Special-functions-Function-classify.html
-tags: [Special-functions,Function-classify]
+tags: [Special functions,Function classify]
 ---
 
 ### Function classify

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classmatch.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-classmatch.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-classmatch
+title: Function classmatch
 categories: [Special-functions,Function-classmatch]
 published: true
 alias: Special-functions-Function-classmatch.html
-tags: [Special-functions,Function-classmatch]
+tags: [Special functions,Function classmatch]
 ---
 
 ### Function classmatch

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-concat.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-concat.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-concat
+title: Function concat
 categories: [Special-functions,Function-concat]
 published: true
 alias: Special-functions-Function-concat.html
-tags: [Special-functions,Function-concat]
+tags: [Special functions,Function concat]
 ---
 
 ### Function concat

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countclassesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countclassesmatching.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-countclassesmatching
+title: Function countclassesmatching
 categories: [Special-functions,Function-countclassesmatching]
 published: true
 alias: Special-functions-Function-countclassesmatching.html
-tags: [Special-functions,Function-countclassesmatching]
+tags: [Special functions,Function countclassesmatching]
 ---
 
 ### Function countclassesmatching

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countlinesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-countlinesmatching.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-countlinesmatching
+title: Function countlinesmatching
 categories: [Special-functions,Function-countlinesmatching]
 published: true
 alias: Special-functions-Function-countlinesmatching.html
-tags: [Special-functions,Function-countlinesmatching]
+tags: [Special functions,Function countlinesmatching]
 ---
 
 ### Function countlinesmatching

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-dirname.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-dirname.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-dirname
+title: Function dirname
 categories: [Special-functions,Function-dirname]
 published: true
 alias: Special-functions-Function-dirname.html
-tags: [Special-functions,Function-dirname]
+tags: [Special functions,Function dirname]
 ---
 
 ### Function dirname

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-diskfree.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-diskfree.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-diskfree
+title: Function diskfree
 categories: [Special-functions,Function-diskfree]
 published: true
 alias: Special-functions-Function-diskfree.html
-tags: [Special-functions,Function-diskfree]
+tags: [Special functions,Function diskfree]
 ---
 
 ### Function diskfree

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-escape.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-escape.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-escape
+title: Function escape
 categories: [Special-functions,Function-escape]
 published: true
 alias: Special-functions-Function-escape.html
-tags: [Special-functions,Function-escape]
+tags: [Special functions,Function escape]
 ---
 
 ### Function escape

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-execresult.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-execresult.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-execresult
+title: Function execresult
 categories: [Special-functions,Function-execresult]
 published: true
 alias: Special-functions-Function-execresult.html
-tags: [Special-functions,Function-execresult]
+tags: [Special functions,Function execresult]
 ---
 
 ### Function execresult

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-fileexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-fileexists.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-fileexists
+title: Function fileexists
 categories: [Special-functions,Function-fileexists]
 published: true
 alias: Special-functions-Function-fileexists.html
-tags: [Special-functions,Function-fileexists]
+tags: [Special functions,Function fileexists]
 ---
 
 ### Function fileexists

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesexist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesexist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-filesexist
+title: Function filesexist
 categories: [Special-functions,Function-filesexist]
 published: true
 alias: Special-functions-Function-filesexist.html
-tags: [Special-functions,Function-filesexist]
+tags: [Special functions,Function filesexist]
 ---
 
 ### Function filesexist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesize.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-filesize.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-filesize
+title: Function filesize
 categories: [Special-functions,Function-filesize]
 published: true
 alias: Special-functions-Function-filesize.html
-tags: [Special-functions,Function-filesize]
+tags: [Special functions,Function filesize]
 ---
 
 ### Function filesize

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getenv.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getenv.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getenv
+title: Function getenv
 categories: [Special-functions,Function-getenv]
 published: true
 alias: Special-functions-Function-getenv.html
-tags: [Special-functions,Function-getenv]
+tags: [Special functions,Function getenv]
 ---
 
 ### Function getenv

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getfields.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getfields.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getfields
+title: Function getfields
 categories: [Special-functions,Function-getfields]
 published: true
 alias: Special-functions-Function-getfields.html
-tags: [Special-functions,Function-getfields]
+tags: [Special functions,Function getfields]
 ---
 
 ### Function getfields

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getgid.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getgid.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getgid
+title: Function getgid
 categories: [Special-functions,Function-getgid]
 published: true
 alias: Special-functions-Function-getgid.html
-tags: [Special-functions,Function-getgid]
+tags: [Special functions,Function getgid]
 ---
 
 ### Function getgid

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getindices.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getindices.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getindices
+title: Function getindices
 categories: [Special-functions,Function-getindices]
 published: true
 alias: Special-functions-Function-getindices.html
-tags: [Special-functions,Function-getindices]
+tags: [Special functions,Function getindices]
 ---
 
 ### Function getindices

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getuid.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getuid.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getuid
+title: Function getuid
 categories: [Special-functions,Function-getuid]
 published: true
 alias: Special-functions-Function-getuid.html
-tags: [Special-functions,Function-getuid]
+tags: [Special functions,Function getuid]
 ---
 
 ### Function getuid

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getusers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getusers.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getusers
+title: Function getusers
 categories: [Special-functions,Function-getusers]
 published: true
 alias: Special-functions-Function-getusers.html
-tags: [Special-functions,Function-getusers]
+tags: [Special functions,Function getusers]
 ---
 
 ### Function getusers

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getvalues.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-getvalues.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-getvalues
+title: Function getvalues
 categories: [Special-functions,Function-getvalues]
 published: true
 alias: Special-functions-Function-getvalues.html
-tags: [Special-functions,Function-getvalues]
+tags: [Special functions,Function getvalues]
 ---
 
 ### Function getvalues

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-grep.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-grep.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-grep
+title: Function grep
 categories: [Special-functions,Function-grep]
 published: true
 alias: Special-functions-Function-grep.html
-tags: [Special-functions,Function-grep]
+tags: [Special functions,Function grep]
 ---
 
 ### Function grep

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-groupexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-groupexists.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-groupexists
+title: Function groupexists
 categories: [Special-functions,Function-groupexists]
 published: true
 alias: Special-functions-Function-groupexists.html
-tags: [Special-functions,Function-groupexists]
+tags: [Special functions,Function groupexists]
 ---
 
 ### Function groupexists

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hash.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hash.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hash
+title: Function hash
 categories: [Special-functions,Function-hash]
 published: true
 alias: Special-functions-Function-hash.html
-tags: [Special-functions,Function-hash]
+tags: [Special functions,Function hash]
 ---
 
 ### Function hash

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hashmatch.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hashmatch.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hashmatch
+title: Function hashmatch
 categories: [Special-functions,Function-hashmatch]
 published: true
 alias: Special-functions-Function-hashmatch.html
-tags: [Special-functions,Function-hashmatch]
+tags: [Special functions,Function hashmatch]
 ---
 
 ### Function hashmatch

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-host2ip.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-host2ip.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-host2ip
+title: Function host2ip
 categories: [Special-functions,Function-host2ip]
 published: true
 alias: Special-functions-Function-host2ip.html
-tags: [Special-functions,Function-host2ip]
+tags: [Special functions,Function host2ip]
 ---
 
 ### Function host2ip

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostinnetgroup.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostinnetgroup.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hostinnetgroup
+title: Function hostinnetgroup
 categories: [Special-functions,Function-hostinnetgroup]
 published: true
 alias: Special-functions-Function-hostinnetgroup.html
-tags: [Special-functions,Function-hostinnetgroup]
+tags: [Special functions,Function hostinnetgroup]
 ---
 
 ### Function hostinnetgroup

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostrange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostrange.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hostrange
+title: Function hostrange
 categories: [Special-functions,Function-hostrange]
 published: true
 alias: Special-functions-Function-hostrange.html
-tags: [Special-functions,Function-hostrange]
+tags: [Special functions,Function hostrange]
 ---
 
 ### Function hostrange

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostsseen.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostsseen.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hostsseen
+title: Function hostsseen
 categories: [Special-functions,Function-hostsseen]
 published: true
 alias: Special-functions-Function-hostsseen.html
-tags: [Special-functions,Function-hostsseen]
+tags: [Special functions,Function hostsseen]
 ---
 
 ### Function hostsseen

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostswithclass.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hostswithclass.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hostswithclass
+title: Function hostswithclass
 categories: [Special-functions,Function-hostswithclass]
 published: true
 alias: Special-functions-Function-hostswithclass.html
-tags: [Special-functions,Function-hostswithclass]
+tags: [Special functions,Function hostswithclass]
 ---
 
 ### Function hostswithclass

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hubknowledge.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-hubknowledge.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-hubknowledge
+title: Function hubknowledge
 categories: [Special-functions,Function-hubknowledge]
 published: true
 alias: Special-functions-Function-hubknowledge.html
-tags: [Special-functions,Function-hubknowledge]
+tags: [Special functions,Function hubknowledge]
 ---
 
 ### Function hubknowledge

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ip2host.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ip2host.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-ip2host
+title: Function ip2host
 categories: [Special-functions,Function-ip2host]
 published: true
 alias: Special-functions-Function-ip2host.html
-tags: [Special-functions,Function-ip2host]
+tags: [Special functions,Function ip2host]
 ---
 
 ### Function ip2host

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-iprange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-iprange.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-iprange
+title: Function iprange
 categories: [Special-functions,Function-iprange]
 published: true
 alias: Special-functions-Function-iprange.html
-tags: [Special-functions,Function-iprange]
+tags: [Special functions,Function iprange]
 ---
 
 ### Function iprange

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-irange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-irange.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-irange
+title: Function irange
 categories: [Special-functions,Function-irange]
 published: true
 alias: Special-functions-Function-irange.html
-tags: [Special-functions,Function-irange]
+tags: [Special functions,Function irange]
 ---
 
 ### Function irange

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isdir.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isdir.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isdir
+title: Function isdir
 categories: [Special-functions,Function-isdir]
 published: true
 alias: Special-functions-Function-isdir.html
-tags: [Special-functions,Function-isdir]
+tags: [Special functions,Function isdir]
 ---
 
 ### Function isdir

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isexecutable.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isexecutable.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isexecutable
+title: Function isexecutable
 categories: [Special-functions,Function-isexecutable]
 published: true
 alias: Special-functions-Function-isexecutable.html
-tags: [Special-functions,Function-isexecutable]
+tags: [Special functions,Function isexecutable]
 ---
 
 ### Function isexecutable

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isgreaterthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isgreaterthan.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isgreaterthan
+title: Function isgreaterthan
 categories: [Special-functions,Function-isgreaterthan]
 published: true
 alias: Special-functions-Function-isgreaterthan.html
-tags: [Special-functions,Function-isgreaterthan]
+tags: [Special functions,Function isgreaterthan]
 ---
 
 ### Function isgreaterthan

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islessthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islessthan.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-islessthan
+title: Function islessthan
 categories: [Special-functions,Function-islessthan]
 published: true
 alias: Special-functions-Function-islessthan.html
-tags: [Special-functions,Function-islessthan]
+tags: [Special functions,Function islessthan]
 ---
 
 ### Function islessthan

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islink.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-islink.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-islink
+title: Function islink
 categories: [Special-functions,Function-islink]
 published: true
 alias: Special-functions-Function-islink.html
-tags: [Special-functions,Function-islink]
+tags: [Special functions,Function islink]
 ---
 
 ### Function islink

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isnewerthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isnewerthan.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isnewerthan
+title: Function isnewerthan
 categories: [Special-functions,Function-isnewerthan]
 published: true
 alias: Special-functions-Function-isnewerthan.html
-tags: [Special-functions,Function-isnewerthan]
+tags: [Special functions,Function isnewerthan]
 ---
 
 ### Function isnewerthan

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isplain.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isplain.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isplain
+title: Function isplain
 categories: [Special-functions,Function-isplain]
 published: true
 alias: Special-functions-Function-isplain.html
-tags: [Special-functions,Function-isplain]
+tags: [Special functions,Function isplain]
 ---
 
 ### Function isplain

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isvariable.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-isvariable.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-isvariable
+title: Function isvariable
 categories: [Special-functions,Function-isvariable]
 published: true
 alias: Special-functions-Function-isvariable.html
-tags: [Special-functions,Function-isvariable]
+tags: [Special functions,Function isvariable]
 ---
 
 ### Function isvariable

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-join.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-join.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-join
+title: Function join
 categories: [Special-functions,Function-join]
 published: true
 alias: Special-functions-Function-join.html
-tags: [Special-functions,Function-join]
+tags: [Special functions,Function join]
 ---
 
 ### Function join

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lastnode.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lastnode.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-lastnode
+title: Function lastnode
 categories: [Special-functions,Function-lastnode]
 published: true
 alias: Special-functions-Function-lastnode.html
-tags: [Special-functions,Function-lastnode]
+tags: [Special functions,Function lastnode]
 ---
 
 ### Function lastnode

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-laterthan.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-laterthan.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-laterthan
+title: Function laterthan
 categories: [Special-functions,Function-laterthan]
 published: true
 alias: Special-functions-Function-laterthan.html
-tags: [Special-functions,Function-laterthan]
+tags: [Special functions,Function laterthan]
 ---
 
 ### Function laterthan

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaparray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaparray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-ldaparray
+title: Function ldaparray
 categories: [Special-functions,Function-ldaparray]
 published: true
 alias: Special-functions-Function-ldaparray.html
-tags: [Special-functions,Function-ldaparray]
+tags: [Special functions,Function ldaparray]
 ---
 
 ### Function ldaparray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaplist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldaplist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-ldaplist
+title: Function ldaplist
 categories: [Special-functions,Function-ldaplist]
 published: true
 alias: Special-functions-Function-ldaplist.html
-tags: [Special-functions,Function-ldaplist]
+tags: [Special functions,Function ldaplist]
 ---
 
 ### Function ldaplist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldapvalue.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-ldapvalue.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-ldapvalue
+title: Function ldapvalue
 categories: [Special-functions,Function-ldapvalue]
 published: true
 alias: Special-functions-Function-ldapvalue.html
-tags: [Special-functions,Function-ldapvalue]
+tags: [Special functions,Function ldapvalue]
 ---
 
 ### Function ldapvalue

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lsdir.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-lsdir.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-lsdir
+title: Function lsdir
 categories: [Special-functions,Function-lsdir]
 published: true
 alias: Special-functions-Function-lsdir.html
-tags: [Special-functions,Function-lsdir]
+tags: [Special functions,Function lsdir]
 ---
 
 ### Function lsdir

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-maplist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-maplist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-maplist
+title: Function maplist
 categories: [Special-functions,Function-maplist]
 published: true
 alias: Special-functions-Function-maplist.html
-tags: [Special-functions,Function-maplist]
+tags: [Special functions,Function maplist]
 ---
 
 ### Function maplist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-not.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-not.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-not
+title: Function not
 categories: [Special-functions,Function-not]
 published: true
 alias: Special-functions-Function-not.html
-tags: [Special-functions,Function-not]
+tags: [Special functions,Function not]
 ---
 
 ### Function not

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-now.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-now.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-now
+title: Function now
 categories: [Special-functions,Function-now]
 published: true
 alias: Special-functions-Function-now.html
-tags: [Special-functions,Function-now]
+tags: [Special functions,Function now]
 ---
 
 ### Function now

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-on.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-on.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-on
+title: Function on
 categories: [Special-functions,Function-on]
 published: true
 alias: Special-functions-Function-on.html
-tags: [Special-functions,Function-on]
+tags: [Special functions,Function on]
 ---
 
 ### Function on

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-or.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-or.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-or
+title: Function or
 categories: [Special-functions,Function-or]
 published: true
 alias: Special-functions-Function-or.html
-tags: [Special-functions,Function-or]
+tags: [Special functions,Function or]
 ---
 
 ### Function or

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parseintarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parseintarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-parseintarray
+title: Function parseintarray
 categories: [Special-functions,Function-parseintarray]
 published: true
 alias: Special-functions-Function-parseintarray.html
-tags: [Special-functions,Function-parseintarray]
+tags: [Special functions,Function parseintarray]
 ---
 
 ### Function parseintarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parserealarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parserealarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-parserealarray
+title: Function parserealarray
 categories: [Special-functions,Function-parserealarray]
 published: true
 alias: Special-functions-Function-parserealarray.html
-tags: [Special-functions,Function-parserealarray]
+tags: [Special functions,Function parserealarray]
 ---
 
 ### Function parserealarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-parsestringarray
+title: Function parsestringarray
 categories: [Special-functions,Function-parsestringarray]
 published: true
 alias: Special-functions-Function-parsestringarray.html
-tags: [Special-functions,Function-parsestringarray]
+tags: [Special functions,Function parsestringarray]
 ---
 
 ### Function parsestringarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarrayidx.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-parsestringarrayidx.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-parsestringarrayidx
+title: Function parsestringarrayidx
 categories: [Special-functions,Function-parsestringarrayidx]
 published: true
 alias: Special-functions-Function-parsestringarrayidx.html
-tags: [Special-functions,Function-parsestringarrayidx]
+tags: [Special functions,Function parsestringarrayidx]
 ---
 
 ### Function parsestringarrayidx

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleader.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleader.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-peerleader
+title: Function peerleader
 categories: [Special-functions,Function-peerleader]
 published: true
 alias: Special-functions-Function-peerleader.html
-tags: [Special-functions,Function-peerleader]
+tags: [Special functions,Function peerleader]
 ---
 
 ### Function peerleader

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleaders.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peerleaders.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-peerleaders
+title: Function peerleaders
 categories: [Special-functions,Function-peerleaders]
 published: true
 alias: Special-functions-Function-peerleaders.html
-tags: [Special-functions,Function-peerleaders]
+tags: [Special functions,Function peerleaders]
 ---
 
 ### Function peerleaders

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-peers.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-peers
+title: Function peers
 categories: [Special-functions,Function-peers]
 published: true
 alias: Special-functions-Function-peers.html
-tags: [Special-functions,Function-peers]
+tags: [Special functions,Function peers]
 ---
 
 ### Function peers

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-product.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-product.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-product
+title: Function product
 categories: [Special-functions,Function-product]
 published: true
 alias: Special-functions-Function-product.html
-tags: [Special-functions,Function-product]
+tags: [Special functions,Function product]
 ---
 
 ### Function product

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-randomint.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-randomint.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-randomint
+title: Function randomint
 categories: [Special-functions,Function-randomint]
 published: true
 alias: Special-functions-Function-randomint.html
-tags: [Special-functions,Function-randomint]
+tags: [Special functions,Function randomint]
 ---
 
 ### Function randomint

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readfile.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readfile.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readfile
+title: Function readfile
 categories: [Special-functions,Function-readfile]
 published: true
 alias: Special-functions-Function-readfile.html
-tags: [Special-functions,Function-readfile]
+tags: [Special functions,Function readfile]
 ---
 
 ### Function readfile

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readintarray
+title: Function readintarray
 categories: [Special-functions,Function-readintarray]
 published: true
 alias: Special-functions-Function-readintarray.html
-tags: [Special-functions,Function-readintarray]
+tags: [Special functions,Function readintarray]
 ---
 
 ### Function readintarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintlist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readintlist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readintlist
+title: Function readintlist
 categories: [Special-functions,Function-readintlist]
 published: true
 alias: Special-functions-Function-readintlist.html
-tags: [Special-functions,Function-readintlist]
+tags: [Special functions,Function readintlist]
 ---
 
 ### Function readintlist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readrealarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readrealarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readrealarray
+title: Function readrealarray
 categories: [Special-functions,Function-readrealarray]
 published: true
 alias: Special-functions-Function-readrealarray.html
-tags: [Special-functions,Function-readrealarray]
+tags: [Special functions,Function readrealarray]
 ---
 
 ### Function readrealarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readreallist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readreallist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readreallist
+title: Function readreallist
 categories: [Special-functions,Function-readreallist]
 published: true
 alias: Special-functions-Function-readreallist.html
-tags: [Special-functions,Function-readreallist]
+tags: [Special functions,Function readreallist]
 ---
 
 ### Function readreallist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readstringarray
+title: Function readstringarray
 categories: [Special-functions,Function-readstringarray]
 published: true
 alias: Special-functions-Function-readstringarray.html
-tags: [Special-functions,Function-readstringarray]
+tags: [Special functions,Function readstringarray]
 ---
 
 ### Function readstringarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarrayidx.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringarrayidx.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readstringarrayidx
+title: Function readstringarrayidx
 categories: [Special-functions,Function-readstringarrayidx]
 published: true
 alias: Special-functions-Function-readstringarrayidx.html
-tags: [Special-functions,Function-readstringarrayidx]
+tags: [Special functions,Function readstringarrayidx]
 ---
 
 ### Function readstringarrayidx

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringlist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readstringlist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readstringlist
+title: Function readstringlist
 categories: [Special-functions,Function-readstringlist]
 published: true
 alias: Special-functions-Function-readstringlist.html
-tags: [Special-functions,Function-readstringlist]
+tags: [Special functions,Function readstringlist]
 ---
 
 ### Function readstringlist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readtcp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-readtcp.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-readtcp
+title: Function readtcp
 categories: [Special-functions,Function-readtcp]
 published: true
 alias: Special-functions-Function-readtcp.html
-tags: [Special-functions,Function-readtcp]
+tags: [Special functions,Function readtcp]
 ---
 
 ### Function readtcp

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regarray.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regarray.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-regarray
+title: Function regarray
 categories: [Special-functions,Function-regarray]
 published: true
 alias: Special-functions-Function-regarray.html
-tags: [Special-functions,Function-regarray]
+tags: [Special functions,Function regarray]
 ---
 
 ### Function regarray

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regcmp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regcmp.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-regcmp
+title: Function regcmp
 categories: [Special-functions,Function-regcmp]
 published: true
 alias: Special-functions-Function-regcmp.html
-tags: [Special-functions,Function-regcmp]
+tags: [Special functions,Function regcmp]
 ---
 
 ### Function regcmp

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regextract.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regextract.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-regextract
+title: Function regextract
 categories: [Special-functions,Function-regextract]
 published: true
 alias: Special-functions-Function-regextract.html
-tags: [Special-functions,Function-regextract]
+tags: [Special functions,Function regextract]
 ---
 
 ### Function regextract

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-registryvalue.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-registryvalue.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-registryvalue
+title: Function registryvalue
 categories: [Special-functions,Function-registryvalue]
 published: true
 alias: Special-functions-Function-registryvalue.html
-tags: [Special-functions,Function-registryvalue]
+tags: [Special functions,Function registryvalue]
 ---
 
 ### Function registryvalue

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regldap.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regldap.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-regldap
+title: Function regldap
 categories: [Special-functions,Function-regldap]
 published: true
 alias: Special-functions-Function-regldap.html
-tags: [Special-functions,Function-regldap]
+tags: [Special functions,Function regldap]
 ---
 
 ### Function regldap

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regline.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-regline.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-regline
+title: Function regline
 categories: [Special-functions,Function-regline]
 published: true
 alias: Special-functions-Function-regline.html
-tags: [Special-functions,Function-regline]
+tags: [Special functions,Function regline]
 ---
 
 ### Function regline

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-reglist.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-reglist.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-reglist
+title: Function reglist
 categories: [Special-functions,Function-reglist]
 published: true
 alias: Special-functions-Function-reglist.html
-tags: [Special-functions,Function-reglist]
+tags: [Special functions,Function reglist]
 ---
 
 ### Function reglist

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remoteclassesmatching.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remoteclassesmatching.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-remoteclassesmatching
+title: Function remoteclassesmatching
 categories: [Special-functions,Function-remoteclassesmatching]
 published: true
 alias: Special-functions-Function-remoteclassesmatching.html
-tags: [Special-functions,Function-remoteclassesmatching]
+tags: [Special functions,Function remoteclassesmatching]
 ---
 
 ### Function remoteclassesmatching

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remotescalar.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-remotescalar.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-remotescalar
+title: Function remotescalar
 categories: [Special-functions,Function-remotescalar]
 published: true
 alias: Special-functions-Function-remotescalar.html
-tags: [Special-functions,Function-remotescalar]
+tags: [Special functions,Function remotescalar]
 ---
 
 ### Function remotescalar

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-returnszero.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-returnszero.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-returnszero
+title: Function returnszero
 categories: [Special-functions,Function-returnszero]
 published: true
 alias: Special-functions-Function-returnszero.html
-tags: [Special-functions,Function-returnszero]
+tags: [Special functions,Function returnszero]
 ---
 
 ### Function returnszero

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-rrange.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-rrange.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-rrange
+title: Function rrange
 categories: [Special-functions,Function-rrange]
 published: true
 alias: Special-functions-Function-rrange.html
-tags: [Special-functions,Function-rrange]
+tags: [Special functions,Function rrange]
 ---
 
 ### Function rrange

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-selectservers.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-selectservers.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-selectservers
+title: Function selectservers
 categories: [Special-functions,Function-selectservers]
 published: true
 alias: Special-functions-Function-selectservers.html
-tags: [Special-functions,Function-selectservers]
+tags: [Special functions,Function selectservers]
 ---
 
 ### Function selectservers

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splayclass.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splayclass.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-splayclass
+title: Function splayclass
 categories: [Special-functions,Function-splayclass]
 published: true
 alias: Special-functions-Function-splayclass.html
-tags: [Special-functions,Function-splayclass]
+tags: [Special functions,Function splayclass]
 ---
 
 ### Function splayclass

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splitstring.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-splitstring.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-splitstring
+title: Function splitstring
 categories: [Special-functions,Function-splitstring]
 published: true
 alias: Special-functions-Function-splitstring.html
-tags: [Special-functions,Function-splitstring]
+tags: [Special functions,Function splitstring]
 ---
 
 ### Function splitstring

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-strcmp.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-strcmp.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-strcmp
+title: Function strcmp
 categories: [Special-functions,Function-strcmp]
 published: true
 alias: Special-functions-Function-strcmp.html
-tags: [Special-functions,Function-strcmp]
+tags: [Special functions,Function strcmp]
 ---
 
 ### Function strcmp

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-sum.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-sum.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-sum
+title: Function sum
 categories: [Special-functions,Function-sum]
 published: true
 alias: Special-functions-Function-sum.html
-tags: [Special-functions,Function-sum]
+tags: [Special functions,Function sum]
 ---
 
 ### Function sum

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-translatepath.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-translatepath.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-translatepath
+title: Function translatepath
 categories: [Special-functions,Function-translatepath]
 published: true
 alias: Special-functions-Function-translatepath.html
-tags: [Special-functions,Function-translatepath]
+tags: [Special functions,Function translatepath]
 ---
 
 ### Function translatepath

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-usemodule.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-usemodule.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-usemodule
+title: Function usemodule
 categories: [Special-functions,Function-usemodule]
 published: true
 alias: Special-functions-Function-usemodule.html
-tags: [Special-functions,Function-usemodule]
+tags: [Special functions,Function usemodule]
 ---
 
 ### Function usemodule

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-userexists.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Function-userexists.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Function-userexists
+title: Function userexists
 categories: [Special-functions,Function-userexists]
 published: true
 alias: Special-functions-Function-userexists.html
-tags: [Special-functions,Function-userexists]
+tags: [Special functions,Function userexists]
 ---
 
 ### Function userexists

--- a/bundles-logs-functions-variables/Special-functions/Special-functions-0-Introduction-to-functions.markdown
+++ b/bundles-logs-functions-variables/Special-functions/Special-functions-0-Introduction-to-functions.markdown
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Introduction-to-functions
+title: Introduction to functions
 categories: [Special-functions,Introduction-to-functions]
 published: true
 alias: Special-functions-Introduction-to-functions.html
-tags: [Special-functions,Introduction-to-functions]
+tags: [Special functions,Introduction to functions]
 ---
 
 ### Introduction to Functions


### PR DESCRIPTION
Made content in metadata of markdown files more human friendly (e.g. replaced some hyphens with spaces, removed _005 in titles, aliases etc.)
