### PR TITLE
Remove confusing description

### DIFF
--- a/reference/promise-types/classes.markdown
+++ b/reference/promise-types/classes.markdown
@@ -221,8 +221,6 @@ Then create `classes.cf`
 The class on the left-hand side will be set if the class expression on the 
 right-hand side evaluates to false.
 
-This negates the effect of the promiser-pattern regular expression. 
-**TODO:does this sentence make sense?**
 
 **Type**: `class`
 


### PR DESCRIPTION
Talking about negating the regular expression right after a good
description of its behavior made me stop and read it twice.
