### PR TITLE
Merged synposis and notes sections in components/common_control_promises.markdown

### DIFF
--- a/reference/components/common_control_promises.markdown
+++ b/reference/components/common_control_promises.markdown
@@ -8,7 +8,8 @@ tags: [body, bodies, components, common, control, promises, bundlesequence]
 ---
 
 # `common` control promises
- 
+
+```cf3 
      body common control
      
      {
@@ -29,12 +30,11 @@ tags: [body, bodies, components, common, control, promises, bundlesequence]
      output_prefix => "cfengine>";
      version => "1.2.3";
      }
+```
 
 The `common` control body refers to those promises that are
 hard-coded into all the components of CFEngine, and therefore
 affect the behaviour of all the components.
-
-
 
 
 ## `bundlesequence`
@@ -43,8 +43,15 @@ affect the behaviour of all the components.
 
 **Allowed input range**: `.*`
 
-**Synopsis**: List of promise bundles to verify in order
+**Description**: A `bundlesequence` slist contains promise bundles
+ to verify, in a specific order.
 
+The `bundlesequence` determines which of the compiled bundles will
+be executed and in what order they will be executed. The list
+refers to the names of bundles (which might be parameterized
+function-like objects).
+
+```cf3
     body common control
     
     {
@@ -54,13 +61,9 @@ affect the behaviour of all the components.
                        "cfengine2"
                        };
     }
+```
 
 **Notes**:
-
-The `bundlesequence` determines which of the compiled bundles will
-be executed and in what order they will be executed. The list
-refers to the names of bundles (which might be parameterized
-function-like objects).
 
 The order in which you execute bundles can affect the outcome of
 your promises. In general you should always define variables before
@@ -71,6 +74,7 @@ bundles act like characteristics of the systems. If you want
 different systems to have different bundlesequences, distinguish
 them with classes
 
+```cf3
     webservers::
     
       bundlesequence => { "main", "web" };
@@ -78,10 +82,12 @@ them with classes
     others::
     
       bundlesequence => { "main", "otherstuff" };
+```
 
 If you want to add a basic common sequence to all sequences, then
 use global variable lists to do this
 
+```cf3
     body common control
     {
     webservers::
@@ -100,16 +106,12 @@ use global variable lists to do this
     
       "bs" slist => { "main", "basic_stuff" }; 
     }
-
-**Default value**:
+```
 
 There is no default value for `bundlesequence`, and the absence of
 a `bundlesequence` will cause a compilation error. A bundlesequence
 may also be specified using the `-b` or `--bundlesequence` command
 line option.
-
-
-
 
 
 ## `goal_patterns`
@@ -118,24 +120,21 @@ line option.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: A list of regular expressions that match
-promisees/topics considered to be organizational goals
+**Description**: A `goal_patterns` slist contains regular expressions 
+that match promisees/topics considered to be organizational goals
 
+It is used as identifier to mark business and organizational goals in
+commercial versions of CFEngine. CFEngine uses this to match
+promisees that represent business goals in promises.
+
+```cf3
     body common control
     {
     goal_patterns => { "goal_.*", "target.*" };
     }
-
-**Notes**:
+```
 
 *History*: Was introduced in version 3.1.5, Nova 2.1.0 (2011)
-
-Used as identifier to mark business and organizational goals in
-commercial versions of CFEngine. CFEngine uses this to match
-promisees that represent business goals in promises.
-
-
-
 
 
 ## `ignore_missing_bundles`
@@ -151,12 +150,17 @@ promisees that represent business goals in promises.
                    on
                    off
 
-**Default value:** false
+**Default value**: false
 
-**Synopsis**: If any bundles in the bundlesequence do not exist,
-ignore and continue
+**Description**: The `ignore_missing_bundles` menu option policy determines 
+whether to ignore missing bundles.
 
+If `ignore_missing_bundles` is set to true, if any bundles in the bundle 
+sequence do not exist, ignore and continue.
+
+```cf3
     ignore_missing_bundles => "true";
+```
 
 **Notes**:
 
@@ -164,9 +168,6 @@ This authorizes the bundlesequence to contain possibly
 "nonexistent" pluggable modules. It defaults to false, whereupon
 undefined bundles cause a fatal error in parsing, and a transition
 to failsafe mode.
-
-
-
 
 
 ## `ignore_missing_inputs`
@@ -184,24 +185,22 @@ to failsafe mode.
 
 **Default value:** false
 
