### PR TITLE
Whitespace fixes

### DIFF
--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1157,7 +1157,7 @@ timeout, in seconds.
 
 **Allowed input range:** `1,3600`
 
-** Default Value:** `default_timeout` [cf-agent#default_timeout]
+**Default Value:** `default_timeout`[cf-agent#default_timeout]
 
 **Example:**
 


### PR DESCRIPTION
Additional whitespace broke formatting: https://docs.cfengine.com/docs/master/reference-promise-types-files.html#timeout
