### PR TITLE
Include note about how randomint is potentially unsafe

### DIFF
--- a/reference/functions/randomint.markdown
+++ b/reference/functions/randomint.markdown
@@ -18,6 +18,8 @@ will return 100 possible values, not 101.
 The function will be re-evaluated on each pass if it is not restricted with a
 context class expression as shown in the example.
 
+**NOTE:** The randomness produced by randomint is not safe for cryptographic usage.
+
 [%CFEngine_function_attributes(lower, upper)%]
 
 **Example:**


### PR DESCRIPTION
This function is seeded by `rand(3)` and isn't safe for certain types of use. I've included a note about that.
