### PR TITLE
Add link to measurements type promises from cf-monitord component

### DIFF
--- a/reference/components/cf-monitord.markdown
+++ b/reference/components/cf-monitord.markdown
@@ -8,11 +8,12 @@ tags: [Components, cf-monitord]
 keywords: [monitor]
 ---
 
-`cf-monitord` is the monitoring daemon for CFEngine. It samples probes defined 
-in policy code and attempts to learn the normal system state based on current 
-and past observations. Current estimates are made available as [special 
-variables][special variables] (e.g. [`$(mon.av_cpu)`][mon#mon.av_cpu]) to 
-`cf-agent`, which may use them to inform policy decisions.
+`cf-monitord` is the monitoring daemon for CFEngine. It samples probes defined
+in policy using `measurements` type promises and attempts to learn the normal
+system state based on current and past observations. Current estimates are made
+available as [special variables][special variables] (e.g.
+[`$(mon.av_cpu)`][mon#mon.av_cpu]) to `cf-agent`, which may use them to inform
+policy decisions.
 
 `cf-monitord` keeps the promises made in `common`and `monitor` bundles, and is
 affected by  `common` and `monitor` control bodies.


### PR DESCRIPTION
Related concepts need to be interlinked.
