### PR TITLE
Fix typo in documentation

### DIFF
--- a/reference/special-variables/sys.markdown
+++ b/reference/special-variables/sys.markdown
@@ -248,7 +248,7 @@ This contains the MAC address of the named interface. For example:
 
 ```cf3
     reports:
-        "Tell me $(harware_mac[eth0])";
+        "Tell me $(hardware_mac[eth0])";
 ```
 
 **History:** Was introduced in 3.3.0, Enterprise 2.2.0 (2011)


### PR DESCRIPTION
harware -> hardware

Signed-off-by: Stefan Weil <sw@weilnetz.de>