### PR TITLE
Added newlines back to promise-types.markdown that had been erroneously removed

### DIFF
--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -7,9 +7,11 @@ alias: reference-promise-types-miscellaneous.html
 tags: [reference, bundles, common, miscellaneous, promises]
 ---
 
-Common bundles may only contain the promise types that are common to all bodies. Their main function is to define cross-component global definitions.
+Common bundles may only contain the promise types that are common to all 
+bodies. Their main function is to define cross-component global definitions.
 
-Common bundles are observed by every agent, whereas the agent specific bundle types are ignored by components other than the intended recipient.
+Common bundles are observed by every agent, whereas the agent specific 
+bundle types are ignored by components other than the intended recipient.
 
 ```cf3
      
@@ -35,14 +37,6 @@ be made in any kind of bundle since they are of a generic input/output nature.
 These are `vars`, `classes`, and `reports` promises. The specific promise 
 attributes are listed below.
 
--   [action in \*](#action-in-_002a)
--   [classes in \*](#classes-in-_002a)
--   [comment in \*](#comment-in-_002a)
--   [depends\_on in \*](#depends_005fon-in-_002a)
--   [handle in \*](#handle-in-_002a)
--   [ifvarclass in \*](#ifvarclass-in-_002a)
--   [meta in \*](#meta-in-_002a)
-
 #### `action` (body template)
 
 **Type**: (ext body)
@@ -59,7 +53,12 @@ attributes are listed below.
                     nop
 ```
 
-**Synopsis**: Whether to repair or report about non-kept promises
+**Description**: The `action_policy` menu option policy determines whether 
+to repair or report about non-kept promises. The `action` settings allow 
+general transaction control to be implemented on promise verification. 
+Action bodies place limits on how often to verify the promise and what 
+classes to raise in the case that the promise can or cannot be kept.
+
 
 **Example**:  
    
@@ -75,18 +74,10 @@ The following example shows a simple use of transaction control:
      
 ```
 
-**Notes**:  
-   
-
-The `action` settings allow general transaction control to be
-implemented on promise verification. Action bodies place limits on how
-often to verify the promise and what classes to raise in the case that
-the promise can or cannot be kept.
-
-Note that actions can be added to sub-bundles like methods and editing
-bundles, and that promises within these do not inherit action settings
-at higher levels. Thus, in the following example there are two levels of
-action setting:
+Note that actions can be added to sub-bundles like methods and editing 
+bundles, and that promises within these do not inherit action settings 
+at higher levels. Thus, in the following example there are two levels
+ of action setting:
 
 ```cf3
      ########################################################
@@ -159,10 +150,18 @@ given by `cf-agent` will differ.
 
 **Allowed input range**: `0,99999999999`
 
-**Synopsis**: Number of minutes before next allowed assessment of
-promise
-
 **Default value:** control body value
+
+**Description**: The number of minutes before next allowed assessment of 
+a promise is set using `ifelapsed`. This overrides the global settings. 
+Promises which take a long time to verify should usually be protected 
+with a long value for this parameter.
+
+This serves as a resource \`spam' protection. A CFEngine check could 
+easily run every 5 minutes provided resource intensive operations are 
+not performed on every run. Using time classes such as `Hr12` is one 
+part of this strategy; using `ifelapsed` is another, which is not tied 
+to a specific time.   
 
 **Example**:  
    
@@ -186,27 +185,17 @@ promise
      
 ```
 
-**Notes**:  
-   
-
-This overrides the global settings. Promises which take a long time to
-verify should usually be protected with a long value for this parameter.
-This serves as a resource \`spam' protection. A CFEngine check could
-easily run every 5 minutes provided resource intensive operations are
-not performed on every run. Using time classes such as `Hr12` is one
-part of this strategy; using `ifelapsed` is another, which is not tied
-to a specific time.   
-
 `expireafter`
 
 **Type**: int
 
 **Allowed input range**: `0,99999999999`
 
-**Synopsis**: Number of minutes before a repair action is interrupted
-and retried
-
 **Default value:** control body value
+
+**Description**: The Number of minutes before a repair action is interrupted 
+and retried is set with `expireafter`. This is the locking time after which 
+CFEngine will attempt to kill and restart its attempt to keep a promise.   
 
 **Example**:  
    
@@ -219,20 +208,21 @@ and retried
      }
 ```
 
-**Notes**:  
-   
 
-The locking time after which CFEngine will attempt to kill and restart
-its attempt to keep a promise.   
-
-`log_string`
 
 **Type**: string
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: A message to be written to the log when a promise
-verification leads to a repair
+**Description**: The message to be written to the log when a promise 
+verification leads to a repair is determined by the `log_string`. The 
+`log_string` works together with `log_repair`, `log_kept` etc, to define 
+a string for logging to one of the named files depending on promise outcome, 
+or to standard output if the log file is stipulated as stdout. Log strings 
+on standard output are denoted by an L: prefix.
+
+Note that `log_string` does not interact with `log_level`, which is about 
+regular system output messages.
 
 **Example**:  
    
