### PR TITLE
Updated install procedures on the Comm and 25 Free Enterprise pages

### DIFF
--- a/getting-started/installation/installation-community.markdown
+++ b/getting-started/installation/installation-community.markdown
@@ -162,7 +162,7 @@ bundle agent test
 {
   reports:                   # This is a promise type.
 
-    cfefengine_3::           # This means the promise will only
+    cfengine_3::           # This means the promise will only
                              # be kept on a CFEngine_3 system.
       "Hello World";         # This is a simple promise; it generates a report
                              # that says "Hello world".

--- a/getting-started/installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/installation-enterprise-free.markdown
@@ -16,6 +16,8 @@ version of CFEngine Enterprise, but the number of Hosts (clients) is limited to 
 * To install this version of CFEngine Enterprise, your machine must be running a recent version of Linux.
 This installation script has been tested on RHEL 5 and 6, SLES 11, CentOS 5 and 6, and Debian 6 and 7.
 * You need a minimum of 2 GB of available memory and a modern 64 bit processor.
+* Plan for approximately 100MB of disk space per host. Due to MongoDB's pre-allocation strategy, always provide an 
+extra 2G to 4G of disk space if you plan to bootstrap more hosts later.
 * You need a least two VMs/servers, one for the Policy Server and one for a Host (client). They must be on the same network.
 
 ## Installation Overview
@@ -96,12 +98,13 @@ The installation process is complete and CFEngine Enterprise is up and running o
 The Mission Portal is immediately accessible. Connect to the Policy Server
 through your web browser at: 
 
-https://`<IP address of your Policy Server>`
+http://`<IP address of your Policy Server>`
 
 username: admin
 password: admin
 
-During the initial setup, the Host(s) might take a few minutes to show up in the Mission Portal. Simply refresh the web page 
+The Mission Portal runs TCP port 80 by default. (Click [here] (https://cfengine.zendesk.com/entries/25005193-Configure-Mission-Portal-to-use-HTTPS-instead-of-HTTP) 
+to configure the Mission Portal to use HTTPS instead of HTTP.) During the initial setup, the Host(s) might take a few minutes to show up in the Mission Portal. Simply refresh the web page 
 and login again if necessary.
 
 Note: If you are running Enterprise with Vagrant, you must add the 


### PR DESCRIPTION
Corrected misspelled word on the Community page. Added disk space requirements to Enterprise page. On Enterprise page, also corrected http error and added link to configure the MP to use https instead of http.
