### PR TITLE
Corrected 1 more space issue, added <hr> to common-attributes-include.markdown

### DIFF
--- a/reference/common-attributes-include.markdown
+++ b/reference/common-attributes-include.markdown
@@ -1,9 +1,8 @@
 ### Common Attributes
 
 Common attributes are available to all promise types. Full details for common
-attributes can be found in the [Common Attributes Section][Promise Types and 
-Attributes#Common Attributes] of the [Promise Types and Attributes] page. The common 
-attributes are as follows:
+attributes can be found in the [Common Attributes Section][Promise Types and Attributes#Common Attributes] of 
+the [Promise Types and Attributes] page. The common attributes are as follows:
 
 #### [action][Promise Types and Attributes#action]
 
@@ -18,3 +17,5 @@ attributes are as follows:
 #### [ifvarclass][Promise Types and Attributes#ifvarclass] 
 
 #### [meta][Promise Types and Attributes#meta] 
+
+<hr>


### PR DESCRIPTION
Internal links do not work when they are spliced on the markdown page:
[Common Attributes Section][Promise Types and 
Attributes#Common Attributes] 

The entire link must be on the same line:
[Common Attributes Section][Promise Types and Attributes#Common Attributes]

I also added a horizontal line <hr> to the macro in order to visually separate the common attributes from the other attributes on each Promise Type page. (I will remove it if it looks bad.)
