### PR TITLE
Shortened titles on many pages in this section

### DIFF
--- a/manuals/design-center.markdown
+++ b/manuals/design-center.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Using Design Center Sketches to Deploy Policy
+title: Design Center Sketches
 categories: [Manuals, Design Center]
 published: true
 sorting: 50
@@ -8,7 +8,7 @@ alias: manuals-design-center.html
 tags: [design center, cf-sketch, sketches, deploy policy]
 ---
 
-## The Design Center Defined
+## Use Design Center Sketches to Deploy Policy
 
 The CFEngine Design Center is a collection of **sketches** which are reusable, configurable 
 policies. Think of sketches as templates that are written in CFEngine policy language; you can 
@@ -19,9 +19,9 @@ The Design Center also contains tools that help you to manipulate and
 manage sketches: 
 
 * **Enterprise users** manage and deploy sketches in the Design Center app that is located on 
-the Mission Portal console. [Deploy your first policy in the Design Center][Deploy your first Policy (Enterprise)].
+the Mission Portal console. [Deploy your first policy in the Design Center][Deploy your first Policy].
 
-* **Community users** manage and deploy sketches on the [command line][Configure and Deploy Sketches on the Command Line (Community)] by using the `cf-sketch` 
+* **Community users** manage and deploy sketches on the [command line][Command Line Sketches] by using the `cf-sketch` 
 tool.
 
 ## The Design Center Sketch Workflow
@@ -31,7 +31,7 @@ A sketch is installed, configured, and deployed, as shown in the diagram below:
 ![Sketch Workflow](DCsketchworkflow.png)
 
 1. Install a sketch on a Host from a repository. At this point, the sketch is merely 
-a template that cannot really do anything because it doesn’t contain parameters.
+a template that cannot do anything because it doesn’t contain parameters.
 
 2. Configure the sketch by providing parameters. Now, you can create sketch 
 configurations.  One sketch can have multiple configurations with different parameter sets 
@@ -59,16 +59,16 @@ sketches can change, just as the behavior of regular CFEngine policy can change.
 The following topics are included in the Design Center section. **Select topics that 
 are specific to your edition of CFEngine: Enterprise or Community.**
  
-* [Deploy your first Policy (Enterprise)][Deploy your first Policy (Enterprise)] This Enterprise-specific tutorial illustrates how 
+* [Deploy your first Policy (Enterprise)][Deploy your first Policy] This Enterprise-specific tutorial illustrates how 
 to use a sketch to configure and deploy a simple policy by using the Design Center app on 
 the Mission Portal console.
-* [Configure the Design Center App (Enterprise)][Configure the Design Center App (Enterprise)] This section is for Enterprise users who plan to 
+* [Configure the Design Center App (Enterprise)][Configure the Design Center App] This section is for Enterprise users who plan to 
 manage sketches and possibly write new ones. It also includes advanced topics that provide a 
 better look at managing Enterprise sketches in the Design Center app and understanding 
 the overall sketch flow.
-* [Configure Sketches on the Command Line (Community)][Configure and Deploy Sketches on the Command Line (Community)] This section is for Community users 
+* [Configure Sketches on the Command Line (Community)][Command Line Sketches] This section is for Community users 
 who plan to install, configure, and deploy sketches.
-* [Write a new Sketch (Enterprise and Community)][Write a new Sketch (Enterprise and Community)] This is an advanced section for both Enterprise 
+* [Write a new Sketch (Enterprise and Community)][Write a new Sketch] This is an advanced section for both Enterprise 
 and Community users who plan to write new sketches.
 
 ### Terminology

--- a/manuals/design-center/configure-sketches-community.markdown
+++ b/manuals/design-center/configure-sketches-community.markdown
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Configure and Deploy Sketches on the Command Line (Community)
+title: Command Line Sketches
 categories: [Manuals, Design Center, Sketches Community]
 published: true
 sorting: 30
 alias: configure-sketches-community.html
 tags: [design center, cf-sketch, sketches]
 ---
