### PR TITLE
Add note about quickinstall script internet access requirement.

### DIFF
--- a/getting-started/installation/installation-community.markdown
+++ b/getting-started/installation/installation-community.markdown
@@ -8,42 +8,45 @@ alias: getting-started-installation-installing-community.html
 tags: [getting started, installation, community]
 ---
 
-These instructions describe how to download and install the latest version of CFEngine Community using pre-compiled rpm and 
-deb packages for Ubuntu, Debian, Redhat, CentOS, and SUSE. 
+These instructions describe how to download and install the latest version of CFEngine Community using pre-compiled rpm and
+deb packages for Ubuntu, Debian, Redhat, CentOS, and SUSE.
 
 It also provides instructions for the following:
 
 * **Install CFEngine on a Policy Server (hub) and on a Host (client).**
-A Policy Server (hub) is a CFEngine instance that contains promises (business policy) that get deployed to Hosts. 
+A Policy Server (hub) is a CFEngine instance that contains promises (business policy) that get deployed to Hosts.
 Hosts are clients that retrieve and execute promises.
 * **Bootstrap the Policy Server to itself and then bootstrap the Host(s) to the Policy Server.**
-Bootstrapping establishes a trust relationship between the Policy Server 
-and all Hosts. Thus, business policy that you create in the Policy Server can be deployed to Hosts throughout your company. 
+Bootstrapping establishes a trust relationship between the Policy Server
+and all Hosts. Thus, business policy that you create in the Policy Server can be deployed to Hosts throughout your company.
 Bootstrapping completes the installation process.
 
 _Tutorials, recommended reading. and production environment recommendations appear at the end of this page._
 
 <hr>
 ## Quick Setup Installation Script
-Use the following script to install CFEngine on your 32- or 64-bit machine. 
+
+Please Note: Internet access is required from the host if you wish to use the quick install script.
+
+Use the following script to install CFEngine on your 32- or 64-bit machine.
 
 ```
 $ wget -O- https://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-community.sh | sudo bash
 ```
 
-1. Run this script on your designated Policy Server machine **and** on your designated Host machine(s). 
+1. Run this script on your designated Policy Server machine **and** on your designated Host machine(s).
 2. Bootstrap the Policy Server to itself and then bootstrap your Host(s) to the Policy Server by running the following command:
 ```
 $ sudo /var/cfengine/bin/cf-agent --bootstrap <IP address of policy server>
 ```
