### PR TITLE
Added how-to-guides section and placeholder docs.

### DIFF
--- a/how-to-guides.markdown
+++ b/how-to-guides.markdown
@@ -1,0 +1,19 @@
+---
+layout: default
+title: How to Guides 
+categories: [How to Guides]
+published: true
+sorting: 10
+alias: how-to-guides.html
+---
+
+| Document | Basic | Intermediate | Advanced | System Administration | Policy & Promise Writing | Management |
+|----------------|:------:|:-----:|:------:|:--------|:-----:|:------:|:--------:|
+|[Basic CFEngine Guide][Basic CFEngine Guide]|X|||X|X||
+|[Intermediate CFEngine Guide][Intermediate CFEngine Guide]||X||X|X||
+|[Advanced CFEngine Guide][Advanced CFEngine Guide]|||X|X|X|X|
+|[CFEngine Enterprise Guide][CFEngine Enterprise Guide]||X|X|X|X|X|
+|[CFEngine Guide for Policy Developers][CFEngine Guide for Policy Developers]|X|X|X||X||
+|[CFEngine Guide for System Administrators][CFEngine Guide for System Administrators]|X|X|X|X||X|
+|[CFEngine Guide for System Architects][CFEngine Guide for System Architects]||X|X|X||X|
+|[CFEngine Guide for Managers][CFEngine Guide for Managers]||X|X|X||X|

--- a/how-to-guides/advanced-cfengine-guide.markdown
+++ b/how-to-guides/advanced-cfengine-guide.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Advanced CFEngine Guide
+categories: [How to Guides, Advanced CFEngine Guide]
+published: true
+sorting: 10
+alias: how-to-guides-advanced-cfengine.html
+---

--- a/how-to-guides/basic-cfengine-guide.markdown
+++ b/how-to-guides/basic-cfengine-guide.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Basic CFEngine Guide
+categories: [How to Guides, Basic CFEngine Guide]
+published: true
+sorting: 10
+alias: how-to-guides-basic-cfengine.html
+---

--- a/how-to-guides/cfengine-guide-managers.markdown
+++ b/how-to-guides/cfengine-guide-managers.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: CFEngine Guide for Managers 
+categories: [How to Guides, CFEngine Guide for Managers]
+published: true
+sorting: 10
+alias: how-to-guides-cfengine-for-managers.html
+---

--- a/how-to-guides/cfengine-guide-policy-developer.markdown
+++ b/how-to-guides/cfengine-guide-policy-developer.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: CFEngine Guide for Policy Developers 
+categories: [How to Guides, CFEngine Guide for Policy Developers]
+published: true
+sorting: 10
+alias: how-to-guides-cfengine-for-policy-developers.html
+---

--- a/how-to-guides/cfengine-guide-system-adminstrators.markdown
+++ b/how-to-guides/cfengine-guide-system-adminstrators.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: CFEngine Guide for System Administrators 
+categories: [How to Guides, CFEngine Guide for System Administrators]
+published: true
+sorting: 10
+alias: how-to-guides-cfengine-for-system-administrators.html
+---

--- a/how-to-guides/cfengine-guide-system-architects.markdown
+++ b/how-to-guides/cfengine-guide-system-architects.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: CFEngine Guide for System Architects 
+categories: [How to Guides, CFEngine Guide for System Architects]
+published: true
+sorting: 10
+alias: how-to-guides-cfengine-for-system-architects.html
+---

--- a/how-to-guides/enterprise-cfengine-guide.markdown
+++ b/how-to-guides/enterprise-cfengine-guide.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: CFEngine Enterprise Guide 
+categories: [How to Guides,CFEngine Enterprise Guide]
+published: true
+sorting: 10
+alias: how-to-guides-cfengine-enterprise.html
+---

--- a/how-to-guides/intermediate-cfengine-guide.markdown
+++ b/how-to-guides/intermediate-cfengine-guide.markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Intermediate CFEngine Guide
+categories: [How to Guides, Intermediate CFEngine Guide]
+published: true
+sorting: 10
+alias: how-to-guides-intermediate-cfengine.html
+---


### PR DESCRIPTION
Began how to guides section.

Docs are mostly empty on this commit.

Includes a matrix for expert level and role (e.g. sys admin, architect.) to help guide people to right content.