-**Synopsis**: If any input files do not exist, ignore and continue
-
-    ignore_missing_inputs => "true";
-
-**Notes**:
+**Description**: If any input files do not exist, ignore and continue
 
 The inputs lists determines which files are parsed by CFEngine.
 Normally stringent security checks are made on input files to
-prevent abuse of the system by unauthorized users. Sometimes
-however, it is appropriate to consider the automatic plug-in of
+prevent abuse of the system by unauthorized users. 
+
+Sometimes however, it is appropriate to consider the automatic plug-in of
 modules that might or might not exist. This option permits CFEngine
 to list possible files that might not exist and continue \`best
 effort' with those that do exist. The default of all Booleans is
 false, so the normal behaviour is to signal an error if an input is
 not found.
 
-
-
+```cf3
+    ignore_missing_inputs => "true";
+```
 
 
 ## `inputs`
@@ -210,8 +209,14 @@ not found.
 
 **Allowed input range**: `.*`
 
-**Synopsis**: List of additional filenames to parse for promises
+**Description**: The `inputs` sist contains additional filenames to parse for promises.
 
+The filenames specified are all assumed to be in the same directory
+as the file which references them (this is usually
+`$(sys.workdir)/inputs`, but may be overridden by the `-f` or
+`--file` command line option.
+
+```cf3
     body common control
     {
     inputs  => {
@@ -219,20 +224,12 @@ not found.
                "library.cf"
                };
     }
+```
 
-**Notes**:  
-The filenames specified are all assumed to be in the same directory
-as the file which references them (this is usually
-`$(sys.workdir)/inputs`, but may be overridden by the `-f` or
-`--file` command line option.
-
-**Default value**:
+**Notes**:
 
 There is no default value. If no filenames are specified, no other
 filenames will be included in the compilation process.
-
-
-
 
 
 ## `version`
@@ -241,23 +238,23 @@ filenames will be included in the compilation process.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: Scalar version string for this configuration
+**Description**: The `version` string contains the scalar version of the 
+configuration. 
 
+It is is used in error messages and reports.
+
+```cf3
     body common control
     {
     version => "1.2.3";
     }
+```
 
 **Notes**:
-
-The version string is used in error messages and reports.
 
 This string should not contain the colon ':' character, as this has
 a special meaning in the context of knowledge management. This
 restriction might be lifted later.
-
-
-
 
 
 ## `lastseenexpireafter`
@@ -268,17 +265,15 @@ restriction might be lifted later.
 
 **Default value:** One week
 
-**Synopsis**: Number of minutes after which last-seen entries are
-purged
+**Description**: The value of `lastseenexpireafter` is the number of minutes after which last-seen entries are
+purged.
 
+```cf3
     body common control
     {
     lastseenexpireafter => "72";
     }
-
-**Notes**:
-
-Default time is one week.
+```
 
 
 
@@ -290,12 +285,14 @@ Default time is one week.
 
 **Allowed input range**: (arbitrary string)
 
-**Synopsis**: The string prefix for standard output
+**Description**: The string prefix for standard output
 
+```cf3
     body common control
     {
     output_prefix => "my_cf3";
     }
+```
 
 **Notes**:
 
@@ -312,19 +309,19 @@ string is also prefixed messages in the event log.
 
 **Allowed input range**: `.*`
 
-**Synopsis**: Specify the domain name for this host
-
-    body common control
-    {
-    domain => "example.org";
-    }
-
-**Notes**:
+**Description**: The `domain` string specifies the domain name for this host.
 
 There is no standard, universal or reliable way of determining the
 DNS domain name of a host, so it can be set explicitly to simplify
 discovery and name-lookup.
 
+
+```cf3
+    body common control
+    {
+    domain => "example.org";
+    }
+```
 
 
 
@@ -344,9 +341,13 @@ discovery and name-lookup.
 
 **Default value:** false
 
-**Synopsis**: Warn about promises that do not have comment
-documentation
+**Description**: The `require_comments` menu option policy warns about 
+promises that do not have comment documentation.
 
+This may be used as a policy Quality Assurance measure, to remind
+policy makers to properly document their promises. 
+
+```cf3
     body common control
     
     {
@@ -354,12 +355,10 @@ documentation
     
     require_comments => "true";
     }