-If you require more details on bootstrapping, review Step 3 below. Bootstrapping completes the installation. 
+If you require more details on bootstrapping, review Step 3 below. Bootstrapping completes the installation.
 3. Go to the [Tutorials][Installing Community#Tutorials] section to learn how to use CFEngine.
 <hr>
 
-## 1. Download Packages 
+## 1. Download Packages
 
-Select the package to download that matches your operating system. 
-This stores the cfengine-community_3.5.2-1_* file onto your machine. 
+Select the package to download that matches your operating system.
+This stores the cfengine-community_3.5.2-1_* file onto your machine.
 
 **Ubuntu/Debian 32-bit:**
 
@@ -60,16 +63,16 @@ $ wget http://cfengine.com/inside/binarydownload/download/items/1183 -O cfengine
 **Redhat/CentOS/SUSE 32-bit:**
 
 ```
-$ wget http://cfengine.com/inside/binarydownload/download/items/1180 -O cfengine-community-3.5.2-1.i386.rpm 
+$ wget http://cfengine.com/inside/binarydownload/download/items/1180 -O cfengine-community-3.5.2-1.i386.rpm
 ```
 
 **Redhat/CentOS/SUSE 64-bit:**
 
 ```
-$ wget http://cfengine.com/inside/binarydownload/download/items/1181 -O cfengine-community-3.5.2-1.x86_64.rpm 
+$ wget http://cfengine.com/inside/binarydownload/download/items/1181 -O cfengine-community-3.5.2-1.x86_64.rpm
 ```
 
-## 2. Install CFEngine on a Policy Server 
+## 2. Install CFEngine on a Policy Server
 
 Install the package on a machine designated as a Policy Server.  A Policy Server is a CFEngine instance that contains promises (business policy)
 that get deployed to Hosts. Hosts are instances (clients) that retrieve and execute promises.
@@ -104,7 +107,7 @@ $ sudo rpm -i cfengine-community-3.5.2-1.x86_64.rpm
 this is taken care of during the bootstrapping process.
 
 
-## 3. Bootstrap the Policy Server 
+## 3. Bootstrap the Policy Server
 
 The Policy Server must be bootstrapped to itself. Find the IP address of your Policy Server (type $ ifconfig).
 
@@ -129,13 +132,13 @@ The Policy Server is installed.
 ## 4. Install CFEngine on a Host
 
 As stated earlier, Hosts are instances that retrieve and execute promises from the Policy Server. Install
-a package on your Host. Use the same package you installed on the Policy Server in Step 2. Note that you must have access 
-to at least one more VM or server and it must be on the same network as the Policy Server that you just installed. 
+a package on your Host. Use the same package you installed on the Policy Server in Step 2. Note that you must have access
+to at least one more VM or server and it must be on the same network as the Policy Server that you just installed.
 
 ## 5. Bootstrap the Host to the Policy Server
 
 The Host(s) must be bootstrapped to the Policy Server in order to establish a connection between the Host and
-the Policy Server. Run the same commands that you ran in Step 3. 
+the Policy Server. Run the same commands that you ran in Step 3.
 
 ```
 $ sudo /var/cfengine/bin/cf-agent --bootstrap <IP address of policy server>
@@ -170,7 +173,7 @@ bundle agent test
 }
 ```
 
-Step 2. Run the policy: 
+Step 2. Run the policy:
 
 ```
 $ sudo /var/cfengine/bin/cf-agent hello_world.cf
@@ -178,7 +181,7 @@ $ sudo /var/cfengine/bin/cf-agent hello_world.cf
 
 The policy displays the following output:
 
-**R: Hello world**  
+**R: Hello world**
 
 Find more policy examples [here][Policy].
 
@@ -209,7 +212,7 @@ files:
 ```
 
 Step 3. Update **/var/cfengine/masterfiles/promises.cf** to include this new policy. To do so, modify
-the **promises.cf** file to ensure that (1 the **mypolicy.cf** file is being included in the next policy 
+the **promises.cf** file to ensure that (1 the **mypolicy.cf** file is being included in the next policy
 distribution and that (2 **example** is in the bundlesequence.
 
 ```
@@ -231,17 +234,17 @@ inputs => {
             "mypolicy.cf",
 ...
 ```
-The process is complete. The next time CFEngine runs on the Host (which by default is every 5 minutes), 
-it will pull down the latest policy update and ensure that the **example.txt** file exists (this is the desired 
-state). In fact, any Host that has installed CFEngine will contain the **example.txt** file (because we defined 
+The process is complete. The next time CFEngine runs on the Host (which by default is every 5 minutes),
+it will pull down the latest policy update and ensure that the **example.txt** file exists (this is the desired
+state). In fact, any Host that has installed CFEngine will contain the **example.txt** file (because we defined
 the cfengine_3:: class above).
 
 ### Try these advanced tutorials:
 
-* [Create a standalone policy (Hello World).][Hello World] This Hello World tutorial provides more depth into how to create business policy (promises) on the 
+* [Create a standalone policy (Hello World).][Hello World] This Hello World tutorial provides more depth into how to create business policy (promises) on the
 command line. Here, you can get a taste of the CFEngine language as you create standalone and executable scripts.
-* [Distribute files from a central location.][Distribute files from a central location] This advanced, command-line tutorial shows 
-you how to distribute policy files from the Policy Server to all pertinent Hosts. 
+* [Distribute files from a central location.][Distribute files from a central location] This advanced, command-line tutorial shows
+you how to distribute policy files from the Policy Server to all pertinent Hosts.
 
 ## Recommended Reading
 
@@ -253,16 +256,16 @@ you how to distribute policy files from the Policy Server to all pertinent Hosts
 
 If you plan to use Community in a production environment, complete the following general requirements:
 
-**Host(s) Memory** 
+**Host(s) Memory**
 
 256 MB available memory in order to run the CFEngine agent software (cf-agent).
 
-**Disk Storage** 
+**Disk Storage**
 
 A full installation of CFEngine requires 25 MB. Additional disk usage
 depends on your specific policies, especially those that concern reporting.
 
-**Network** 
+**Network**
 
 * Verify that the machine’s network connection is working and that port 5308
   (used by CFEngine) is open for both incoming and outgoing connections.
@@ -276,7 +279,7 @@ depends on your specific policies, especially those that concern reporting.
 
 ## Rate your experience
 
-Everyone is a first-time user a some point. We want to make the CFEngine Enterprise installation process easy for all of our new users. 
+Everyone is a first-time user a some point. We want to make the CFEngine Enterprise installation process easy for all of our new users.
 Before you forget your first-time experience, we would love for you to let us know how we can improve on this process.
 
 <iframe src="https://docs.google.com/forms/d/1wnVR3HQwUNKs5fT0zf_OHjtIQxI_nd00QCFbDZOyXZk/viewform?embedded=true" width="760" height="800" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/getting-started/installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/installation-enterprise-free.markdown
@@ -9,14 +9,14 @@ tags: [getting started, installation, enterprise free]
 ---
 
 These instructions describe how to install the latest version of CFEngine Enterprise 25 Free. This is the full
-version of CFEngine Enterprise, but the number of Hosts (clients) is limited to 25. 
+version of CFEngine Enterprise, but the number of Hosts (clients) is limited to 25.
 
 **Note the following requirements:**
 
 * To install this version of CFEngine Enterprise, your machine must be running a recent version of Linux.
 This installation script has been tested on RHEL 5 and 6, SLES 11, CentOS 5 and 6, and Debian 6 and 7.
 * You need a minimum of 2 GB of available memory and a modern 64 bit processor.
-* Plan for approximately 100MB of disk space per host. Due to MongoDB's pre-allocation strategy, always provide an 
+* Plan for approximately 100MB of disk space per host. Due to MongoDB's pre-allocation strategy, always provide an
 extra 2G to 4G of disk space if you plan to bootstrap more hosts later.
 * You need a least two VMs/servers, one for the Policy Server and one for a Host (client). They must be on the same network.
 
@@ -24,19 +24,21 @@ extra 2G to 4G of disk space if you plan to bootstrap more hosts later.
 
 During the course of the instructions outlined in this guide, you will perform the following tasks:
 
-* **Install CFEngine Enterprise onto a Policy Server and onto Hosts.** 
-A Policy Server (hub) is a CFEngine instance that contains promises (business policy) that get deployed to Hosts. 
-Hosts are clients that retrieve and execute promises. 
-* **Bootstrap the Policy Server to itself and then bootstrap each of the Hosts to the Policy Server.** Bootstrapping establishes a trust relationship between the Policy Server 
-and all Hosts. Thus, business policy that you create in the Policy Server can be deployed to Hosts throughout your company. 
+* **Install CFEngine Enterprise onto a Policy Server and onto Hosts.**
+A Policy Server (hub) is a CFEngine instance that contains promises (business policy) that get deployed to Hosts.
+Hosts are clients that retrieve and execute promises.
+* **Bootstrap the Policy Server to itself and then bootstrap each of the Hosts to the Policy Server.** Bootstrapping establishes a trust relationship between the Policy Server
+and all Hosts. Thus, business policy that you create in the Policy Server can be deployed to Hosts throughout your company.
 Bootstrapping completes the installation process.
-* **Log in to the Mission Portal.** The Mission Portal is a graphical user interface that allows you to verify the 
-the actual state of all your Hosts, thus ensuring that your promises are being executed. By using the **Design Center** inside the Mission Portal, you 
-can also define new desired states (business policies) for your infrastructure. 
+* **Log in to the Mission Portal.** The Mission Portal is a graphical user interface that allows you to verify the
+the actual state of all your Hosts, thus ensuring that your promises are being executed. By using the **Design Center** inside the Mission Portal, you
+can also define new desired states (business policies) for your infrastructure.
 * **Try out the Tutorials.** Links to three tutorials give you a head start on learning CFEngine.
 
 
 ## 1. Download and install Enterprise on a Policy Server
+
+Please Note: Internet access is required from the host if you wish to use the quick install script.
 
 Run the following script on your designated Policy Server (hub) 64-bit machine (32-bit is not supported on the Policy Server):
 
@@ -44,9 +46,9 @@ Run the following script on your designated Policy Server (hub) 64-bit machine (
 $ wget http://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh hub
 ```
 
-This script installs the latest CFEngine Enterprise Policy Server on your machine. 
+This script installs the latest CFEngine Enterprise Policy Server on your machine.
 
-## 2. Bootstrap the Policy Server 
+## 2. Bootstrap the Policy Server
 
 The Policy Server must be bootstrapped to itself. Find the IP address of your Policy Server (type $ ifconfig).
 
@@ -69,10 +71,10 @@ $ /var/cfengine/bin/cf-promises --version
 The Policy Server is installed.
 
 ## 3. Install Enterprise on Hosts
- 
-Install Enterprise on your designated Host(s) by running the script below. Per the **Free 25** agreement, you can 
-install Enterprise on 25 Hosts. Note that the Hosts must be 
-on the same network as the Policy Server that you just installed in Step 2. 
+
+Install Enterprise on your designated Host(s) by running the script below. Per the **Free 25** agreement, you can
+install Enterprise on 25 Hosts. Note that the Hosts must be
+on the same network as the Policy Server that you just installed in Step 2.
 
 ```
 wget http://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh client
@@ -83,7 +85,7 @@ Note that this installation works on 64- and 32-bit machines.
 ## 4. Bootstrap the Host to the Policy Server
 
 All Hosts must be bootstrapped to the Policy Server in order to establish a connection between the Host and
-the Policy Server. Run the same commands that you ran in Step 3. 
+the Policy Server. Run the same commands that you ran in Step 3.
 
 ```
 $ sudo /var/cfengine/bin/cf-agent --bootstrap <IP address of policy server>
@@ -96,33 +98,33 @@ The installation process is complete and CFEngine Enterprise is up and running o
 ## 5. Log in to the Mission Portal
 
 The Mission Portal is immediately accessible. Connect to the Policy Server
-through your web browser at: 
+through your web browser at:
 
 http://`<IP address of your Policy Server>`
 
 username: admin
 password: admin
 
-The Mission Portal runs TCP port 80 by default. (Click [here] (https://cfengine.zendesk.com/entries/25005193-Configure-Mission-Portal-to-use-HTTPS-instead-of-HTTP) 
-to configure the Mission Portal to use HTTPS instead of HTTP.) During the initial setup, the Host(s) might take a few minutes to show up in the Mission Portal. Simply refresh the web page 
+The Mission Portal runs TCP port 80 by default. (Click [here] (https://cfengine.zendesk.com/entries/25005193-Configure-Mission-Portal-to-use-HTTPS-instead-of-HTTP)
+to configure the Mission Portal to use HTTPS instead of HTTP.) During the initial setup, the Host(s) might take a few minutes to show up in the Mission Portal. Simply refresh the web page
 and login again if necessary.
 
-Note: If you are running Enterprise with Vagrant, you must add the 
-correct port: http://localhost:<port> in your browser.  The <port> is the port-forwarder 
+Note: If you are running Enterprise with Vagrant, you must add the
+correct port: http://localhost:<port> in your browser.  The <port> is the port-forwarder
 number you use in your **Vagrantfile** (e.g. policyserver.vm.network "forwarded_port", guest: 80, host: 8080; the port will be 8080).
 
 <hr>
 
 ## Tutorials
 
-* [Configure and deploy a policy using sketches in the Design Center.][Configure and Deploy a Policy Using Sketches (Enterprise Only)] This tutorial 
-teaches you how to configure and deploy business policy by using the Design Center application in the Mission Portal. Next, it shows you how to verify 
+* [Configure and deploy a policy using sketches in the Design Center.][Configure and Deploy a Policy Using Sketches (Enterprise Only)] This tutorial
+teaches you how to configure and deploy business policy by using the Design Center application in the Mission Portal. Next, it shows you how to verify
 that your business policy is being activated by viewing the Reports in the Mission Portal.
-* [Create a standalone policy (Hello World).][Hello World] Whereas the above tutorial uses pre-defined policy (called sketches) that you can modify in the Mission Portal, this 
-tutorial teaches you how to create business policy (promises) on the command line. Here, you 
+* [Create a standalone policy (Hello World).][Hello World] Whereas the above tutorial uses pre-defined policy (called sketches) that you can modify in the Mission Portal, this
+tutorial teaches you how to create business policy (promises) on the command line. Here, you
 can get a taste of the CFEngine language as you create standalone and executable scripts.
-* [Distribute files from a central location.][Distribute files from a central location] Whereas the first tutorial in this list teaches you how to deploy business policy 
-through the Mission Portal, this advanced, command-line tutorial shows you how to distribute policy files from the Policy Server to all pertinent Hosts. 
+* [Distribute files from a central location.][Distribute files from a central location] Whereas the first tutorial in this list teaches you how to deploy business policy
+through the Mission Portal, this advanced, command-line tutorial shows you how to distribute policy files from the Policy Server to all pertinent Hosts.
 
 ## Recommended Reading
 
@@ -133,7 +135,7 @@ through the Mission Portal, this advanced, command-line tutorial shows you how t
 
 ## Rate your experience
 
-Everyone is a first-time user a some point. We want to make the CFEngine Enterprise installation process easy for all of our new users. 
+Everyone is a first-time user a some point. We want to make the CFEngine Enterprise installation process easy for all of our new users.
 Before you forget your first-time experience, we would love for you to let us know how we can improve on this process.
 
 <iframe src="https://docs.google.com/forms/d/1-D5ny2_5HDmPBpRR69aZeC-dVY08VlDouCsdGXBCnyc/viewform?embedded=true" width="760" height="800" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>


### PR DESCRIPTION
The quickinstall script downloads packages from the internet, so it
needs internet access to properly function. Also cleaned up trailing
whitespace.