@@ -255,22 +245,10 @@ verification leads to a repair
           
 ```
 
-**Notes**:  
-   
-
-The `log_string` works together with `log_repair`, `log_kept` etc, to
-define a string for logging to one of the named files depending on
-promise outcome, or to standard output if the log file is stipulated as
-stdout. Log strings on standard output are denoted by an L: prefix.
-
-Note that `log_string` does not interact with `log_level`, which is
-about regular system output messages.
-
-Hint: the promise handle \$(this.handle) can be a useful referent in a
-log message, indicating the origin of the message. In CFEngine Nova and
-above, every promise has a default handle, which is based on the
-filename and line number (specifying your own handle will probably be
-more mnemonic).   
+**Hint**: The promise handle \$(this.handle) can be a useful referent in a 
+log message, indicating the origin of the message. In CFEngine Nova and 
+above, every promise has a default handle, which is based on the filename 
+and line number (specifying your own handle will probably be more mnemonic).   
 
 `log_level`
 
@@ -285,7 +263,16 @@ more mnemonic).
                     log
 ```
 
-**Synopsis**: The reporting level sent to syslog
+**Description**: The `log_level` describes the reporting level sent to 
+syslog. Use this as an alternative to auditing if you wish to use the 
+syslog mechanism to centralize or manage messaging from CFEngine. A backup
+ of these messages will still be kept in WORKDIR/outputs if you are using 
+ `cf-execd`.
+
+On the native Windows version of CFEngine (Nova or above), using verbose 
+will include a message when the promise is kept or repaired in the event 
+log.   
+
 
 **Example**:  
    
