### PR TITLE
Added lines to the top of a few pages to show distinction between Enterprise and Community tasks

### DIFF
--- a/manuals/design-center/configure-sketches-enterprise.markdown
+++ b/manuals/design-center/configure-sketches-enterprise.markdown
@@ -8,9 +8,9 @@ alias: configure-sketches-enterprise.html
 tags: [sketch, design center]
 ---
 
-This section is for Enterprise users who plan to manage Design Center sketches. 
+### Enterprise Users can Manage Design Center Sketches 
 
-### Getting Started Topics 
+## Getting Started Topics 
 
 [Integrating the Mission Portal with git][Integrating Mission Portal with git]  The Design 
 Center app requires access to a git repository in order to manage sketches. This section 
@@ -24,7 +24,7 @@ Center app. It describes how to allow or limit a Mission Portal user's ability t
 to the git repository and make changes to the hosts. All Mission Portal changes that users 
 make through the Design Center app can be viewed in the git commit log.
 
-### Advanced Topics
+## Advanced Topics
 
 [Sketches Available in the Mission Portal][Sketches Available in the Mission Portal]  
 At some point, new sketches must be added to the Design Center app. This section shows 
@@ -35,7 +35,7 @@ describes how to add or remove sketches from the app.
 This section provides a detailed look at the file structure and services that make up the 
 Design Center app.
 
-### Further Reading
+## Further Reading
 
 The following topics are not included in this section but are equally necessary for 
 understanding and managing Design Center sketches:

--- a/manuals/design-center/design-center-deploy-sketch.markdown
+++ b/manuals/design-center/design-center-deploy-sketch.markdown
@@ -8,6 +8,8 @@ alias: design-center-deploy-sketch.html
 tags: [design center, sketches]
 ---
 
+### Enterprise Users can Deploy Policies through the Design Center App
+
 **Note:** This tutorial walks you 
 through using a sketch to generate a policy. You must be an Enterprise user who has access 
 to the CFEngine Mission Portal console. CFEngine must be up and running in order to complete 

--- a/manuals/design-center/design-center-write-sketch.markdown
+++ b/manuals/design-center/design-center-write-sketch.markdown
@@ -8,7 +8,9 @@ alias: design-center-write-sketch.html
 tags: [design center, write sketches]
 ---
 
-### Overview
+### Enterprise and Community Users can Write Sketches from the Command Line
+
+## Overview
 
 This page describes how to create a Design Center sketch by converting an existing policy 
 into a sketch and by using the **sketchify** tool in `cf-sketch` to complete the process. 
@@ -37,6 +39,7 @@ Used with permission. It has been reformatted and edited for website consistency
 This is an advanced topic; we assume that you know how to write policy and you are familiar 
 with the [Design Center API][The Design Center API] and Design Center sketch [management][Configure the Design Center App].
 
+## Instructions
 
 ### Step 1. Select a policy to convert into a sketch
 The foundation of any Design Center sketch should be a working piece of CFEngine


### PR DESCRIPTION
Once the page titles were shortened, a few of the pages were not clearly labeled as Enterprise-only or Community-only. Thus, lines were added to the tops of these pages to distinguish between the two. The goal is to make certain users only read documentation that is specific to their edition.
