### PR TITLE
Fix the default scope of classes

### DIFF
--- a/reference/promise-types/classes.markdown
+++ b/reference/promise-types/classes.markdown
@@ -258,14 +258,14 @@ on [Negative Knowledge][classes and decisions].
     bundle
 ```
 
-**Default value:** namespace
+**Default value:** bundle
 
 **Example:**
 
 ```cf3
     classes:
       "bundle_context"
-          scope => "bundle";
+          scope => "namespace";
 ```
 
 **See also:** [`scope` in `body classes`][Promise Types and Attributes#scope]


### PR DESCRIPTION
The default class scope was incorrectly set as `namespace`.
3.5 has the same typo and this should be backported.