@@ -299,26 +286,25 @@ more mnemonic).
      
 ```
 
-**Notes**:  
-   
-
-Use this as an alternative to auditing if you wish to use the syslog
-mechanism to centralize or manage messaging from CFEngine. A backup of
-these messages will still be kept in WORKDIR/outputs if you are using
-`cf-execd`.
-
-On the native Windows version of CFEngine (Nova or above), using verbose
-will include a message when the promise is kept or repaired in the event
-log.   
-
 `log_kept`
 
 **Type**: string
 
 **Allowed input range**: `stdout|udp_syslog|("?[a-zA-Z]:\\.*)|(/.*)`
 
-**Synopsis**: This should be the filename of a file to which log\_string
-will be saved, and if undefined it goes to the system logger
+**Description**: The `log_kept` string should be the filename of a 
+file to which log\_string will be saved, and if undefined it goes to 
+the system logger.
+
+If this option is specified together with `log_string`, the current 
+promise will log promise-kept status using the log string to this named
+ file. If these log names are absent, the default logging destination 
+ for the log string is syslog, but only for non-kept promises. Only the 
+ `log_string` is affected by this setting. Other messages destined for 
+ logging are sent to syslog.
+
+It is intended that named file logs should be different for the three 
+cases: promise kept, promise not kept and promise repaired.
 
 **Example**:  
    
@@ -335,34 +321,19 @@ will be saved, and if undefined it goes to the system logger
      
 ```
 
-**Notes**:  
-   
-
-If this option is specified together with `log_string`, the current
-promise will log promise-kept status using the log string to this named
-file. If these log names are absent, the default logging destination for
-the log string is syslog, but only for non-kept promises. Only the
-`log_string` is affected by this setting. Other messages destined for
-logging are sent to syslog.
-
-It is intended that named file logs should be different for the three
-cases: promise kept, promise not kept and promise repaired.
-
-This string should be the full path to a text file which will contain
+This string should be the full path to a text file which will contain 
 the log, of one of the following special values:
 
 stdout
 
-Send the log message to the standard output, prefixed with an L: to
-indicate a log message.   
+Send the log message to the standard output, prefixed with an L: to indicate 
+a log message.   
 
 udp\_syslog
 
-Attempt to connect to the `syslog_server` defined in body common control
-and log the message there, assuming the server is configured to receive
-the request.
-
-  
+Attempt to connect to the `syslog_server` defined in body common control and 
+log the message there, assuming the server is configured to receive the 
+request.
 
 `log_priority`
 
@@ -381,8 +352,9 @@ the request.
                     debug
 ```
 
-**Synopsis**: The priority level of the log message, as interpreted by a
-syslog server
+**Description**: The `log_priority` menu option policy is the priority level 
+of the log message, as interpreted by a syslog server. It determines the 
+importance of messages from CFEngine.   
 
 **Example**:  
    
@@ -394,19 +366,15 @@ syslog server
      }
 ```
 
-**Notes**:  
-   
-
-This determines the importance of messages from CFEngine.   
-
 `log_repaired`
 
 **Type**: string
 
 **Allowed input range**: `stdout|udp_syslog|("?[a-zA-Z]:\\.*)|(/.*)`
 
-**Synopsis**: This should be filename of a file to which log\_string
-will be saved, if undefined it goes to the system logger
+**Description**: The `log_repaired` string should contain the filename of a 
+file to which log\_string will be saved, if undefined it goes to the system 
+logger.
 
 **Example**:  
    
@@ -443,25 +411,20 @@ will be saved, if undefined it goes to the system logger
      }
 ```
 
-**Notes**:  
-   
-
-This may be the name of a log to which the `log_string` is written if a
-promise is repaired. It should be the full path to a text file which
-will contain the log, of one of the following special values:
+`log_repaired` may be the name of a log to which the `log_string` is 
+written if a promise is repaired. It should be the full path to a text 
+file which will contain the log, of one of the following special values:
 
 stdout
 
-Send the log message to the standard output, prefixed with an L: to
+Send the log message to the standard output, prefixed with an L: to 
 indicate a log message.   
 
 udp\_syslog
 
-Attempt to connect to the `syslog_server` defined in body common control
-and log the message there, assuming the server is configured to receive
+Attempt to connect to the `syslog_server` defined in body common control 
+and log the message there, assuming the server is configured to receive 
 the request.
-
-  
 
 `log_failed`
 
@@ -469,8 +432,14 @@ the request.
 
 **Allowed input range**: `stdout|udp_syslog|("?[a-zA-Z]:\\.*)|(/.*)`
 
-**Synopsis**: This should be the filename of a file to which log\_string
-will be saved, and if undefined it goes to the system logger
+**Description**: The string `log_failed` should contain the filename of a 
+file to which log\_stringvwill be saved, and if undefined it goes to the 
+system logger. If this option is specified together with `log_string`, 
+the current promise will log promise-kept status using the log string to 
+this named file. If these log names are absent, the default logging 
+destination for the log string is syslog, but only for non-kept promises. 
+Only the `log_string` is affected by this setting. Other messages 
+destined for logging are sent to syslog.
 
 **Example**:  
    
@@ -503,33 +472,21 @@ will be saved, and if undefined it goes to the system logger
      
 ```
 
-**Notes**:  
-   
-
-If this option is specified together with `log_string`, the current
-promise will log promise-kept status using the log string to this named
-file. If these log names are absent, the default logging destination for
-the log string is syslog, but only for non-kept promises. Only the
-`log_string` is affected by this setting. Other messages destined for
-logging are sent to syslog.
-
-It is intended that named file logs should be different for the three
-cases: promise kept, promise not kept and promise repaired. This string
-should be the full path to a text file which will contain the log, of
-one of the following special values:
+It is intended that named file logs should be different for the three cases: 
+promise kept, promise not kept and promise repaired. This string should be 
+the full path to a text file which will contain the log, of one of the 
+following special values:
 
 stdout
 
-Send the log message to the standard output, prefixed with an L: to
-indicate a log message.   
+Send the log message to the standard output, prefixed with an L: to indicate 
+a log message.   
 
 udp\_syslog
 
-Attempt to connect to the `syslog_server` defined in body common control
-and log the message there, assuming the server is configured to receive
+Attempt to connect to the `syslog_server` defined in body common control 
+and log the message there, assuming the server is configured to receive 
 the request.
-
-  
 
 `value_kept`
 
@@ -537,7 +494,10 @@ the request.
 
 **Allowed input range**: `-9.99999E100,9.99999E100`
 
-**Synopsis**: A real number value attributed to keeping this promise
+**Description**: The value of `value_kept` is a real number value attributed 
+to keeping this promise. If nothing is specified, the default value is 
++1.0. However, nothing is logged unless the agent control body switched 
+on track\_value = "true".
 
 **Example**:  
    
@@ -553,13 +513,6 @@ the request.
      }
      
 ```
-
-**Notes**:  
-   
-
-If nothing is specified, the default value is +1.0. However, nothing is
-logged unless the agent control body switched on track\_value = "true".
-  
 
 `value_repaired`
 
@@ -567,8 +520,11 @@ logged unless the agent control body switched on track\_value = "true".
 
 **Allowed input range**: `-9.99999E100,9.99999E100`
 
-**Synopsis**: A real number value attributed to repairing this promise
-
+**Description**: The value of `value_repaired` is a real number value 
+attributed to repairing a promise. If nothing is specified, the default 
+value is 0.5. However, nothing is logged unless the agent control body 
+switched on track\_value = "true".
+  
 **Example**:  
    
 
@@ -583,13 +539,6 @@ logged unless the agent control body switched on track\_value = "true".
      }
      
 ```
-
-**Notes**:  
-   
-
-If nothing is specified, the default value is 0.5. However, nothing is
-logged unless the agent control body switched on track\_value = "true".
-  
 
 `value_notkept`
 
@@ -597,9 +546,11 @@ logged unless the agent control body switched on track\_value = "true".
 
 **Allowed input range**: `-9.99999E100,9.99999E100`
 
-**Synopsis**: A real number value (possibly negative) attributed to not
-keeping this promise
-
+**Description**: The value of `value_notkept` is a real number value (possibly 
+negative) attributed to not keeping a promise. If nothing is specified, the 
+default value is -1.0. However, nothing is logged unless the agent control 
+body switched on track\_value = "true".
+  
 **Example**:  
    
 
@@ -615,12 +566,6 @@ keeping this promise
      
 ```
 
-**Notes**:  
-   
-
-If nothing is specified, the default value is -1.0. However, nothing is
-logged unless the agent control body switched on track\_value = "true".
-  
 
 `audit`
 
