### PR TITLE
Created new directories for Writing Policy section; added Policy Framework page.

### DIFF
--- a/manuals/writing-policy/best-practices.markdown
+++ b/manuals/writing-policy/best-practices.markdown
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Best Practices
+categories: [Manuals, Writing Policy, Best Practices]
+published: true
+sorting: 15
+alias: manuals-writing-policy-best-practices.html
+tags: [manuals, style, policy]
+---
+
+Refer to these best practices as you write policy.
+
+Policy Style Guide
+
+Bundles Best Practices
+
+Default Configuration File Structure
+
+Testing Policies
+
+ 

--- a/manuals/writing-policy/best-practices/policy-framework.markdown
+++ b/manuals/writing-policy/best-practices/policy-framework.markdown
@@ -1,0 +1,162 @@
+---
+layout: default
+title: Policy Framework
+categories: [Manuals, Writing Policy, Policy Framework]
+published: true
+sorting: 20
+alias: policy-framework.html
+tags: [manuals, masterfiles, policy, framework]
+---
+
+The policy framework (master files) for CFEngine is located in the /var/cfengine/masterfiles directory on
+the Policy Server. When Hosts (clients) are bootstrapped, they can pull policy from the 
+master files in order to locally store and run them. 
+
+Below is a brief description of the  default master files that you receive with a new install. 
+Keep the master files updated with every new CFEngine release. 
+
+## Files
+### def.cf
+
+This file contains common/global settings such as variables and classes. It lists the acl 
+settings, or which servers are allowed to connect to your policy server. It contains other
+settings to purge policies that don't exist, encrypt the transfer of policies, or to do a 
+log rotation.
+
+**Tip:** Make certain that the Hosts that are connecting to your policy server are included 
+in the acl list.
+
+### promises.cf
+
+This file contains the basic CFEngine policy; thus, CFEngine loads and executes it by default. 
+Every policy file that you want to include 
+must be added to the **inputs** (and possibly **bundlesequence**). Add the path to the file 
+that contains the policy so that it can be evaluated. If you want it to be executed (such 
+as the bundle inside the file), you must either add it to the bundlesequence or add a methods 
+promise to call them.
+
+**Tip:** Create a customized promises.cf file and include all of your promises in it. This 
+helps to avoid upgrade issues and conflicts in the master file. Add this customized promise 
+file to inputs so that it can get evaluated. Add the bundle name to the bundlesequence list.
+
+<!-- This is a good place to add a training slide that shows how cf-agent checkes the 
+promises.cf file on the policy server for recent updates. -->
+
+### update.cf
+
+This file contains the basic update policy. It is always evaluated before promises.cf is 
+run to ensure that all files are properly updated. Policies that are driven by this file 
+are located in the **update** directory. 
+
+## Directories
+
+### bootstrap
+This directory contains the policy that's used for bootstrapping. It includes the 
+**failsafe.cf** file, which CFEngine uses for recovery if the primary failsafe/update loses 
+functionality due to modifications made by the user. This file cannot be edited. 
+
+### cfe_interal
+This directory contains Enterprise-related policies that should not be modified.
+
+### controls
+
+This directory contains the controls for each component of the agent:
+
+* **cf_agent.cf** Manages the `cf-agent` component.
+* **cf_execd.cf** Controls the execution of CFEngine. Specifically, it includes splaytime settings 
+and mail settings for email reports. It also includes the schedule to run the cf-agent and the 
+command to run it. 
+* **cf_hub.cf** Manages the `cf-hub` component. It 
+includes settings for collecting information from Hosts for analysis and reporting purposes. 
+This is Enterprise-specific.
+* **cf_monitor.cf** Manages the `cf-monitor` component.
+* **cf_runagent.cf** Manages the `cf-runagent` component.
+The most important parameter is the list of hosts that the agent will poll for connections.
+* **cf_serverd.cf** Contains the general IP access policy for the connection protocol (i.e. access 
+to the server itself). Access to specific files must also be granted.
+
+### inventory  (New in 3.6)
+This directory contains inventory modules that are loaded before anything else in order to 
+discover facts about the system.
+
+<!-- Add more later. -->
+
+### lib
+
+This directory contains the 3.5 and 3.6 versions of the Standard Library. The standard library 
+contains and extensive amount of commonly-used bundles and bodies that you can use to implement 
+different tasks with CFEngine. 
+
+Import individual files from the CFEngine Standard Library into your CFEngine policy as follows:
+
+```cf3
+body common control
+{
+    inputs => { "lib/3.6/common.cf",
+                "lib/3.6/files.cf",
+                "lib/3.6/commands.cf" };
+}
+```
+
+The following files make up the Standard Library:
+
+* **bundles.cf** Contains standalone agent bundles that perform common tasks, such as
+`fileinfo()` (extract file information using the `filestat()` function) and
+`logrotate()` (rotate log files by size).
+* **commands.cf** Defines a number of `contain` bodies for use with `commands:` promises.
+* **common.cf** Defines bodies that can be used with all promise types, such as `action` and
+`classes` bodies.
+* **databases.cf** Contains database_server bodies to use with `databases:` promises.
+* **feature.cf** NEW in 3.6  
+* **files.cf**  Includes all bundles and bodies that can be used with `files:` promises, including
+`edit_line` bundles, `edit_field` bodies, `copy_from` bodies, etc.
+* **guest_environments.cf**  Includes `environment_resources` bodies to use in defining virtual machines for
+`guest_environments:` promises.
+* **monitor.cf**  Includes bodies that can be used with `measurements:` promises (only in CFEngine
+Enterprise), such as `match_value` bodies.
+* **packages.cf**  Includes all `package_method` body definitions, to use with `packages:` promises
+to interact with different package and software managers.
+* **paths.cf**  Contains the paths common bundle, which defines the paths for many common
+system binaries in different operating systems. By using this bundle, you
+can make your policies system-independent by avoding hard-coded command
+paths.
+* **processes.cf**  Includes `process_select` and `process_count` bodies for use with `processes:`
+promises.
+* **services.cf**  Includes the `standard_services()` bundle, which provides the built-in support
+for most common services in different operating systems, and implements the
+default behavior of `services:` promises.
+* **storage.cf**  storage.cf
+Defines `volume` and `mount` bodies to use with `storage:` promises.
+
+Definitions of the Standard Library files provided by 
+[Diego Zamboni][[Learning CFEngine 3](http://shop.oreilly.com/basket.do?nav=ext)]. 
+
+### libraries
+
+The directory contains older versions of the Standard Library.
+
+### services
+
+This is the location of user's policy files (the .cf files). Two policies are included:
+`init_msg.cf` (initial message display) and `file_change.cf` (change management).
+
+### sketches
+
+This is the location of user's sketches. If you activate a sketch, it goes here. It contains 
+the meta/api-runfile.cf file, which calls two bundles:
+cfsketch_g Defines common variables that are necessary to execute sketches.
+cfsketch_run Executes the sketches.
+
+### update
+
+This directory contains files that drive the update.cf file, or the basic update policy.
+
+* **mongod.conf** Mongo database update information.
+* **update_bins.cf** Updates the binaries.
+* **update_masterfiles**_internal.cf Updates the masterfiles 
+* **update_policy.cf** Copies updates files from /var/cfengine/masterfiles/ on the policy server to 
+/var/cfengine/inputs all machines (policy server and hosts).
+* **update_processes.cf** Starts tasks that should be running.
+
+
+<!-- Should I add anything about .gitignore, Makefile, Makefile.am, README? -->

--- a/manuals/writing-policy/best-practices/policy-style.markdown
+++ b/manuals/writing-policy/best-practices/policy-style.markdown
@@ -1,0 +1,173 @@
+---
+layout: default
+title: Policy Style Guide
+categories: [Manuals, Writing Policy, Policy Style Guide]
+published: true
+sorting: 10
+alias: manuals-writing-policy-policy-style-guide.html
+tags: [manuals, style, policy]
+---
+
+Style is a very personal choice and the contents of this guide should only be
+considered suggestions. We invite you to contribute to the growth of this
+guide.
+
+## Style Summary
+* one indent = 2 spaces
+* avoid letting line length surpass 80 characters.
+* vertically align opening and closing curly braces unless on same line
+* promise type = 1 indent
+* context class expression = 2 indents
+* promiser = 3 indents
+* promise attributes = (we suggest 3 or 4 indents)
+
+## Whitespace and Line Length
+
+Spaces are preferred to tab characters. Lines should not have trailing
+whitespace. Generally line length should not surpass 80 characters. 
+
+## Curly brace alignment
+
+Generally if opening and closing braces are not on a single line they should
+be aligned vertically.
+
+Example:
+
+```cf3
+
+    bundle agent example
+    {
+      vars:
+          "people" slist => {
+                              "Obi-Wan Kenobi",
+                              "Luke Skywalker",
+                              "Chewbacca",
+                              "Yoda",
+                              "Darth Vader",
+                            };
+
+          "cuddly" slist => { "Chewbacca", "Yoda" };
+    }
+```
+
+## Promise types
+
+Promise types should have 1 indent and each promise type after the first
+listed should have a blank line before the next promise type.
+
+This example illustrates the blank line before the "classes" type.
+
+```cf3
+    bundle agent example
+    {
+      vars:
+          "policyhost" string => "MyPolicyServerHostname";
+
+      classes:
+          "EL5" or => { "centos_5", "redhat_5" };
+          "EL6" or => { "centos_6", "redhat_6" };
+    }
+```
+
+## Context class expressions
+
+Context class expressions should have 2 indents and each context class
+expression after the first listed within a given promise type should have a
+blank line preceding it.
+
+This example illustrates the blank line before the second context class
+expression (solaris) in the files type promise section:
+
+```cf3
+    bundle agent example
+    {
+      files:
+        any::
+          "/var/cfengine/inputs/"
+            copy_from    => update_policy( "/var/cfengine/masterfiles","$(policyhost)" ),
+            classes      => policy_updated( "policy_updated" ),
+            depth_search => recurse("inf");
+
+        solaris::
+          "/var/cfengine/inputs"
+            copy_from => update_policy( "/var/cfengine/masterfiles", "$(policyhost" ),
+            classes   => policy_updated( "policy_updated" );
+    }
+```
+
+## Policy Comments
+
+In-line policy comments are useful for debugging and explaining why something
+is done a specific way. We encourage you to document your policy throughly.
+
+Comments about general body and bundle behavior and parameters should be
+placed after the body or bundle definition, before the opening curly brace and
+should not be indented. Comments about specific promise behavior should be
+placed before the promise at the same indention level as the promiser or on
+the same line after the attribute.
+
+```cf3
+    bundle agent example(param1)
+    # This is an example bundle to illustrate comments
+    # param1 - string - 
+    {
+      vars:
+          "copy_of_param1" string => "$(param1)";
+
+          "jedi" slist => { 
+                            "Obi-Wan Kenobi",
+                            "Luke Skywalker",
+                            "Yoda",
+                            "Darth Vader", # He used to be a Jedi, and since he
+                                           # tossed the emperor into the Death
+                                           # Star's reactor shaft we are including
+                                           # him.
+                          };
+      classes:
+          # Most of the time we don't need differentiation of redhat and centos
+          "EL5" or => { "centos_5", "redhat_5" };
+          "EL6" or => { "centos_6", "redhat_6" };
+    }
+```
+
+## Hashrockets (=>)
+
+Hash rockets should be aligned within a promise body scope and for grouped
+single line promises.
+
+Example:
+
+```cf3
+    bundle agent example
+    {
+      files:
+        any::
+          "/var/cfengine/inputs/"
+            copy_from    => update_policy( "/var/cfengine/masterfiles","$(policyhost)" ),
+            classes      => policy_updated( "policy_updated" ),
+            depth_search => recurse("inf");
+
+          "/var/cfengine/modules"
+            copy_from => update_policy( "/var/cfengine/modules", "$(policyhost" ),
+            classes   => policy_updated( "modules_updated" );
+
+      classes:
+          "EL5" or => { "centos_5", "redhat_5" };
+          "EL6" or => { "centos_6", "redhat_6" };
+    }
+```
+
+## Naming Conventions
+### Internal variables & classes
+
+Variables and classes that have no centralized reporting value are considered
+"internal". By convention internal variables and classes should be prefix with
+an underscore "_". This convention is used by the policy framework to exclude
+collection of any prefixed variables and classes when polled by the `cf-hub`
+component.
+
+## Automatic reindentation
+
+You can run `contrib/reindent.pl FILE1.cf FILE2.c FILE3.h` to reindent files,
+if you don't want to set up Emacs.  It will rewrite them with the new
+indentation, using Emacs in batch mode.

--- a/manuals/writing-policy/configure-cfengine.markdown
+++ b/manuals/writing-policy/configure-cfengine.markdown
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Policy Concepts
+categories: [Manuals, Writing Policy, Configure CFEngine]
+published: true
+sorting: 30
+alias: manuals-writing-policy-configure-cfengine.html
+tags: [manuals, style, policy, concepts]
+---
+
+Configure CFEngine:
+
+Controlling Frequency
+
+Version Control
+
+Filenames and Paths
+
+
+
+ 

--- a/manuals/writing-policy/policy-concepts.markdown
+++ b/manuals/writing-policy/policy-concepts.markdown
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Policy Concepts
+categories: [Manuals, Writing Policy, Policy Concepts]
+published: true
+sorting: 20
+alias: manuals-writing-policy-policy-concepts.html
+tags: [manuals, style, policy, concepts]
+---
+
+Learn the concepts that make up CFEngine:
+
+Language Concepts
+
+Policy Framework
+
+Syntax, identifiers, names
+
+
+
+ 


### PR DESCRIPTION
The Writing Policies section contains too many sub-topics. Creating new directories and then moving pages into those directories will make the WP section seem less overwhelming. 
