### PR TITLE
Modified reference/promise-types/access.markdown to merge synopsis and notes sections 

### DIFF
--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -154,7 +154,7 @@ access:
 
 **Allowed input range**: (arbitrary string)
 
-**Description**: The `deny` sist contains host names or IP addresses 
+**Description**: The `deny` slist contains host names or IP addresses 
 to deny access to file objects.
 
 Denial is for special exceptions. A better strategy is always to grant


### PR DESCRIPTION
Modified reference/promise-types/access.markdown to merge synopsis and notes sections into a description section, as well as to heavily edit the same content where necessary.