@@ -637,8 +582,11 @@ logged unless the agent control body switched on track\_value = "true".
                     off
 ```
 
-**Synopsis**: true/false switch for detailed audit records of this
-promise
+**Description**: The `audit` menu option policy is a true/false switch for 
+detailed audit records of a promise. If this is set, CFEngine will perform 
+auditing on this specific promise. This means that all details surrounding 
+the verification of the current promise will be recorded in the audit 
+database.   
 
 **Default value:** false
 
@@ -656,13 +604,6 @@ promise
      
 ```
 
-**Notes**:  
-   
-
-If this is set, CFEngine will perform auditing on this specific promise.
-This means that all details surrounding the verification of the current
-promise will be recorded in the audit database.   
-
 `background`
 
 **Type**: (menu option)
@@ -678,7 +619,18 @@ promise will be recorded in the audit database.
                     off
 ```
 
-**Synopsis**: true/false switch for parallelizing the promise repair
+**Description**: The `background` menu option policy is a true/false 
+switch for parallelizing the promise repair. If possible, perform the 
+verification of the current promise in the background. This is advantageous 
+only if the verification might take a significant amount of time, e.g. 
+in remote copying of filesystem/disk scans.
+
+On the Windows version of CFEngine Nova, this can be useful if we don't
+ want to wait for a particular command to finish execution before checking 
+ the next promise. This is particular for the Windows platform because there 
+ is no way that a program can start itself in the background here; in other 
+ words, fork off a child process. However, file operations can not be 
+ performed in the background on Windows.   
 
 **Default value:** false
 
@@ -694,21 +646,6 @@ promise will be recorded in the audit database.
      
 ```
 
-**Notes**:  
-   
-
-If possible, perform the verification of the current promise in the
-background. This is advantageous only if the verification might take a
-significant amount of time, e.g. in remote copying of filesystem/disk
-scans.
-
-On the windows version of CFEngine Nova, this can be useful if we don't
-want to wait for a particular command to finish execution before
-checking the next promise. This is particular for the Windows platform
-because there is no way that a program can start itself in the
-background here; in other words, fork off a child process. However, file
-operations can not be performed in the background on windows.   
-
 `report_level`
 
 **Type**: (menu option)
@@ -722,9 +659,17 @@ operations can not be performed in the background on windows.
                     log
 ```
 
-**Synopsis**: The reporting level for standard output for this promise
-
 **Default value:** none
+
+**Description**: The `report_level` menu option policy defines the reporting 
+level for standard output for this promise. cf-agent can be run in verbose 
+mode (-v), inform mode (-I) and just print errors (no arguments). This 
+attribute allows to set these three output levels on a per promise basis, 
+allowing the promise to be more verbose than the global setting (but not 
+less).
+
+In CFEngine 2 one would say inform=true or syslog=true, and so on. This 
+replaces these levels since they act as encapsulating super-sets.   
 
 **Example**:  
    
@@ -738,16 +683,6 @@ operations can not be performed in the background on windows.
      
 ```
 
-**Notes**:  
-   
-
-cf-agent can be run in verbose mode (-v), inform mode (-I) and just
-print errors (no arguments). This attribute allows to set these three
-output levels on a per promise basis, allowing the promise to be more
-verbose than the global setting (but not less).
-
-In CFEngine 2 one would say inform=true or syslog=true, and so on. This
-replaces these levels since they act as encapsulating super-sets.   
 
 `measurement_class`
 
@@ -755,12 +690,13 @@ replaces these levels since they act as encapsulating super-sets.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: If set performance will be measured and recorded under
-this identifier
+**Description**: The `measurement_class` string, if set, performance 
+will be measured and recorded under this identifier. By setting this string 
+you switch on performance measurement for the current promise, and also 
+give the measurement a name. 
 
 **Example**:  
    
-
 ```cf3
      
      
@@ -771,13 +707,7 @@ this identifier
      
 ```
 
-**Notes**:  
-   
-
-By setting this string you switch on performance measurement for the
-current promise, and also give the measurement a name. The identifier
-forms a partial identity for optional performance scanning of promises
-of the form:
+The identifier forms a partial identity for optional performance scanning of promises of the form:
 
 ```cf3
           ID:promise-type:promiser.
@@ -788,17 +718,22 @@ of the form:
 
 **Type**: (ext body)
 
+
 `promise_repaired`
 
 **Type**: slist
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be defined globally
+**Description**: The `promise_repaired` slist contains classes to be defined 
+globally. If a promise is \`repaired' it means that a corrective action had 
+to be taken to keep the promise.
+
+Note that any strings passed to this list are automatically canonified, so 
+it is unnecessary to call a canonify function on such inputs.
 
 **Example**:  
    
-
 ```cf3
      
      body classes example
