### PR TITLE
Added text to the index pages for "Policy" and "Enterprise API" topics.

### DIFF
--- a/examples/enterprise-api.markdown
+++ b/examples/enterprise-api.markdown
@@ -6,3 +6,19 @@ published: true
 alias: examples-enterprise-api.html
 tags: [examples, enterprise, rest, api, reporting]
 ---
+The CFEngine Enterprise API allows HTTP clients to interact with the Policy server (hub) 
+of a CFEngine Enterprise installation. With the Enterprise API, you can do the following:
+
+* Check installation status
+
+* Manage users, groups, and settings
+
+* Browse host (agent) information and policy
+
+* Issue flexible SQL queries against data collected by the Policy server from hosts
+
+* Schedule reports for email and later download
+
+The Enterprise API is a REST API, but a central part of interacting with the API involves 
+using SQL. This provides users with maximum flexibility for 
+crafting custom reports based on the wealth of data residing on the Policy server.

--- a/examples/policy.markdown
+++ b/examples/policy.markdown
@@ -6,3 +6,18 @@ published: true
 alias: examples-policy.html
 tags: [examples, policy]
 ---
+
+This section includes examples to use as you write policy for your system environment. 
+The examples here are generic so that you can complete them based on your organization's 
+requirements. 
+
+For more information, visit the following:
+
+* [Tutorials][Tutorials] This section provides examples and explanations of 
+common tasks.
+
+* [Writing Policy] [Writing Policy] This section provides detailed information on writing 
+policy and understanding policy concepts.
+
+
+


### PR DESCRIPTION
Text for the following pages has always been missing. This is now corrected.

examples-enterprise-api.html

examples-policy.html
