### PR TITLE
Change: Fix link to old bucket

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-community.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-community.markdown
@@ -29,7 +29,7 @@ Please Note: Internet access is required from the host if you wish to use the qu
 Use the following script to install CFEngine on your 32- or 64-bit machine.
 
 ```
-$ wget -O- https://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-community.sh | sudo bash
+$ wget -O- http://cfengine.package-repos.s3.amazonaws.com/quickinstall/quick-install-cfengine-community.sh | sudo bash
 ```
 
 1. Run this script on your designated Policy Server machine **and** on your designated Host machine(s).


### PR DESCRIPTION
We don't need to preserve this outdated instruction just because a video shows
that URL. It is better to have up to date text, and not have the quickinstall
scripts duplicated in multiple places. Though we will continue to publish the
quickinstall script at the old location as well for some time.
