### PR TITLE
fix example of rotate with edit_backup

### DIFF
--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1709,8 +1709,9 @@ deleted (that is, it "falls off the end" of the rotation).
 **Example:**
 
 ```cf3
-     body rename example
+     body edit_defaults example
      {
+     edit_backup => "rotate";
      rotate => "4";
      }
 ```


### PR DESCRIPTION
rotate is inside 'edit_defaults' body, not inside 'rename'
