### PR TITLE
Cleanup perms body example

### DIFF
--- a/manuals/language-concepts/bodies.markdown
+++ b/manuals/language-concepts/bodies.markdown
@@ -27,10 +27,6 @@ The CFEngine reserved word `body` is used to encapsulate the details of complex
 attribute values. Bodies can optionally have parameters.
 
 ```cf3
-    files:
-        "/home/promiser"
-            perms => myexample;
-
     bundle agent example
     {
       files:


### PR DESCRIPTION
Make non parametrized example more practical. Multiple file owner and group specification can confuse people. It's documented in the reference manual but when introducing the concept I think its better to KISS.

Augment example to show parametrized use of perms body.
