### PR TITLE
Corrected link error on the enterprise api page

### DIFF
--- a/examples/enterprise-api.markdown
+++ b/examples/enterprise-api.markdown
@@ -29,5 +29,5 @@ SQL and the scalability through Multi-Site queries, users can craft custom
 reports about systems of arbitrary scale, mining a wealth of data residing 
 on globally distributed CFEngine Database Servers.
 
-Refer to the [Enterprise API Reference][Enterprise API Reference] section for the SQL schema 
+Refer to the [Enterprise API Reference][Enterprise  API Reference] section for the SQL schema 
 and URI resources. 


### PR DESCRIPTION
Link to the Enterprise API reference page is not showing. Fixed.
