### PR TITLE
Added text to the index page of Special Variables.

### DIFF
--- a/reference/special-variables.markdown
+++ b/reference/special-variables.markdown
@@ -8,3 +8,27 @@ alias: reference-special-variables.html
 tags: [reference, variables]
 ---
 
+Variables are promises that can be defined in any promise bundle. Users can create their 
+own [variables][Variables]. 
+
+CFEngine includes the following **special variables**:
+
+* **const**[const]  
+Variables defined for embedding unprintable values or values with special meanings 
+in strings.
+
+* **edit**[edit]  
+Variables used to access information about editing promises during their execution.
+
+* **match**[match]  
+Variable used in string matching.
+
+* **mon**[mon]  
+Variables defined in a monitoring context.
+
+* **sys**[sys]  
+Variables defined in order to automate discovery of system values.
+
+* **this**[this]  
+Variables used to access information about promises during their execution.
+


### PR DESCRIPTION
This is a cosmetic fix. The index page contained no text and looked incomplete.
