### PR TITLE
Add links to CFEngine 3.5, Getting Started, and Tutorials pages 

### DIFF
--- a/examples/tutorials.markdown
+++ b/examples/tutorials.markdown
@@ -10,6 +10,10 @@ tags: [Examples, Tutorials]
 
 Familarize yourself with CFEngine by following these tutorials. 
 
+#### [Get CFEngine Up and Running Quickly: A Primer for New Community Users][Up and Running]
+
+This getting-started primer is perfect for new users.  
+
 ### [Create a standalone policy (Hello World).][Hello World]
 
 In this tutorial, you will perform the following:

--- a/getting-started.markdown
+++ b/getting-started.markdown
@@ -11,6 +11,8 @@ Download, install, and evaluate
 [CFEngine Enterprise in 15 minutes][evaluate cfengine]
 with ready-made VirtualBox VMs.
 
+[Get CFEngine Up and Running Quickly: A Primer for New Community Users][Up and Running]. This getting-started primer is perfect for new users.
+
 Download [Community](https://cfengine.com/community).
 
 Install [CFEngine][Installing CFEngine].

--- a/welcome.markdown
+++ b/welcome.markdown
@@ -24,6 +24,8 @@ This documentation is valid for **all versions** of CFEngine except where noted.
 
 ### Quick Links
 
+[Get CFEngine Up and Running Quickly: A Primer for New Community Users][Up and Running]. This getting-started primer is perfect for new users. 
+
 [Get Started][Getting Started] with downloads and installation instructions. 
 
 Learn [what's new][New in CFEngine] in CFEngine 3.5.


### PR DESCRIPTION
Added new-user.html page links to the pages listed above.

Note to Deb and Volker: These merges did not get committed during the previous cherry-pick (git cherry-pick -x 2a6dc50) where the new-users.html page was added to 3.5). Instead of spending time trying to create a new CP, I just decided to make manual changes.  
