### PR TITLE
Add known issue about removal of system apache

### DIFF
--- a/getting-started/installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/installation-enterprise-free.markdown
@@ -48,6 +48,9 @@ $ wget http://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-enterpri
 
 This script installs the latest CFEngine Enterprise Policy Server on your machine.
 
+**Note:** CFEngine enterprise expectes to be installed on to a fresh system and
+not be co-located with any other webserver or database server.
+
 ## 2. Bootstrap the Policy Server
 
 The Policy Server must be bootstrapped to itself. Find the IP address of your Policy Server (type $ ifconfig).

--- a/getting-started/installation/installation-enterprise.markdown
+++ b/getting-started/installation/installation-enterprise.markdown
@@ -41,6 +41,11 @@ additional software is not required.
 
 CFEngine recommends the following:
 
+### Dedicated server
+
+CFEngine enterprise expectes to be installed on to a fresh system and not be
+co-located with any other webserver or database server.
+
 ### Memory
 
 A minimum of 2 GB of available memory and a modern 64 bit processor. For a

--- a/getting-started/known-issues.markdown
+++ b/getting-started/known-issues.markdown
@@ -287,3 +287,8 @@ https://cfengine.com/dev/issues/2956
 #### Workaround
 
 Remove cfengine-nova-hub from the yum repository and install the hub using rpm.
+
+### Installing cfengine-nova-hub removes system apache
+
+The cfengine-nova-hub package removes apache if it is already installed on the system. In addition it removes `/var/www`.
+


### PR DESCRIPTION
Document in enterprise install guides that CFEngine enterprise hub expects to
be run on a dedicated server not to be colocated with any other webserver or
database server. Ref: https://cfengine.com/dev/issues/4023
