### PR TITLE
Fixing documentation for call collect

### DIFF
--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -89,7 +89,7 @@ access:
 
   policy_hub::
 
-  "collect call"
+  "collect_calls"
           comment => "Grant access to cfengine client to request the collection of its reports",
     resource_type => "query",
             admit => { "10.1.2.*" };


### PR DESCRIPTION
The documentation mentioned "collect call", however the server
is sending "collect_calls". Fixed the documentation so it matches
reality.

PS This was correct in the older documentation, somehow it got
changed.
