### PR TITLE
Document containers, readjson(), and parsejson().  Note the two alternative merging syntaxes.

### DIFF
--- a/reference/functions/parsejson.markdown
+++ b/reference/functions/parsejson.markdown
@@ -1,0 +1,33 @@
+---
+layout: default
+title: parsejson
+categories: [Reference, Functions, parsejson]
+published: true
+alias: reference-functions-parsejson.html
+tags: [reference, io functions, functions, parsejson, json, container]
+---
+
+[%CFEngine_function_prototype(string)%]
+
+**Description:** Parses JSON data directly from an inlined string and
+returns the result as a `container` variable.
+
+[%CFEngine_function_attributes(string)%]
+
+Please note that because JSON uses double quotes, it's usually most
+convenient to use single quotes for the string (CFEngine allows both
+types of quotes around a string).
+
+**Example:**
+
+```cf3
+    vars:
+
+      "loadthis" 
+
+         container =>  parsejson('
+{ "key": "value" }
+', 4000);
+```
+
+**See also:** [`rwadjson()`][readjson] and `container` documentation.

--- a/reference/functions/readjson.markdown
+++ b/reference/functions/readjson.markdown
@@ -1,0 +1,27 @@
+---
+layout: default
+title: readjson
+categories: [Reference, Functions, readjson]
+published: true
+alias: reference-functions-readjson.html
+tags: [reference, io functions, functions, readjson, json, container]
+---
+
+[%CFEngine_function_prototype(filename, maxbytes)%]
+
+**Description:** Parses JSON data from the first `maxbytes` bytes of
+file `filename` and returns the result as a `container` variable.
+
+[%CFEngine_function_attributes(filename, maxbytes)%]
+
+**Example:**
+
+```cf3
+    vars:
+
+      "loadthis" 
+
+         container =>  readjson("/tmp/data.json", 4000);
+```
+
+**See also:** [`parsejson()`][parsejson] and `container` documentation.

--- a/reference/promise-types/vars.markdown
+++ b/reference/promise-types/vars.markdown
@@ -186,6 +186,39 @@ contain the values copied from another `slist`, `rlist`, or `ilist`. See [`polic
 
 ***
 
+## Container variables
+
+Containers are obtained with the `readjson` or `parsejson` functions
+or from other functions specifically declared so, or from merging
+other containers.  They can *NOT* be modified, once created.
+
+Note that containers can contain several levels of data structures,
+e.g. list of lists of key-value arrays.
+
+### container
+
+**Description:** A container data structure
+
+**Type:** `container`
+
+**Allowed input range:** (arbitrary string)
+
+**Example:**  
+
+```cf3
+    vars:
+
+     "loaded1" container => readjson("myfile.json", 40000);
+     "loaded2" container => parsejson('{"key":"value"}');
+     # proposed merge syntax #1
+     "merged1" container => mergecontainer(@(loaded1), @(loaded2));
+     # proposed merge syntax #2
+     "merged2" container => { @(loaded1), @(loaded2) };
+     
+```
+
+***
+
 ## Attributes
 
 ### policy
@@ -224,6 +257,8 @@ redefined) or they can be constant.
 The policy `constant` indicates that the variable value may not be changed. 
 The policies `free` and `overridable` are synonymous, and indicated that the 
 variable's value may be changed.
+
+Containers can only have policy `constant`.
 
 The policy `ifdefined` applies only to lists and implies that unexpanded or 
 undefined lists are dropped. The default behavior is otherwise to retain this 


### PR DESCRIPTION
@vohi @sigurdteigen @zzamboni @nickanderson have asked for these docs...