+```
 
 **Notes**:
-
-This may be used as a policy Quality Assurance measure, to remind
-policy makers to properly document their promises. When true,
-`cf-promises` will report loudly on promises that do not have
+When true, `cf-promises` will report loudly on promises that do not have
 comments. Variables promises are exempted from this rule, since
 they may be considered self-documenting.
 
@@ -375,21 +374,23 @@ they may be considered self-documenting.
 
 **Default value:** 25
 
-**Synopsis**: The number of licenses that you promise to have paid
-for by setting this value (legally binding for commercial license)
-
-    body common control
-    {
-    host_licenses_paid => "1000";
-    }
-
-**Notes**:
+**Description**: The value of `host_licenses_paid` represents the number
+ of licenses that you promise to have paid for by setting this value 
+ (legally binding for commercial license).
 
 Licensees of the commercial CFEngine releases have to make a
 promise in acceptance of contract terms by setting this value to
 the number of licenses they have paid for. This is tallied with the
 number of licenses granted. This declaration should be placed in
 all separate configuration files, e.g. failsafe.cf, promises.cf.
+
+
+```cf3
+    body common control
+    {
+    host_licenses_paid => "1000";
+    }
+```
 
 
 
@@ -401,18 +402,18 @@ all separate configuration files, e.g. failsafe.cf, promises.cf.
 
 **Allowed input range**: `[a-zA-Z0-9_!&@@$|.()\[\]{}:]+`
 
-**Synopsis**: A list of classes that will represent geographical
-site locations for hosts. These should be defined elsewhere in the
-configuration in a classes promise.
+**Description**: A `site_classes` clist contains classes that will represent 
+geographical site locations for hosts. These should be defined elsewhere in 
+the configuration in a classes promise.
 
+```cf3
     body common control
     {
     site_classes => { "datacenters","datacentres"  }; # locations is by default
     }
+```
 
 **Notes**:
-
-*History*: Was introduced in version 3.2.0, Nova 2.1.0 (2011)
 
 This list is used to match against topics when connecting
 inferences about host locations in the knowledge map. Normally any
@@ -420,6 +421,9 @@ CFEngine classes promise whose name is defined as a thing or topic
 under class `locations::` will be assumed to be a location defining
 classifier. This list will add alternative class contexts for
 interpreting location.
+
+
+*History*: Was introduced in version 3.2.0, Nova 2.1.0 (2011)
 
 
 
@@ -433,20 +437,23 @@ interpreting location.
 
 **Default value:** 514
 
-**Synopsis**: The name or address of a host to which syslog
-messages should be sent directly by UDP
+**Description**: The `syslog_host` contains the name or address of a 
+host to which syslog messages should be sent directly by UDP.
 
+This is the hostname or IP address of a local syslog service to which all
+CFEngine's components may promise to send data. 
+
+```cf3
     body common control
     {
     syslog_host => "syslog.example.org";
     syslog_port => "514";
     }
+```
 
 **Notes**:
 
-The hostname or IP address of a local syslog service to which all
-CFEngine's components may promise to send data. This feature is
-provided in CFEngine Nova and above.
+This feature is provided in CFEngine Nova and above.
 
 
 
@@ -458,18 +465,23 @@ provided in CFEngine Nova and above.
 
 **Allowed input range**: `0,99999999999`
 
-**Synopsis**: The port number of a UDP syslog service
+**Description**: The value of `syslog_port` represents the port number 
+of a UDP syslog service.
 
+It is the UDP port of a local syslog service to which all CFEngine's
+components may promise to send data. 
+
+```cf3
     body common control
     {
     syslog_host => "syslog.example.org";
     syslog_port => "514";
     }
+```
 
 **Notes**:
 
-The UDP port of a local syslog service to which all CFEngine's
-components may promise to send data. This feature is provided in
+This feature is provided in
 CFEngine Nova and above.
 
 
@@ -491,16 +503,19 @@ CFEngine Nova and above.
 
 **Default value:** false
 
-**Synopsis**: Activate full FIPS mode restrictions
+**Description**: The `fips_mode` menu option policy determines whether 
+to activate full FIPS mode restrictions.
 
+```cf3
     body common control
     {
     fips_mode => "true";
     }
+```
 
 **Notes**:
 
-Appears as of Nova 2.0. If CFEngine commercial editions this value
+Appears as of Nova 2.0. In CFEngine commercial editions this value
 may be set to avoid the use of old deprecated algorithms that are
 no longer FIPS 140-2 compliant. If not set, there is some degree of
 compatibility with older versions and algorithms. During an


### PR DESCRIPTION
Merged synposis and notes sections in components/common_control_promises.markdown into a description section, and also marked off some code sections with proper markdown and lexer details.
