### PR TITLE
Minor typo in methods.markdown

### DIFF
--- a/reference/promise-types/methods.markdown
+++ b/reference/promise-types/methods.markdown
@@ -19,7 +19,7 @@ the time being.
 
       "any"
 
-         usebundle = method_id("parameter",...);
+         usebundle => method_id("parameter",...);
 
 ```
 


### PR DESCRIPTION
Forward porting from 3.6.x branch.
