### PR TITLE
Add link to normal ordering from promise type documentation

### DIFF
--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -7,8 +7,8 @@ tags: [reference, bundles, common, promises]
 ---
 
 Within a bundle, the promise types are executed in a round-robin fashion in the
-following 'normal ordering'. Which promise types are available depends on the
-[bundle][bundles] type:
+following [normal ordering][Normal Ordering]. Which promise types are available
+depends on the [bundle][bundles] type:
 
 | Promise Type   | common | agent | server | monitor |
 |----------------|:------:|:-----:|:------:|:--------|


### PR DESCRIPTION
The promise type documentation references normal ordering and should link to a
more full description of it.
