### PR TITLE
Corrected links, spacing issues on the common-attributes-include.markdown page

### DIFF
--- a/reference/common-attributes-include.markdown
+++ b/reference/common-attributes-include.markdown
@@ -1,19 +1,20 @@
 ### Common Attributes
 
 Common attributes are available to all promise types. Full details for common
-attributes can be found in the [Common Attributes Section][Promise Types and
-Attributes#Common Attributes] of the [Promise Types and Attributes] page.
+attributes can be found in the [Common Attributes Section][Promise Types and 
+Attributes#Common Attributes] of the [Promise Types and Attributes] page. The common 
+attributes are as follows:
 
-#### [action][Promise Types and Attributes#action] [common attribute]
+#### [action][Promise Types and Attributes#action]
 
-#### [classes][Promise Types and Attributes#classes] [common attribute]
+#### [classes][Promise Types and Attributes#classes] 
 
-#### [comment][Promise Types and Attributes#comment] [common attribute]
+#### [comment][Promise Types and Attributes#comment] 
 
-####  [depends_on][Promise Types and Attributes#depends_on] [common attribute]
+####  [depends_on][Promise Types and Attributes#depends_on] 
 
-#### [handle][Promise Types and Attributes#handle] [common attribute]
+#### [handle][Promise Types and Attributes#handle] 
 
-#### [ifvarclass][Promise Types and Attributes#ifvarclass] [common attribute]
+#### [ifvarclass][Promise Types and Attributes#ifvarclass] 
 
-#### [meta][Promise Types and Attributes#meta] [common attribute]
+#### [meta][Promise Types and Attributes#meta] 


### PR DESCRIPTION
1. Removed  [common attribute] from each of the attributes because it wasn't working and it wasn't needed. For example, [action][Promise Types and Attributes#action] takes the user to action under Common Attributes.
2. A missing space between in [Common Attributes Section][Promise Types andAttributes#Common Attributes] was causing the link to appear incorrectly. This has been fixed.
3. Added a line to the text to give more clarity: "The common attributes are as follows:"
