### PR TITLE
Change sorting to correctly organize sections under Learning CFEngine

### DIFF
--- a/manuals/design-center.markdown
+++ b/manuals/design-center.markdown
@@ -3,7 +3,7 @@ layout: default
 title: Design Center Sketches
 categories: [Manuals, Design Center]
 published: true
-sorting: 50
+sorting: 60
 alias: manuals-design-center.html
 tags: [design center, cf-sketch, sketches, deploy policy]
 ---

--- a/manuals/reports.markdown
+++ b/manuals/reports.markdown
@@ -3,7 +3,7 @@ layout: default
 title: Reports
 categories: [Manuals, Reports]
 published: true
-sorting: 60
+sorting: 70
 alias: manuals-reports.html
 ---
 
@@ -30,13 +30,13 @@ every 5 minutes from all bootstrapped hosts, and includes information about:
 * software information
 * file changes
 
-This data can be mined using SQL queries, and then be used for inventory 
-management, compliance reporting, system diagnostics, capacity planning etc.
+This data can be mined using SQL queries, and then be used for such issues as inventory 
+management, compliance reporting, system diagnostics, and capacity planning.
 
 Access to the data is provided through two ways:
 
-* the Mission Portal 
-* the Enterprise Report API and console.
+* the Mission Portal console
+* the Enterprise Report API.
 
 
 ### Command-Line Reporting
@@ -47,7 +47,7 @@ Basic output to file or logs can be customized on a per-promise basis.
 Users can design their own log and report formats, but data processing and extraction from
 CFEngine's embedded databases must be scripted by the user.
 
-Note: 
+**Note:**
 
 If you have regular reporting needs, we recommend using our commercially-supported version
 of CFEngine, Enterprise. It will save considerable time and resources in

--- a/manuals/writing-policy.markdown
+++ b/manuals/writing-policy.markdown
@@ -3,7 +3,7 @@ layout: default
 title: Writing Policy
 categories: [Manuals, Writing Policy]
 published: true
-sorting: 60
+sorting: 50
 alias: manuals-writing-policy.html
 ---
 


### PR DESCRIPTION
This is the order:

Language Concepts

Writing Policy

Design Center Sketches

Reports

Enterprise API