@@ -808,24 +743,16 @@ of the form:
      
 ```
 
-**Notes**:  
-   
-
-If a promise is \`repaired' it means that a corrective action had to be
-taken to keep the promise.
-
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.
-
-Important: complex promises can report misleadingly; for example,
+**Important**: Complex promises can report misleadingly; for example, 
 `files` promises that set multiple parameters on a file simultaneously.
 
-The classes for different parts of a promise are not separable. Thus, if
-you promise to create and file and change its permissions, when the file
-exists with incorrect permissions, `cf-agent` will report that the
-promise\_kept for the file existence, but promise\_repaired for the
-permissions. If you need separate reports, you should code two separate
+The classes for different parts of a promise are not separable. Thus, if 
+you promise to create and file and change its permissions, when the file 
+exists with incorrect permissions, `cf-agent` will report that the 
+promise\_kept for the file existence, but promise\_repaired for the 
+permissions. If you need separate reports, you should code two separate 
 promises rather than \`overloading' a single one.   
+
 
 `repair_failed`
 
@@ -833,7 +760,10 @@ promises rather than \`overloading' a single one.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be defined globally
+**Description**: A `repair_failed` list contains classes to be defined 
+globally. A promise could not be repaired because the corrective action 
+failed for some reason. Any strings passed to this list are automatically 
+canonified, so it is unnecessary to call a canonify function on such inputs.   
 
 **Example**:  
    
@@ -847,26 +777,20 @@ promises rather than \`overloading' a single one.
      
 ```
 
-**Notes**:  
-   
-
-A promise could not be repaired because the corrective action failed for
-some reason.
-
-Any strings passed to this list are automatically canonified, so it is
-unnecessary to call a canonify function on such inputs.   
-
 `repair_denied`
 
 **Type**: slist
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be defined globally
+**Description**: The `repair_denied` slist contains classes to be defined 
+globally. Note that any strings passed to this list are automatically 
+canonified, so it is unnecessary to call a canonify function on such 
+inputs.   
+
 
 **Example**:  
    
-
 ```cf3
      
      body classes example
@@ -876,13 +800,9 @@ unnecessary to call a canonify function on such inputs.
      
 ```
 
-**Notes**:  
-   
+In the above example, a promise could not be kept because access to a key 
+resource was denied. 
 
-A promise could not be kept because access to a key resource was denied.
-
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.   
 
 `repair_timeout`
 
@@ -890,7 +810,8 @@ so it is unnecessary to call a canonify function on such inputs.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be defined globally
+**Description**: The `repair_timeout` slist contains classes to be defined 
+globally.
 
 **Example**:  
    
@@ -902,13 +823,9 @@ so it is unnecessary to call a canonify function on such inputs.
      repair_timeout => { "too_slow", "did_not_wait" };
      }
      
-```
+``` 
 
-**Notes**:  
-   
-
-A promise maintenance repair timed-out waiting for some dependent
-resource.   
+In the above example, a promise maintenance repair timed-out waiting for some dependent resource.   
 
 `promise_kept`
 
@@ -916,7 +833,10 @@ resource.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be defined globally
+**Description**: The `promise_kept` slist contains classes to be defined 
+globally. Note that any strings passed to this list are automatically 
+canonified, so it is unnecessary to call a canonify function on such inputs.
+
 
 **Example**:  
    
@@ -930,23 +850,18 @@ resource.
      
 ```
 
-**Notes**:  
-   
+The class in the above example is set if no action was necessary by 
+`cf-agent`, because the promise concerned was already kept without further 
+action required.
 
-This class is set if no action was necessary by `cf-agent` because the
-promise concerned was already kept without further action required.
+**Important**: complex promises can report misleadingly. For example, 
+`files`promises that set multiple parameters on a file simultaneously.
 
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.
-
-Important: complex promises can report misleadingly; for example `files`
-promises that set multiple parameters on a file simultaneously .
-
-The classes for different parts of a promise are not separable. Thus, if
-you promise to create and file and change its permissions, when the file
-exists with incorrect permissions, `cf-agent` will report that the
-promise\_kept for the file existence, but promise\_repaired for the
-permissions. If you need separate reports, you should code two separate
+The classes for different parts of a promise are not separable. Thus, 
+if you promise to create and file and change its permissions, when the 
+file exists with incorrect permissions, `cf-agent` will report that the 
+promise\_kept for the file existence, but promise\_repaired for the 
+permissions. If you need separate reports, you should code two separate 
 promises rather than \`overloading' a single one.   
 
 `cancel_kept`
@@ -955,11 +870,13 @@ promises rather than \`overloading' a single one.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be canceled if the promise is kept
+**Description**: A `cancel_kept` slist contains classes to be canceled if 
+the promise is kept. Note that any strings passed to this list are 
+automatically canonified, so it is unnecessary to call a canonify function 
+on such inputs.
 
 **Example**:  
    
-
 ```cf3
      
      body classes example
@@ -969,17 +886,11 @@ promises rather than \`overloading' a single one.
      
 ```
 
-**Notes**:  
-   
+In the above example, if the promise was already kept and nothing was done, 
+cancel (undefine) any of the listed classes so that they are no longer 
+defined.
 
-If the promise was already kept and nothing was done, cancel (undefine)
-any of the listed classes so that they are no longer defined.
-
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.
-
-**History**: This attribute was introduced in CFEngine version 3.0.4
-(2010)   
+**History**: This attribute was introduced in CFEngine version 3.0.4 (2010)   
 
 `cancel_repaired`
 
@@ -987,8 +898,10 @@ so it is unnecessary to call a canonify function on such inputs.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be canceled if the promise is
-repaired
+**Description**: A `cancel_repaired` slist contains classes to be canceled 
+if the promise is repaired. Note that any strings passed to this list are 
+automatically canonified, so it is unnecessary to call a canonify function 
+on such inputs.
 
 **Example**:  
    
