### PR TITLE
Removed reference to DiffLexer and just created normal code blocks on Known Issues page

### DIFF
--- a/getting-started/known-issues.markdown
+++ b/getting-started/known-issues.markdown
@@ -47,7 +47,7 @@ bindtointerface => "0.0.0.0";
 
 ### cf-execd sends out emails on every execution
 
-**This problem is solved as of CFEngine 3.5.1**
+**This problem is solved as of CFEngine 3.5.1.**
 
 The inclusion of the timestamp in the new log output format causes this
 behavior. This will be resolved in the next release.


### PR DESCRIPTION
Areas that have `DiffLexer have been changed to` (adding```cf3 brought a confusing color scheme to the code that was not helpful for seeing adds/deletes).
