### PR TITLE
Add default value for copy_from timeout which is default_timeout in agent control body

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -561,7 +561,7 @@ depends on system behavior.
 
 **Allowed input range:** `0,99999999999`
 
-**Default value:** 10 seconds
+**Default value:** 30 seconds
 
 **Example:**
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1157,6 +1157,8 @@ timeout, in seconds.
 
 **Allowed input range:** `1,3600`
 
+** Default Value:** `default_timeout` [cf-agent#default_timeout]
+
 **Example:**
 
 ```cf3


### PR DESCRIPTION
AND
Correct default value of agent control "default_timeout"
Which is actually 30 seconds if not specified in agent control body.

https://github.com/cfengine/core/blob/3.6rc-build2/libpromises/cf3globals.c#L111

Redmine: https://dev.cfengine.com/issues/6104