@@ -1002,17 +915,11 @@ repaired
      
 ```
 
-**Notes**:  
-   
+In the above example, if the promise was repaired and changes were made to 
+the system, cancel (undefine) any of the listed classes so that they are 
+no longer defined.
 
-If the promise was repaired and changes were made to the system, cancel
-(undefine) any of the listed classes so that they are no longer defined.
-
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.
-
-**History**: This attribute was introduced in CFEngine version 3.0.4
-(2010)   
+**History**: This attribute was introduced in CFEngine version 3.0.4 (2010)   
 
 `cancel_notkept`
 
@@ -1020,12 +927,13 @@ so it is unnecessary to call a canonify function on such inputs.
 
 **Allowed input range**: `[a-zA-Z0-9_$(){}\[\].:]+`
 
-**Synopsis**: A list of classes to be canceled if the promise is not
-kept for any reason
+**Description**: A `cancel_notkept` slist contains classes to be canceled 
+if the promise is not kept for any reason. Note that any strings passed 
+to this list are automatically canonified, so it is unnecessary to call 
+a canonify function on such inputs.
 
 **Example**:  
    
-
 ```cf3
      
      body classes example
@@ -1035,17 +943,11 @@ kept for any reason
      
 ```
 
-**Notes**:  
-   
+In the above example, if the promise was not kept but nothing could be done, 
+cancel (undefine) any of the listed classes so that they are no longer 
+defined.
 
-If the promise was not kept but nothing could be done, cancel (undefine)
-any of the listed classes so that they are no longer defined.
-
-Note that any strings passed to this list are automatically canonified,
-so it is unnecessary to call a canonify function on such inputs.
-
-**History**: This attribute was introduced in CFEngine version 3.0.4
-(2010)   
+**History**: This attribute was introduced in CFEngine version 3.0.4 (2010)   
 
 `kept_returncodes`
 
@@ -1053,8 +955,8 @@ so it is unnecessary to call a canonify function on such inputs.
 
 **Allowed input range**: `[-0-9_$(){}\[\].]+`
 
-**Synopsis**: A list of return codes indicating a kept command-related
-promise
+**Description**: A `kept_returncodes` slist contains return codes indicating a 
+kept command-related promise.
 
 **Example**:  
    
@@ -1078,31 +980,28 @@ promise
      }
 ```
 
-**Notes**:  
-   
+In the above example, a list of integer return codes indicates that a 
+command-related promise has been kept. This can in turn be used to define 
+classes using the `promise_kept` attribute, or merely alter the total 
+compliance statistics.
 
-A list of integer return codes indicating that a command-related promise
-has been kept. This can in turn be used to define classes using the
-`promise_kept` attribute, or merely alter the total compliance
-statistics.
-
-Currently, the attribute has impact on the following command-related
-promises.
+Currently, the attribute has impact on the following command-related 
+promises:
 
 -   All promises of type `commands:`
 -   `files`-promises containing a `transformer`-attribute
--   The package manager change command in `packages`-promises (e.g. the
-    command for add, remove, etc.)
+-   The package manager change command in `packages`-promises (e.g. the 
+command for add, remove, etc.)
 
-If none of the attributes `kept_returncodes`, `repaired_returncodes`, or
-`failed_returncodes` are set, the default is to consider a return code
+If none of the attributes `kept_returncodes`, `repaired_returncodes`, or 
+`failed_returncodes` are set, the default is to consider a return code 
 zero as promise repaired, and nonzero as promise failed.
 
-Note that the return codes may overlap, so multiple classes may be set
-from one return code. In Unix systems the possible return codes are
+Note that the return codes may overlap, so multiple classes may be set 
+from one return code. In Unix systems the possible return codes are 
 usually in the range from 0 to 255.
 
-*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
+**History**: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
 `repaired_returncodes`
 
@@ -1110,12 +1009,11 @@ usually in the range from 0 to 255.
 
 **Allowed input range**: `[-0-9_$(){}\[\].]+`
 
-**Synopsis**: A list of return codes indicating a repaired
-command-related promise
+**Description**: A `repaired_returncodes` slist contains return codes 
+indicating a repaired command-related promise
 
 **Example**:  
    
-
 ```cf3
      bundle agent cmdtest
      {
@@ -1131,33 +1029,29 @@ command-related promise
      body classes example
      {
      repaired_returncodes => { "0", "1" };
-     promise_repaired => { "wasrepaired" };
+     promise_repaired => { "wasrepaired" }; 
      }
 ```
 
-**Notes**:  
-   
+In the above example, a list of integer return codes indicating that a 
+command-related promise has been repaired. This can in turn be used to 
+define classes using the `promise_repaired` attribute, or merely alter the total compliance statistics.
 
-A list of integer return codes indicating that a command-related promise
-has been repaired. This can in turn be used to define classes using the
-`promise_repaired` attribute, or merely alter the total compliance
-statistics.
-
-Currently, the attribute has impact on the following command-related
-promises.
+Currently, the attribute has impact on the following command-related 
+promises:
 
 -   All promises of type `commands:`
 -   `files`-promises containing a `transformer`-attribute
