### PR TITLE
Change dir name from Learning Tools to Learning Resources (updated impacted pages)

### DIFF
--- a/getting-started.markdown
+++ b/getting-started.markdown
@@ -34,7 +34,7 @@ systems. Find these examples on our [website][Policy] and in our github [reposit
 [Concepts][Concepts] Learn the concepts of CFEngine such as its architecture and components. 
 Also learn about promise theory and the phases of managing systems with CFEngine. 
 
-[Learning Resources][Learning Tools] In addition to the documentation that's provided on 
+[Learning Resources][Learning Resources] In addition to the documentation that's provided on 
 our [website][Learning CFEngine], we provide guides, demos, and other resources from our CFEngine 
 staff and our special CFEngine contributors. 
 

--- a/getting-started/installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/installation-enterprise-free.markdown
@@ -131,7 +131,7 @@ through the Mission Portal, this advanced, command-line tutorial shows you how t
 ## Recommended Reading
 
 * CFEngine [manuals][Learning CFEngine].
-* Additional [tutorials, examples, and documentation][Learning Tools].
+* Additional [tutorials, examples, and documentation][Learning Resources].
 
 <hr>
 

--- a/getting-started/installation/installation-enterprise.markdown
+++ b/getting-started/installation/installation-enterprise.markdown
@@ -210,6 +210,6 @@ Learn more about CFEngine by using the following resources:
 
 * CFEngine [manuals][Learning CFEngine].
 
-* Additional [tutorials, examples, and documentation][Learning Tools].
+* Additional [tutorials, examples, and documentation][Learning Resources].
 
 * Get [Support][Support and Community] from the CFEngine community.

--- a/getting-started/learning-tools.markdown
+++ b/getting-started/learning-tools.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Learning Tools 
+title: Learning Resources 
 categories: [Getting Started, Learning Tools]
 published: true
 sorting: 40

--- a/getting-started/support-and-community.markdown
+++ b/getting-started/support-and-community.markdown
@@ -29,7 +29,7 @@ have downloaded the free version of CFEngine 3 Enterprise.
 
 Sometimes the best help is already written. 
 
-* Visit our [learning resources][Learning Tools] for guides, demos, training videos, and tools.
+* Visit our [learning resources][Learning Resources] for guides, demos, training videos, and tools.
 
 ### Social Media
 


### PR DESCRIPTION
Pages that reference Learning Resources and were updated are:

--Getting Started

--Installing Enterprise--Free

--Installing Enterprise--Production

--Support and Community
