### PR TITLE
Removed Mission Portal link on 2 pages because it no longer exists at cfengine.com.

### DIFF
--- a/manuals/enterprise-reporting.markdown
+++ b/manuals/enterprise-reporting.markdown
@@ -27,4 +27,4 @@ This data can be mined using SQL queries, and then be used for inventory
 management, compliance reporting, system diagnostics, capacity planning etc.
 
 Access to the data is provided through the [Enterprise API][Enterprise API] 
-and the [Mission Portal][Mission Portal] web front-end.
+and the Mission Portal web front-end.

--- a/manuals/enterprise-reporting/reporting-architecture.markdown
+++ b/manuals/enterprise-reporting/reporting-architecture.markdown
@@ -52,9 +52,8 @@ the database to provide access to the data via SQL queries.
 ### Apache
 
 REST over HTTP is provided by the
-[Apache http server](http://httpd.apache.org) which also hosts the
-[Mission Portal][Mission Portal]. The`httpd` process is started through 
-CFEngine policy, and listens on port 80.
+[Apache http server](http://httpd.apache.org) which also hosts the Mission Portal. 
+The`httpd` process is started through CFEngine policy, and listens on port 80.
 
 Apache is part of the CFEngine Enterprise installation in 
 `/var/cfengine/httpd`. A user `apache` is created with privileges to run 


### PR DESCRIPTION
Removed Mission Portal link from:

--manuals-enterprise-reporting.html

--manuals-enterprise-reporting-architecture.html.

Links will be added when Mission Portal info is completed.