--   The package manager change command in `packages`-promises (e.g. the
-    command for add, remove, etc.)
+-   The package manager change command in `packages`-promises (e.g. the 
+command for add, remove, etc.)
 
-If none of the attributes `kept_returncodes`, `repaired_returncodes`, or
-`failed_returncodes` are set, the default is to consider a return code
-zero as promise repaired, and nonzero as promise failed.
+If none of the attributes `kept_returncodes`, `repaired_returncodes`, 
+or `failed_returncodes` are set, the default is to consider a return 
+code zero as promise repaired, and nonzero as promise failed.
 
-Note that the return codes may overlap, so multiple classes may be set
-from one return code. In Unix systems the possible return codes are
-usually in the range from 0 to 255.
+Note that the return codes may overlap, so multiple classes may be set 
+from one return code. In Unix systems the possible return codes are usually 
+in the range from 0 to 255.
 
 *History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
@@ -1167,8 +1061,8 @@ usually in the range from 0 to 255.
 
 **Allowed input range**: `[-0-9_$(){}\[\].]+`
 
-**Synopsis**: A list of return codes indicating a failed command-related
-promise
+**Description**: A `failed_returncodes` slist contains return codes 
+indicating a failed command-related promise.
 
 **Example**:  
    
@@ -1207,31 +1101,28 @@ promise
      } 
 ```
 
-**Notes**:  
-   
+The above example contains a list of integer return codes indicating 
+that a command-related promise has failed. This can in turn be used to 
+define classes using the `promise_repaired` attribute, or merely alter 
+the total compliance statistics.
 
-A list of integer return codes indicating that a command-related promise
-has failed. This can in turn be used to define classes using the
-`promise_repaired` attribute, or merely alter the total compliance
-statistics.
-
-Currently, the attribute has impact on the following command-related
+Currently, the attribute has impact on the following command-related 
 promises.
 
 -   All promises of type `commands:`
 -   `files`-promises containing a `transformer`-attribute
--   The package manager change command in `packages`-promises (e.g. the
-    command for add, remove, etc.)
+-   The package manager change command in `packages`-promises (e.g. the 
+command for add, remove, etc.)
 
-If none of the attributes `kept_returncodes`, `repaired_returncodes`, or
-`failed_returncodes` are set, the default is to consider a return code
+If none of the attributes `kept_returncodes`, `repaired_returncodes`, or 
+`failed_returncodes` are set, the default is to consider a return code 
 zero as promise repaired, and nonzero as promise failed.
 
-Note that the return codes may overlap, so multiple classes may be set
-from one return code. In Unix systems the possible return codes are
-usually in the range from 0 to 255.
+Note that the return codes may overlap, so multiple classes may be set from 
+one return code. In Unix systems the possible return codes are usually in 
+the range from 0 to 255.
 
-*History*: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
+**History**: Was introduced in version 3.1.3, Nova 2.0.2 (2010)   
 
 `persist_time`
 
@@ -1239,8 +1130,10 @@ usually in the range from 0 to 255.
 
 **Allowed input range**: `0,99999999999`
 
-**Synopsis**: A number of minutes the specified classes should remain
-active
+**Description**: The value of `persist_time` defines the number of minutes 
+the specified classes should remain active. By default classes are ephemeral 
+entities that disappear when `cf-agent` terminates. By setting a persistence 
+time, they can last even when the agent is not running.   
 
 **Example**:  
    
@@ -1254,13 +1147,6 @@ active
      
 ```
 
-**Notes**:  
-   
-
-By default classes are ephemeral entities that disappear when `cf-agent`
-terminates. By setting a persistence time, they can last even when the
-agent is not running.   
-
 `timer_policy`
 
 **Type**: (menu option)
@@ -1272,8 +1158,11 @@ agent is not running.
                     reset
 ```
 
-**Synopsis**: Whether a persistent class restarts its counter when
-rediscovered
+**Description**: The `timer_policy` menu option policy determines whether 
+a persistent class restarts its counter when rediscovered. In most cases 
+resetting a timer will give a more honest appraisal of which classes are 
+currently important, but if we want to activate a response of limited 
+duration as a rare event then an absolute time limit is useful.
 
 **Default value:** reset
 
@@ -1289,21 +1178,15 @@ rediscovered
      
 ```
 
-**Notes**:  
-   
-
-In most cases resetting a timer will give a more honest appraisal of
-which classes are currently important, but if we want to activate a
-response of limited duration as a rare event then an absolute time limit
-is useful.
-
 #### `comment`
 
 **Type**: string
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: A comment about the real intention of the promise
+**Description**: The `comment` string describes the real intention of the 
+promise. Comments written in code follow the program, they are not merely 
+discarded; they appear in reports and error messages.
 
 **Example**:  
    
