### PR TITLE
Add syntax highlighting for JSON guide

### DIFF
--- a/guide/cookbook/json-support-in-cfengine.markdown
+++ b/guide/cookbook/json-support-in-cfengine.markdown
@@ -61,7 +61,7 @@ expressions or class names.
 
 Easy, right?
 
-```
+```cf3
 body common control
 {
       bundlesequence => { "run" };
@@ -95,13 +95,13 @@ through them and look up values.
 
 Well, you can change
 
-```
+```cf3
       "bykey" data => parsejson('{ "dev": ["c", "b"], "prod": ["flea"], "qa": ["a"], "private": ["linux"] }');
 ```
 
 with
 
-```
+```cf3
       "bykey" data => data_readstringarray(...);
 ```
 
@@ -118,7 +118,7 @@ private linux
 You can also use
 
 
-```
+```cf3
       "bykey" data => readjson(...);
 ```
 


### PR DESCRIPTION
Syntax highlighting makes for easier to
read policy.
