### PR TITLE
Added "Enterprise-only" to measurements.markdown and monitor.markdown

### DIFF
--- a/reference/promise-types/measurements.markdown
+++ b/reference/promise-types/measurements.markdown
@@ -7,7 +7,7 @@ alias: reference-promise-types-measurements.html
 tags: [reference, bundle monitor, measurements, monitoring, promise types]
 ---
 
-**These features are available only in CFEngine Enterprise.**
+**This is an Enterprise-only feature.**
 
 By default,CFEngine's monitoring component `cf-monitord` records performance data about the system. These include process counts, service traffic, load average and CPU utilization and temperature when available.
 

--- a/reference/standard-library/monitor.markdown
+++ b/reference/standard-library/monitor.markdown
@@ -7,6 +7,7 @@ sorting: 60
 alias: reference-standard-library-monitor.html
 tags: [reference, standard library]
 ---
+**This is an Enterprise-only feature.**
 
 See the [`measurements` promises][measurements] documentation for a
 comprehensive reference on the body types and attributes used here.


### PR DESCRIPTION
The Monitor Bundles and Bodies as well as the Measurements Promises are Enterprise-only. This is now clear on both pages.
