### PR TITLE
	 add a blank like to try to fix that the code blocks on https://cfengine.com/tmp_docs/manuals-policy-style-guide.html are messed up

### DIFF
--- a/manuals/policy-style.markdown
+++ b/manuals/policy-style.markdown
@@ -31,7 +31,9 @@ Generally if opening and closing braces are not on a single line they should
 be aligned vertically.
 
 Example:
+
 ```cf3
+
     bundle agent example
     {
       vars:


### PR DESCRIPTION
...com/tmp_docs/manuals-policy-style-guide.html are off (messed up)