+
+### Community Users can Configure and Deploy Sketches on the Command Line
 
 The CFEngine Design Center is a repository of pre-made components
 called **sketches** that allow you to use the full power of CFEngine
@@ -26,23 +28,23 @@ command-line tools. The overview is as follows:
 
 **Before you Begin**
 
-[Requirements][Configure and Deploy Sketches on the Command Line (Community)#Requirements]
+[Requirements][Command Line Sketches#Requirements]
 
-[Basic Concepts][Configure and Deploy Sketches on the Command Line (Community)#Basic Concepts]
+[Basic Concepts][Command Line Sketches#Basic Concepts]
 
 **Instructions**
 
-[Step 1. Check out the Design Center repository][Configure and Deploy Sketches on the Command Line (Community)#Step 1. Check out the Design Center repository]
+[Step 1. Check out the Design Center repository][Command Line Sketches#Step 1. Check out the Design Center repository]
 
-[Step 2. Run cf-sketch][Configure and Deploy Sketches on the Command Line (Community)#Step 2. Run cf-sketch]
+[Step 2. Run cf-sketch][Command Line Sketches#Step 2. Run cf-sketch]
 
-[Step 3. Search for sketches][Configure and Deploy Sketches on the Command Line (Community)#Step 3. Search for sketches]
+[Step 3. Search for sketches][Command Line Sketches#Step 3. Search for sketches]
 
-[Step 4. Install a sketch][Configure and Deploy Sketches on the Command Line (Community)#Step 4. Install a sketch]
+[Step 4. Install a sketch][Command Line Sketches#Step 4. Install a sketch]
 
-[Step 5. Activate a sketch][Configure and Deploy Sketches on the Command Line (Community)#Step 5. Activate a sketch]  Define the parameter set and environment, and run the activate command.
+[Step 5. Activate a sketch][Command Line Sketches#Step 5. Activate a sketch]  Define the parameter set and environment, and run the activate command.
 
-[Step 6. Deploy the sketch][Configure and Deploy Sketches on the Command Line (Community)#Step 6. Deploy the sketch: Generate and execute the runfile]  Generate and execute the runfile.
+[Step 6. Deploy the sketch][Command Line Sketches#Step 6. Deploy the sketch: Generate and execute the runfile]  Generate and execute the runfile.
 
 Additional resources are included at the end of this page.
 
@@ -397,5 +399,5 @@ the [advanced discussion][Advanced Walkthrough] on configuring sketches.
 
 * Visit the [Design Center API][The Design Center API] for reference.
 
-* Once you are ready to start [writing Design Center sketches][Write a new Sketch (Enterprise and Community)], refer to the 
+* Once you are ready to start [writing Design Center sketches][Write a new Sketch], refer to the 
 [sketch structure][Sketch Structure] documentation.

--- a/manuals/design-center/configure-sketches-community/design-center-advanced.markdown
+++ b/manuals/design-center/configure-sketches-community/design-center-advanced.markdown
@@ -10,18 +10,18 @@ tags: [design center, walkthrough, cf-sketch, sketches]
 
 This walkthrough illustrates how a Design Center sketch can be found,
 installed, configured, and executed as policy. Many items are already discussed at
-[Configure and Deploy Sketches on the Command Line][Configure and Deploy Sketches on the Command Line (Community)]. 
+[Command Line Sketches][Command Line Sketches]. 
 This Walkthrough provides a more advanced look at sketches in that it describes internal and backend processes. 
 
 ## Before you Begin
 
 Make certain you have installed all necessary software and have checked out the Design Center repository:
 
-[Complete the software requirements][Configure and Deploy Sketches on the Command Line (Community)#Requirements]
+[Complete the software requirements][Command Line Sketches#Requirements]
  
-[Review the basics concepts of sketches][Configure and Deploy Sketches on the Command Line (Community)#Basic Concepts]
+[Review the basics concepts of sketches][Command Line Sketches#Basic Concepts]
 
-[Check out the Design Center repository][Configure and Deploy Sketches on the Command Line (Community)#Step 1. Check out the Design Center repository]
+[Check out the Design Center repository][Command Line Sketches#Step 1. Check out the Design Center repository]
 
 ## Overview
 

--- a/manuals/design-center/configure-sketches-enterprise.markdown
+++ b/manuals/design-center/configure-sketches-enterprise.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Configure the Design Center App (Enterprise)
+title: Configure the Design Center App
 categories: [Manuals, Design Center, Enterprise Sketches]
 published: true
 sorting: 20
@@ -12,41 +12,41 @@ This section is for Enterprise users who plan to manage Design Center sketches.
 
 ### Getting Started Topics 
 
-[Integrating the Mission Portal with git][Integrating Mission Portal with git]  The Design Center app requires access to a git repository 
-in order to manage sketches. This section describes how to set up the git repository and how 
-to connect the Mission Portal to the git repository. (The Design Center app is located on 
-the Mission Portal console.) Instructions for testing the Design Center 
-app and for reviewing git commit logs are also included. 
+[Integrating the Mission Portal with git][Integrating Mission Portal with git]  The Design 
+Center app requires access to a git repository in order to manage sketches. This section 
+describes how to set up the git repository and how to connect the Mission Portal to the 
+git repository. (The Design Center app is located on the Mission Portal console.) 
+Instructions for testing the Design Center app and for reviewing git commit logs are also included. 
 
-[Controlling Access to the Design Center UI][Controlling Access to the Design Center UI]  This section describes how to give users access 
-rights for making changes to the Design Center app. It describes how to allow or limit a 
-Mission Portal user's ability to commit to the git repository and make changes to the hosts. 
-All Mission Portal changes that users make through the Design Center app can be viewed in 
-the git commit log.
+[Controlling Access to the Design Center UI][Controlling Access to the Design Center UI]  
+This section describes how to give users access rights for making changes to the Design 
+Center app. It describes how to allow or limit a Mission Portal user's ability to commit 
+to the git repository and make changes to the hosts. All Mission Portal changes that users 
+make through the Design Center app can be viewed in the git commit log.
 
 ### Advanced Topics
 
-[Sketches Available in the Mission Portal][Sketches Available in the Mission Portal]  At some point, new sketches must be added to 
-the Design Center app. This section shows which directory controls the sketches that are 
-available in the Design Center app and it describes how to add or remove sketches 
-from the app.
+[Sketches Available in the Mission Portal][Sketches Available in the Mission Portal]  
+At some point, new sketches must be added to the Design Center app. This section shows 
+which directory controls the sketches that are available in the Design Center app and it 
+describes how to add or remove sketches from the app.
 
-[Sketch Flow in the CFEngine Enterprise][Sketch Flow in CFEngine Enterprise]  This section provides a detailed look at the file 
-structure and services that make up the Design Center app.
+[Sketch Flow in the CFEngine Enterprise][Sketch Flow in CFEngine Enterprise]  
+This section provides a detailed look at the file structure and services that make up the 
+Design Center app.
 
 ### Further Reading
 
 The following topics are not included in this section but are equally necessary for 
 understanding and managing Design Center sketches:
 
-[The Design Center API][The Design Center API]  The Design Center API performs all operations related to 
-sketches, parameter sets, environments, validations, and deployment.
+[The Design Center API][The Design Center API]  The Design Center API performs all 
+operations related to sketches, parameter sets, environments, validations, and deployment.
 
-[Design Center Sketch Structure][Sketch Structure]  This reference documentation includes a complete list of 
-requirements necessary for a sketch to work well with the Design Center app.
+[Design Center Sketch Structure][Sketch Structure]  This reference documentation includes 
+a complete list of requirements necessary for a sketch to work well with the Design Center app.
 
-[Write a new Sketch][Write a new Sketch (Enterprise and Community)]  This section describes 
-how to write a Design Center sketch.
+[Write a new Sketch][Write a new Sketch]  This section describes how to write a Design Center sketch.
 
 
 

--- a/manuals/design-center/configure-sketches-enterprise/access-control-mission-portal.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/access-control-mission-portal.markdown
@@ -50,8 +50,7 @@ for a large amount of directories, this will have a performance impact across th
 
 To get complete control over what users do, changes can be reviewed before 
 they are copied to `/var/cfengine/masterfiles` on the policy server. Refer 
-to [Integrating Mission Portal with git][Integrating Mission Portal with 
-git] for more information.
+to [Integrating Mission Portal with git][Integrating Mission Portal with git] for more information.
 
 
 ## Audit log

--- a/manuals/design-center/configure-sketches-enterprise/integrating-mission-portal-with-git.markdown
+++ b/manuals/design-center/configure-sketches-enterprise/integrating-mission-portal-with-git.markdown
@@ -16,7 +16,7 @@ These instructions describe how to set up a git repository that is hosted on the
 Policy Server with the initial CFEngine `masterfiles` and how to configure
 the CFEngine Mission Portal to use this repository. If you already have a git
 service, ensure that you have a passphraseless key generated as shown in step 4 of [Set up the git service][Integrating Mission Portal with git#Set up the git service] 
-and proceed to [Connect Mission Portal to the git repository][Integrating Mission Portal with git#Connect Mission Portal to the git repository].
+and proceed to [Connect the Mission Portal to the git repository][Integrating Mission Portal with git#Connect the Mission Portal to the git repository].
 
 As you follow these steps, refer to the diagram
 in the [CFEngine Enterprise sketch flow][Sketch Flow in CFEngine Enterprise]. It provides 
@@ -27,7 +27,7 @@ a detailed look at the file structure and services that make up the Design Cente
 1. [Set up the git service][Integrating Mission Portal with git#Set up the git service] 
 2. [Initialize the git repository][Integrating Mission Portal with git#Initialize the git repository]
 3. [Update masterfiles from git][Integrating Mission Portal with git#Update masterfiles from git]
-4. [Connect Mission Portal to the git repository][Integrating Mission Portal with git#Connect the Mission Portal to the git repository]
+4. [Connect the Mission Portal to the git repository][Integrating Mission Portal with git#Connect the Mission Portal to the git repository]
 5. [Test the Design Center app][Integrating Mission Portal with git#Test the Design Center app]
 6. [End to end waiting time][Integrating Mission Portal with git#End to end wait time]
 7. [Access control and security][Integrating Mission Portal with git#Access control and security]

--- a/manuals/design-center/design-center-deploy-sketch.markdown
+++ b/manuals/design-center/design-center-deploy-sketch.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Deploy your first Policy (Enterprise)
+title: Deploy your first Policy
 categories: [Manuals, Design Center, Deploy Policy]
 published: true
 sorting: 10

--- a/manuals/design-center/design-center-write-sketch.markdown
+++ b/manuals/design-center/design-center-write-sketch.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Write a new Sketch (Enterprise and Community)
+title: Write a new Sketch
 categories: [Manuals, Design Center, Write Sketch]
 published: true
 sorting: 40
@@ -14,20 +14,20 @@ This page describes how to create a Design Center sketch by converting an existi
 into a sketch and by using the **sketchify** tool in `cf-sketch` to complete the process. 
 These steps are followed:
 
-[Step 1. Select a policy to convert into a sketch][Write a new Sketch (Enterprise and Community)#Step 1. Select a policy to convert into a sketch]
+[Step 1. Select a policy to convert into a sketch][Write a new Sketch#Step 1. Select a policy to convert into a sketch]
 
-[Step 2. Define a sketch name][Write a new Sketch (Enterprise and Community)#Step 2. Define a sketch name]
+[Step 2. Define a sketch name][Write a new Sketch#Step 2. Define a sketch name]
 
-[Step 3. Define the sketch interface][Write a new Sketch (Enterprise and Community)#Step 3. Define the sketch interface]
+[Step 3. Define the sketch interface][Write a new Sketch#Step 3. Define the sketch interface]
 
-[Step 4. Revise the policy file as necessary][Write a new Sketch (Enterprise and Community)#Step 4. Revise the policy file as necessary] 
+[Step 4. Revise the policy file as necessary][Write a new Sketch#Step 4. Revise the policy file as necessary] 
 
-[Step 5. Use the sketchify command to wrap the policy file into a sketch structure][Write a new Sketch (Enterprise and Community)#Step 5. Use the sketchify command to wrap the policy file into a sketch structure]
+[Step 5. Use the sketchify command to wrap the policy file into a sketch structure][Write a new Sketch#Step 5. Use the sketchify command to wrap the policy file into a sketch structure]
 
-[Step 6. Verify that the new sketch is ready for installation and use][Write a new Sketch (Enterprise and Community)#Step 6. Verify that the new sketch is ready for installation and use]
+[Step 6. Verify that the new sketch is ready for installation and use][Write a new Sketch#Step 6. Verify that the new sketch is ready for installation and use]
 
-Refer to the [password_expiration() bundle example][Write a new Sketch (Enterprise and Community)#password_expiration() bundle example] 
-as you follow the steps outlined on this page.
+Refer to the password_expiration() bundle [example][Write a new Sketch#Example] as you 
+follow the steps outlined on this page.
 
 _This information is from Diego Zamboni's book, [Learning CFEngine 3](http://shop.oreilly.com/basket.do?nav=ext). 
 Used with permission. It has been reformatted and edited for website consistency._
@@ -35,7 +35,7 @@ Used with permission. It has been reformatted and edited for website consistency
 ### Before you Begin
 
 This is an advanced topic; we assume that you know how to write policy and you are familiar 
-with the [Design Center API][The Design Center API] and Design Center sketch [management][Configure the Design Center App (Enterprise)].
+with the [Design Center API][The Design Center API] and Design Center sketch [management][Configure the Design Center App].
 
 
 ### Step 1. Select a policy to convert into a sketch
@@ -45,7 +45,7 @@ This bundle can call other bundles or bodies as appropriate, but it should be ca
 as a single point of entry. Until you become more familiar with how sketches
 are structured, write your bundles first as regular CFEngine
 policy, and then convert them to sketches. The instructions on this page create a sketch from the 
-`password_expiration()` [bundle][Write a new Sketch (Enterprise and Community)#password_expiration() bundle example]. 
+`password_expiration()` [bundle][Write a new Sketch#Example]. 
 
 ### Step 2. Define a sketch name
 Arbitrary names are acceptable, but
@@ -95,7 +95,7 @@ For this example, use **cflearn_password_expiration**.
 ### Step 4. Revise the policy file as necessary 
 Once the sketch interface is defined, rewrite the policy file as necessary to make it ready to
 use as a sketch. Below is the updated code, with some comments about the changes made 
-(as you go through these, compare them to the original code in the password_expiration() [bundle][Write a new Sketch (Enterprise and Community)#password_expiration() bundle example]):
+As you go through these, compare them to the original code in the password_expiration() [bundle][Write a new Sketch#Example]:
 
 ```cf3
 bundle agent password_expiration(pass_max_days, pass_min_days, pass_warn_age,
@@ -453,8 +453,9 @@ points per sketch (to different bundles). This is not supported at the moment by
 sketchify, so you must add any additional entry points by hand.
 
 <hr>
+### Example
 
-### password_expiration() bundle example
+#### password_expiration() bundle
 
 Below is the existing policy example that is used to turn into a sketch. Refer to it as
 you follow the steps for creating a sketch.


### PR DESCRIPTION
Most titles of newly-created files in the Design Center section were too long; as a result, the text was spilling into the body of the web page. This did not look good. Page titles have been shortened and links were updated.

Note: Existing files have long titles, too, but they were not shortened at this time.  Do so will cause users to lose their bookmarks.
