### PR TITLE
More changes to categories--cannot have () in cat names

### DIFF
--- a/manuals/design-center.markdown
+++ b/manuals/design-center.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Using Design Center Sketches to Deploy Policy
-categories: [Manuals, Using Design Center Sketches to Deploy Policy]
+categories: [Manuals, Design Center]
 published: true
 sorting: 50
 alias: manuals-design-center.html

--- a/manuals/design-center/configure-sketches-community.markdown
+++ b/manuals/design-center/configure-sketches-community.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Configure and Deploy Sketches on the Command Line (Community)
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure and Deploy Sketches on the Command Line (Community)]
+categories: [Manuals, Design Center, Sketches Community]
 published: true
 sorting: 30
 alias: configure-sketches-community.html

--- a/manuals/design-center/configure-sketches-community/design-center-advanced.markdown
+++ b/manuals/design-center/configure-sketches-community/design-center-advanced.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Advanced Walkthrough
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure and Deploy Sketches on the Command Line (Community), Advanced Walkthrough]
+categories: [Manuals, Design Center, Sketches Community, Advanced Walkthrough]
 published: true
 sorting: 10
 alias: manuals-design-center-advanced.html

--- a/manuals/design-center/configure-sketches-enterprise.markdown
+++ b/manuals/design-center/configure-sketches-enterprise.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Configure the Design Center App (Enterprise)
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure the Design Center App (Enterprise)]
+categories: [Manuals, Design Center, Enterprise Sketches]
 published: true
 sorting: 20
 alias: configure-sketches-enterprise.html

--- a/manuals/design-center/configure-sketches-enterprise/access-control-mission-portal.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/access-control-mission-portal.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Controlling Access to the Design Center UI
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure the Design Center App (Enterprise), Controlling Access to the Design Center UI]
+categories: [Manuals, Design Center, Enterprise Sketches, Controlling Access to the Design Center UI]
 published: true
 sorting: 20
 alias: mission-portal-design-center-access-control.html

--- a/manuals/design-center/configure-sketches-enterprise/enterprise-sketch-flow.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/enterprise-sketch-flow.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Sketch Flow in CFEngine Enterprise
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure the Design Center App (Enterprise), Sketch Flow in CFEngine Enterprise]
+categories: [Manuals, Design Center, Enterprise Sketches, Sketch Flow in CFEngine Enterprise]
 published: true
 sorting: 40
 alias: manuals-design-center-enterprise-sketch-flow.html

--- a/manuals/design-center/configure-sketches-enterprise/integrating-mission-portal-with-git.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/integrating-mission-portal-with-git.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Integrating Mission Portal with git
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure the Design Center App (Enterprise), Integrating Mission Portal with git]
+categories: [Manuals, Design Center, Enterprise Sketches, Integrating Mission Portal with git]
 published: true
 sorting: 10
 alias: manuals-design-center-integrating-mission-portal-with-git.html

--- a/manuals/design-center/configure-sketches-enterprise/mission-portal-sketches.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/mission-portal-sketches.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Sketches Available in the Mission Portal
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Configure the Design Center App (Enterprise), Sketches Available in the Mission Portal]
+categories: [Manuals, Design Center, Enterprise Sketches, Sketches Available in the Mission Portal]
 published: true
 sorting: 30
 alias: mission-portal-design-center-sketches-available.html

--- a/manuals/design-center/design-center-deploy-sketch.markdown
+++ b/manuals/design-center/design-center-deploy-sketch.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Deploy your first Policy (Enterprise)
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Deploy your first Policy (Enterprise)]
+categories: [Manuals, Design Center, Deploy Policy]
 published: true
 sorting: 10
 alias: design-center-deploy-sketch.html

--- a/manuals/design-center/design-center-write-sketch.markdown
+++ b/manuals/design-center/design-center-write-sketch.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Write a new Sketch (Enterprise and Community)
-categories: [Manuals, Using Design Center Sketches to Deploy Policy, Write a new Sketch (Enterprise and Community)]
+categories: [Manuals, Design Center, Write Sketch]
 published: true
 sorting: 40
 alias: design-center-write-sketch.html
@@ -176,7 +176,7 @@ fully-qualified name of the array (cflearn_password_expiration:password_expirati
 contains the namespace, the bundle name, and the array name.
 
 <5>  We must add the `default:` namespace to all the standard library components we
-use and—-in this case--also to the `backup_timestamp` body and the `set_user_field()` bundle.
+use and, in this case, also to the `backup_timestamp` body and the `set_user_field()` bundle.
 
 <6>  Finally, and to complement the limitation of functionality of the sketch to Linux
 systems, we have added a `reports:` promise that prints a warning on non-Linux systems to let 


### PR DESCRIPTION
Changed category names but erroneously added () to a few names. This has been fixed.
