### PR TITLE
Changed dir name from Manuals to Learning CFEngine (updated other pages)

### DIFF
--- a/getting-started.markdown
+++ b/getting-started.markdown
@@ -35,7 +35,7 @@ systems. Find these examples on our [website][Policy] and in our github [reposit
 Also learn about promise theory and the phases of managing systems with CFEngine. 
 
 [Learning Resources][Learning Tools] In addition to the documentation that's provided on 
-our [website][CFEngine Manuals], we provide guides, demos, and other resources from our CFEngine 
+our [website][Learning CFEngine], we provide guides, demos, and other resources from our CFEngine 
 staff and our special CFEngine contributors. 
 
 

--- a/getting-started/installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/installation-enterprise-free.markdown
@@ -130,7 +130,7 @@ through the Mission Portal, this advanced, command-line tutorial shows you how t
 
 ## Recommended Reading
 
-* CFEngine [manuals][CFEngine Manuals].
+* CFEngine [manuals][Learning CFEngine].
 * Additional [tutorials, examples, and documentation][Learning Tools].
 
 <hr>

--- a/getting-started/installation/installation-enterprise.markdown
+++ b/getting-started/installation/installation-enterprise.markdown
@@ -208,7 +208,7 @@ Learn more about CFEngine by using the following resources:
 
 * Tutorial: [Configure and deploy a policy using sketches in the Design Center.][Configure and Deploy a Policy Using Sketches (Enterprise Only)]
 
-* CFEngine [manuals][CFEngine Manuals].
+* CFEngine [manuals][Learning CFEngine].
 
 * Additional [tutorials, examples, and documentation][Learning Tools].
 

--- a/manuals.markdown
+++ b/manuals.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: CFEngine Manuals 
+title: Learning CFEngine 
 categories: [Manuals]
 published: true
 sorting: 30


### PR DESCRIPTION
These pages were updated because they reference the Learning CFEngine index page:

--Getting Started

--Installing Enterprise-Free

--Installing Enterprise-Production
