### PR TITLE
Change: Improve description of udp_syslog

### DIFF
--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -259,9 +259,9 @@ log message.
 
 * `udp_syslog`
 
-Attempt to connect to the `syslog_server` defined in body common control and
-log the message there, assuming the server is configured to receive the
-request.
+Log messages to [syslog_host][Components and Common Control#syslog_host] as
+defined in body common control over UDP. Please note
+[UDP is unreliable](http://en.wikipedia.org/wiki/Syslog#Limitations).
 
 **Example:**
 


### PR DESCRIPTION
`syslog_server` is not a valid attribute setting in body common control, it
should have read `syslog_host`.

The wording sounded funny so I changed it up a bit.

Ref: https://dev.cfengine.com/issues/6904#change-35851
