### PR TITLE
Change: Update pacakge URLs

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-community.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-community.markdown
@@ -49,25 +49,25 @@ This stores the cfengine-community_3.6.1-1_* file onto your machine.
 **Redhat/CentOS/SUSE 64-bit:**
 
 ```
-$ wget https://s3.amazonaws.com/cfengine.package-repos/community_binaries/cfengine-community-3.6.1-1.x86_64.rpm
+$ wget http://cfengine.package-repos.s3.amazonaws.com/community_binaries/cfengine-community-3.6.1-1.x86_64.rpm
 ```
 
 **Redhat/CentOS/SUSE 32-bit:**
 
 ```
-$ wget https://s3.amazonaws.com/cfengine.package-repos/community_binaries/cfengine-community-3.6.1-1.i386.rpm
+$ wget http://cfengine.package-repos.s3.amazonaws.com/community_binaries/cfengine-community-3.6.1-1.i386.rpm
 ```
 
 **Ubuntu/Debian 64-bit:**
 
 ```
-$ wget https://s3.amazonaws.com/cfengine.package-repos/community_binaries/cfengine-community_3.6.1-1_amd64.deb
+$ wget http://cfengine.package-repos.s3.amazonaws.com/community_binaries/cfengine-community_3.6.1-1_amd64.deb
 ```
 
 **Ubuntu/Debian 32-bit:**
 
 ```
-$ wget https://s3.amazonaws.com/cfengine.package-repos/community_binaries/cfengine-community_3.6.1-1_i386.deb
+$ wget http://cfengine.package-repos.s3.amazonaws.com/community_binaries/cfengine-community_3.6.1-1_i386.deb
 ```
 
 

--- a/guide/installation-and-configuration/general-installation/installation-enterprise-free-aws-rhel.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise-free-aws-rhel.markdown
@@ -129,7 +129,7 @@ Run the following script on your designated Policy Server (hub), the virtual mac
 configured firewall from earlier steps:
 
 ```console
-$ wget http://s3.amazonaws.com/cfengine.package-repos/quickinstall/quick-install-cfengine-enterprise.sh && sudo bash ./quick-install-cfengine-enterprise.sh hub
+$ wget http://cfengine.package-repos.s3.amazonaws.com/quickinstall/quick-install-cfengine-enterprise.sh && sudo bash ./quick-install-cfengine-enterprise.sh hub
 ```
 
 This script installs the latest CFEngine Enterprise Policy Server on your server machine.
@@ -158,7 +158,7 @@ Upon successful completion, a confirmation message appears: "Bootstrap to '172.3
 * Install CFEngine client version using the following:
 
 ```console
-$ wget http://s3.amazonaws.com/cfengine.package-repos/quickinstall/quick-install-cfengine-enterprise.sh && sudo bash ./quick-install-cfengine-enterprise.sh agent
+$ wget http://cfengine.package-repos.s3.amazonaws.com/quickinstall/quick-install-cfengine-enterprise.sh && sudo bash ./quick-install-cfengine-enterprise.sh agent
 ```
 
 Note: The installation will work on 64-bit and 32-bit client machines (the host requires a 64-bit machine).

--- a/guide/installation-and-configuration/general-installation/installation-enterprise-free.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise-free.markdown
@@ -43,7 +43,7 @@ Please Note: Internet access is required from the host if you wish to use the qu
 Run the following script on your designated Policy Server (hub) 64-bit machine (32-bit is not supported on the Policy Server):
 
 ```console
-$ wget http://s3.amazonaws.com/cfengine.package-repos/quickinstall/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh hub
+$ wget http://cfengine.package-repos.s3.amazonaws.com/quickinstall/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh hub
 ```
 
 This script installs the latest CFEngine Enterprise Policy Server on your machine.
@@ -77,7 +77,7 @@ install Enterprise on 25 Hosts. Note that the Hosts must be
 on the same network as the Policy Server that you just installed in Step 2.
 
 ```console
-$ wget http://s3.amazonaws.com/cfengine.package-repos/quickinstall/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh agent
+$ wget http://cfengine.package-repos.s3.amazonaws.com/quickinstall/quick-install-cfengine-enterprise.sh  && sudo bash ./quick-install-cfengine-enterprise.sh agent
 ```
 
 Note that this installation works on 64- and 32-bit machines.

--- a/guide/installation-and-configuration/upgrading-to-36.markdown
+++ b/guide/installation-and-configuration/upgrading-to-36.markdown
@@ -22,7 +22,7 @@ Our recommendation is to upgrade the Policy Server first. The rationale is that 
 
     CFEngine 3.6 uses LMDB for local databases, whereas older versions of CFEngine typically use TokyoCabinet or QDBM. The classic networking protocol uses the `lastseen` database to verify that the mapping between a peer's IP address and the corresponding hostkey is not changed. Since the 3.6 installation will not have any mappings in the lastseen database, hosts won't trust the IP address of the policy server without that setting.
 3. Optional, Enterprise only: Export the data from your existing Enterprise MongoDB.
-  * Download the [`cfmigrate`](http://s3.amazonaws.com/cfengine.package-repos/tools/cfmigrate) binary.
+  * Download the [`cfmigrate`](http://cfengine.package-repos.s3.amazonaws.com/tools/cfmigrate) binary.
   * This binary will export user/role settings as well as long-living file-changes data from MongoDB.
   * No other data will be exported, as it would either way expire after
     one week. If you need continued access to 3.5 compliance data,
@@ -83,7 +83,7 @@ Our recommendation is to upgrade the Policy Server first. The rationale is that 
     ```console
     cf-agent -f update.cf -IK
     ```
-7. Optional: Import data previously exported from MongoDB using the [`cfmigrate`](http://s3.amazonaws.com/cfengine.package-repos/tools/cfmigrate) binary.
+7. Optional: Import data previously exported from MongoDB using the [`cfmigrate`](http://cfengine.package-repos.s3.amazonaws.com/tools/cfmigrate) binary.
   * Verify that users can log into Mission Portal.
 8. Take the Policy Server online.
   * Verify with `cf-key -s` that connections from all clients have been established within 5-10 minutes.


### PR DESCRIPTION
Update to a more readable url for packages and use http instead of https.
There is no need to transfer these things over a secure connection.