@@ -1312,20 +1195,25 @@ is useful.
 comment => "This comment follows the data for reference ...",
 ```
 
-**Notes**:  
-   
-
-Comments written in code follow the program, they are not merely
-discarded. They appear in reports and error messages.
-
 #### `depends_on`
 
 **Type**: slist
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: A list of promise handles that this promise builds on or
-depends on somehow
+**Description**: A `depends_on` slist contains promise handles that this 
+promise builds on or depends on somehow. This is a list of promise handles 
+for whom this promise is a promisee. In other words, we acknowledge that 
+this promise will be affected by the list of promises whose handles are 
+specified. It has the effect of partially ordering promises.
+
+As of version 3.4.0, this feature may be considered short-hand for setting 
+classes. If one promise depends on a list of others, it will not be verified 
+unless the dependent promises have already been verified and kept: in other 
+words, as long as the dependent promises are either kept or repaired the 
+dependee can be verified.
+
+Handles in other namespaces may be referred to by namespace:handle.
 
 **Example**:  
    
@@ -1352,58 +1240,38 @@ reports:
 
 ```
 
-**Notes**:  
-   
-
-This is a list of promise handles for whom this promise is a promisee.
-In other words, we acknowledge that this promise will be affected by the
-list of promises whose handles are specified. It has the effect of
-partially ordering promises.
-
-As of version 3.4.0, this feature is active and may be considered
-short-hand for setting classes. If one promise depends on a list of
-others, it will not be verified unless the dependent promises have
-already been verified and kept: in other words, as long as the dependent
-promises are either kept or repaired the dependee can be verified.
-
-Handles in other namespaces may be referred to by namespace:handle.
-
 #### `handle`
 
 **Type**: string
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: A unique id-tag string for referring to this as a promisee
-elsewhere
+**Description**: The `handle` string is a unique id-tag string for referring 
+to this as a promisee elsewhere.
+
+A promise handle is like a \`goto' label. It allows you to refer to a promise
+ as the promisee of `depends_on` client of another promise. Handles are 
+ essential for mapping dependencies and performing impact analyses. In 
+ Enterprise versions of CFEngine, promise handles can also be used in 
+ `outputs` promises, See [outputs in agent promises]
+ (#outputs-in-agent-promises).
+
+Handles may consist of regular identifier characters. CFEngine automatically 
+\`canonifies' the names of handles to conform to this standard.
 
 **Example**:  
    
 
 ```cf3
 access:
-
+ 
   "/source"
 
     handle  => "update_rule",
     admit   => { "127.0.0.1" };
 ```
 
-**Notes**:  
-   
-
-A promise handle is like a \`goto' label. It allows you to refer to a
-promise as the promisee of `depends_on` client of another promise.
-Handles are essential for mapping dependencies and performing impact
-analyses. In Enterprise versions of CFEngine, promise handles can also
-be used in `outputs` promises, See [outputs in agent
-promises](#outputs-in-agent-promises).
-
-Handles may consist of regular identifier characters. CFEngine
-automatically \`canonifies' the names of handles to conform to this
-standard.
-
-Caution: If the handle name is based on a variable, and the variable
+**Caution**: If the handle name is based on a variable, and the variable
 fails to expand, the handle will be based on the name of the variable
 rather than its content.
 
@@ -1413,7 +1281,13 @@ rather than its content.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: Extended classes ANDed with context
+**Description**: The `ifvarclass` string describes extended classes ANDed 
+with context. This is an additional class expression that will be evaluated 
+after the class:: classes have selected promises. It is provided in order 
+to enable a channel between variables and classes.
+
+The result is thus the logical AND of the ordinary classes and the variable 
+classes.
 
 **Example**:  
    
@@ -1452,17 +1326,7 @@ commands:
 }
 ```
 
-**Notes**:  
-   
-
-This is an additional class expression that will be evaluated after the
-class:: classes have selected promises. It is provided in order to
-enable a channel between variables and classes.
-
-The result is thus the logical AND of the ordinary classes and the
-variable classes.
-
-This function is provided so that one can form expressions that link
+This function is provided so that one can form expressions that link 
 variables and classes. For example:
 
 ```cf3
@@ -1483,9 +1347,9 @@ commands:
        ifvarclass => canonify("start_$(component)");
 ```
 
-Notice that the function `canonify()` is provided to convert a general
-variable input into a string composed only of legal characters, using
-the same algorithm that CFEngine uses.
+Notice that the function `canonify()` is provided to convert a general variable 
+input into a string composed only of legal characters, using the same algorithm 
+that CFEngine uses.
 
 #### `meta`
 
@@ -1493,7 +1357,12 @@ the same algorithm that CFEngine uses.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: User-data associated with policy, e.g. key=value strings
+**Description**: The `meta` string describes user-data associated with policy, 
+e.g. key=value strings.
+
+It is sometimes convenient to attach meta-data of a more technical nature to 
+policy. It may be used for arbitrary key=value strings for example.
+
 
 **Example**:  
    
@@ -1509,11 +1378,5 @@ files:
     meta => { "owner=John",  "version=2.0" };
 ```
 
-**Notes**:  
-   
-
-*History*: Was introduced in 3.3.0, Nova 2.2.0 (2012)
-
-It is sometimes convenient to attach meta-data of a more technical
-nature to policy. It may be used for arbitrary key=value strings for
-example.
+**History**: Was introduced in 3.3.0, Nova 2.2.0 (2012)
+s


### PR DESCRIPTION
Added newlines back to promise-types.markdown that had been erroneously removed. Also replaced Synopsis with Description where appropriate.
