### PR TITLE
Grammar improvements; fix broken links on Standard Library pages

### DIFF
--- a/reference/functions/filesize.markdown
+++ b/reference/functions/filesize.markdown
@@ -26,4 +26,4 @@ Output:
 
 [%CFEngine_include_snippet(filesize.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**History:** Was introduced in version 3.1.3,Nova 2.0.2 (2010)
+**History:** Was introduced in version 3.1.3, Nova 2.0.2 (2010).

--- a/reference/standard-library/commands.markdown
+++ b/reference/standard-library/commands.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-commands.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`commands` promises][commands] for a
+See the [`commands` promises][commands] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 [%CFEngine_library_include(lib/3.6/commands)%]
 

--- a/reference/standard-library/common.markdown
+++ b/reference/standard-library/common.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-common.html
 tags: [reference, standard library]
 ---
 
-See the documentation of the [common promise attributes][Promise Types and Attributes]
-for a comprehensive reference on the body types and attributes used here.
+See the [common promise attributes][Promise Types and Attributes#Common Attributes] 
+documentation for a comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 
@@ -35,7 +34,7 @@ methods:
     usebundle => library_bundle(parameters)
 ```
 
-To use these bundles, add
+To use these bundles, add the following to your policy:
 
 ```cf3
 body file control
@@ -44,7 +43,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 

--- a/reference/standard-library/databases.markdown
+++ b/reference/standard-library/databases.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-databases.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`databases` promises][databases] for a
+See the [`databases` promises][databases] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/databases)%]

--- a/reference/standard-library/files.markdown
+++ b/reference/standard-library/files.markdown
@@ -8,11 +8,11 @@ alias: reference-standard-library-files.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`files` promises][files] and
-[`edit_line` bundles][edit_line] for a comprehensive reference on
-the bundles, body types and attributes used here.
+See the [`files` promises][files] and [`edit_line` bundles][bundle edit_line] 
+documentation for a comprehensive reference on
+the bundles, body types, and attributes used here.
 
-To use these bodies and bundles, add
+To use these bodies and bundles, add the following to your policy:
 
 ```cf3
 body file control
@@ -21,6 +21,5 @@ body file control
 }
 ```
 
-to your policy.
 
 [%CFEngine_library_include(lib/3.6/files)%]

--- a/reference/standard-library/guest_environments.markdown
+++ b/reference/standard-library/guest_environments.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-guest_environments.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`guest_environments` promises][guest_environments] for a
+See the [`guest_environments` promises][guest_environments] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/guest_environments)%]

--- a/reference/standard-library/monitor.markdown
+++ b/reference/standard-library/monitor.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-monitor.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`measurements` promises][measurements] for a
+See the [`measurements` promises][measurements] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/monitor)%]

--- a/reference/standard-library/packages.markdown
+++ b/reference/standard-library/packages.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-packages.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`packages` promises][packages] for a
+See the [`packages` promises][packages] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies and bundles, add
+To use these bodies and bundles, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,7 @@ body file control
 }
 ```
 
-to your policy.
+
 
 
 [%CFEngine_library_include(lib/3.6/packages)%]

--- a/reference/standard-library/processes.markdown
+++ b/reference/standard-library/processes.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-processes.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`processes` promises][processes] for a
+See the [`processes` promises][processes] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/processes)%]

--- a/reference/standard-library/services.markdown
+++ b/reference/standard-library/services.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-services.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`services` promises][services] for a
+See the [`services` promises][services] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies and bundles, add
+To use these bodies and bundles, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/services)%]

--- a/reference/standard-library/storage.markdown
+++ b/reference/standard-library/storage.markdown
@@ -8,10 +8,10 @@ alias: reference-standard-library-storage.html
 tags: [reference, standard library]
 ---
 
-See the documentation of [`storage` promises][storage] for a
+See the [`storage` promises][storage] documentation for a
 comprehensive reference on the body types and attributes used here.
 
-To use these bodies, add
+To use these bodies, add the following to your policy:
 
 ```cf3
 body file control
@@ -20,7 +20,6 @@ body file control
 }
 ```
 
-to your policy.
 
 
 [%CFEngine_library_include(lib/3.6/storage)%]


### PR DESCRIPTION
Changed all sentences in Std Library pages to: "To use these bodies, add the following to your policy:"

Changed all sentences in Std Library pages to: "See the [promises] documentation for a comprehensive reference on the body types and attributes used here."

A link was broken on the files.markdown page. Fixed.

---

Minor edit on the filesize.markdown page (space between words).
