### PR TITLE
cf-sketch walkthrough cleanup and simplification

### DIFF
--- a/manuals/design-center-advanced.markdown
+++ b/manuals/design-center-advanced.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Design Center
+title: Design Center - an advanced walkthrough
 categories: [Manuals, Design Center]
 published: true
 alias: manuals-design-center-advanced.html
 ---
 
-## Design Center - and advanced walkthrough
+## Design Center - an advanced walkthrough
 
 This walkthrough will show how a Design Center sketch can be found,
 installed, configured, and executed as policy.

--- a/manuals/design-center.markdown
+++ b/manuals/design-center.markdown
@@ -357,12 +357,10 @@ managing all the backend framework, and cf-sketch offers an "expert"
 mode in addition to the interactive mode described in this
 tutorial. Once you are familiar with the basic concepts and want to
 learn more about how things work internally, you can take a look at
-the [advanced walkthrough](design-center-advanced.html).
+the [advanced walkthrough][Design Center - an advanced walkthrough].
 
 You may also want to look at the
-[Design Center API reference guide](reference-design-center-api.html).
+[Design Center API reference guide][The Design Center API].
 
 Once you are ready to start writing Design Center sketches, you need
-to look at the
-[Sketch Structure](reference-design-center-sketch-structure.html)
-documentation.
+to look at the [Sketch Structure][Sketch Structure] documentation.


### PR DESCRIPTION
Simplified the cf-sketch walkthrough to make it more accessible to first-time users, by leaving only interactive-mode examples, removing all the API interactions. Moved the original guide to design-center-advanced.markdown, and linked to it as a more advanced walkthrough, for more advanced users.
