### PR TITLE
Refactor steps 1.1/1.2 in 3.6 upgrade procedure

### DIFF
--- a/guide/installation-and-configuration/upgrading-to-36.markdown
+++ b/guide/installation-and-configuration/upgrading-to-36.markdown
@@ -12,8 +12,8 @@ Our recommendation is to upgrade the Policy Server first. The rationale is that 
 ## Prepare masterfiles and the Policy Server for upgrade.
 
 1. Merge your masterfiles with the CFEngine 3.6 policy framework on an infrastructure separate from your existing CFEngine installation.
-  * The 3.6 masterfiles can be found in a clean installation of CFEngine (hub package on Enterprise), under /var/cfengine/masterfiles.
-  * Apply your existing masterfiles on top of the 3.6 masterfiles and save it to a well-known location, e.g. `/root/3.6/masterfiles`.
+  * Identify existing modifications to the masterfiles directory.  If patches from version control are unavailable or require verification, a copy of /var/cfengine/masterfiles from a clean installation of your previous version can help identify changes which will need to be applied to a new 3.6 install.
+  * The 3.6 masterfiles can be found in a clean installation of CFEngine (hub package on Enterprise), under /var/cfengine/masterfiles.  Apply any customizations against a copy of the 3.6 masterfiles in a well-known location, e.g. `/root/3.6/masterfiles`.
   * Use `cf-promises` to verify that the policy runs with 3.6, by running `cf-promises /root/3.6/masterfiles/promises.cf` and `cf-promises /root/3.6/masterfiles/update.cf`.
   * Use `cf-promises` to verify that the policy runs with you previous version of CFEngine (e.g. 3.5), by running the same commands as above on a node with that CFEngine version.
   * The merged masterfiles should now be based on the 3.6 framework, include your policies and work on both the version you are upgrading from and with 3.6.


### PR DESCRIPTION
Early steps haven't been very constructive in my attempt to begin an upgrade assessment. Current wording implies that masterfiles can be dropped in as a fileset; however, at least with 3.5->3.6, it seems some changes are more likely to have to be applied line by line.  I tried make the change minimal, though the result might be awkward.

I haven't tried to include diff examples since they don't really fit here, but in attempting to prep an upgrade, I've found it helpful to diff existing masterfiles against 3.5, then planning patches by diffing between 3.5 and 3.6.  In particular, the following one-liner has been useful:

for f in *; do echo "$f $(2>/dev/null diff $f ../masterfiles-3.5.clean/$f >/dev/null && echo -n IS || echo -n is NOT) from 3.5"; done

For each "is NOT" result, I check for conflicts, identify the origin (usually easy), copy entire files/directories if they are not modifications of provided files, and study diffs if they are.

For each "IS" result, I omit the file/directory altogether, with the intention of testing against its 3.6 counterpart.

Depending on results of testing and comments on this PR, I may continue to offer any discrepancies between what is here and what I needed to do to upgrade.
