### PR TITLE
No class based decisions inside file control bodies.

### DIFF
--- a/reference/components/file_control_promises.markdown
+++ b/reference/components/file_control_promises.markdown
@@ -24,6 +24,7 @@ tags: [body, bodies, components, common, namespace, promises, bundlesequence]
 This directive can be given multiple times within any file,
 outside of body and bundle definitions.
 
+Class based decisions are not allowed inside `file control` bodies.
 
 ### inputs
 


### PR DESCRIPTION
Just making clear that class based decisions are not allowed inside file control bodies.