### PR TITLE
set all aliases to lowercase

### DIFF
--- a/reference/special-variables/const.markdown
+++ b/reference/special-variables/const.markdown
@@ -3,7 +3,7 @@ layout: default
 title: const
 categories: [Reference, Special Variables, const]
 published: true
-alias: reference-special-Variables-context-const.html
+alias: reference-special-variables-context-const.html
 tags: [reference, variables, const, const]
 ---
 

--- a/reference/special-variables/edit.markdown
+++ b/reference/special-variables/edit.markdown
@@ -3,7 +3,7 @@ layout: default
 title: edit
 categories: [Reference, Special Variables, edit]
 published: true
-alias: reference-special-Variables-context-edit.html
+alias: reference-special-variables-context-edit.html
 tags: [reference, variables, edit, edit_line, files promises]
 ---
 

--- a/reference/special-variables/match.markdown
+++ b/reference/special-variables/match.markdown
@@ -3,7 +3,7 @@ layout: default
 title: match
 categories: [Reference, Special Variables, match]
 published: true
-alias: reference-special-Variables-context-match.html
+alias: reference-special-variables-context-match.html
 tags: [reference, variables, match, strings, file editing, files promises, edit_line]
 ---
 


### PR DESCRIPTION
Edited some camelcase aliases to lowercase.
It's hurting my ocd to have url's in mixed cases ;)

ie, from the current live site;
- https://cfengine.com/docs/3.5/reference-special-Variables-context-match.html
- https://cfengine.com/docs/3.5/reference-special-variables-context-sys.html
