### PR TITLE
Fix: Links to sections

### DIFF
--- a/guide/faq.markdown
+++ b/guide/faq.markdown
@@ -242,7 +242,7 @@ https://github.com/cfengine/masterfiles/blob/master/controls/cf_execd.cf. It
 defaults to `root@$(def.domain)` which is configured in `bundle common def`
 https://github.com/cfengine/masterfiles/blob/master/def.cf.
 
-For details see [domain][The Policy Framework#domain (variable)].
+For details see [domain][The Policy Framework#domain variable].
 
 #### How do I disable agent email output ####
 
@@ -251,7 +251,7 @@ You can simply remove or comment out the settings.
 In 3.6.x there is a convenience class `cfengine_internal_agent_email` avaiable
 in `bundle common def` to switch on/off agent email.
 
-For details see [cfengine_internal_agent_email][The Policy Framework#cfengine_internal_agent_email (class)].
+For details see [cfengine_internal_agent_email][The Policy Framework#cfengine_internal_agent_email class].
 
 ### Mustache Templating ###
 

--- a/guide/latest-release/policy-framework-updates.markdown
+++ b/guide/latest-release/policy-framework-updates.markdown
@@ -3,10 +3,10 @@ layout: default
 title: Policy Framework Updates
 published: true
 sorting: 40
-tags: [releases, latest release, "3.6", platforms, versions, what's new]
+tags: [releases, latest release, "3.7", platforms, versions, what's new]
 ---
 
-## CFEngine Policy Framework Updates for 3.6 ##
+## CFEngine Policy Framework Updates for 3.7 ##
 
 If you follow the CFEngine masterfiles policy framework (the masterfiles you
 get out of the box) we encourage you to upgrade the policy framework each time
@@ -14,6 +14,9 @@ you upgrade CFEngine. We recommend making as few changes as possible to the
 shipped masterfiles to make these upgrades as painless as possible. Generally
 the best way to accomplish that is to take your custom policy and integrate it
 on top of the new masterfiles.
+
+3.7 introduces some minor re-orginization of policy, and some new
+features aimed at making policy framework upgrades easier.
 
 3.6 introduces significant changes to the masterfiles policy framework.
 Masterfiles was moved out from core into its own repository and was merged
@@ -25,7 +28,7 @@ easily accessible from either product.
 
 Please consult [The Policy Framework] for a map to the policy framework.
 
-* [What is new in the 3.6 masterfiles policy framework][Policy Framework Updates#What is new in the 3.6 masterfiles policy framework]
+* [What is new in the 3.7 masterfiles policy framework][Policy Framework Updates#What is new in the 3.7 masterfiles policy framework]
 	* [Directories][Policy Framework Updates#Directories]
 		* [templates][Policy Framework Updates#templates]
 		* [cfe_internal][Policy Framework Updates#cfe_internal]
@@ -44,7 +47,7 @@ Please consult [The Policy Framework] for a map to the policy framework.
 		* [Options controlling which variables to report have moved and changed][Policy Framework Updates#Options controlling which variables to report have moved and changed]
 		* [Host licenses paid deprecated][Policy Framework Updates#Host licenses paid deprecated]
 
-## What is new in the 3.6 masterfiles policy framework ##
+## What is new in the 3.7 masterfiles policy framework ##
 		
 ## Directories ##
 
@@ -81,15 +84,15 @@ for some time, including various common directories, and simple access control
 list definition to control which remote hosts could connect. Comparing def.cf
 from 3.5 and 3.6 will reveal many additions
 
-* [services_autorun][The Policy Framework#services_autorun (class)] provides automatic loading and activation of policy.
-* [cfengine_internal_rotate_logs][The Policy Framework#cfengine_internal_rotate_logs (class)] Enables log rotation for CFEngines log files.
-* [cfengine_internal_encrypt_transfers][The Policy Framework#cfengine_internal_encrypt_transfers (class)] Enables encryption for policy and binary updates done during the update policy.
+* [services_autorun][The Policy Framework#services_autorun class] provides automatic loading and activation of policy.
+* [cfengine_internal_rotate_logs][The Policy Framework#cfengine_internal_rotate_logs class] Enables log rotation for CFEngines log files.
+* [cfengine_internal_encrypt_transfers][The Policy Framework#cfengine_internal_encrypt_transfers class] Enables encryption for policy and binary updates done during the update policy.
 
   Note: This setting is mirrored from
   update.cf for CFEngine enterprise reporting. This setting is superfluous
   when `protocol_version` is set to 2 or higher which enables TLS encryption for
   communication.
-* [cfengine_internal_purge_policies][The Policy Framework#cfengine_internal_purge_policies (class)]: Enables purging of policies that no longer exist in masterfiles.
+* [cfengine_internal_purge_policies][The Policy Framework#cfengine_internal_purge_policies class]: Enables purging of policies that no longer exist in masterfiles.
 
   Note: This setting is mirrored from update.cf for [CFEngine Enterprise][] reporting.
   

--- a/guide/writing-and-serving-policy/policy-framework.markdown
+++ b/guide/writing-and-serving-policy/policy-framework.markdown
@@ -386,7 +386,7 @@ Here is an example `augments_file`:
 [%CFEngine_include_markdown(masterfiles/example_def.json)%]
 </pre>
 
-###### domain (variable)
+###### domain variable
 
 Set your `domain` to the right value. By default it's used for mail
 and to deduce your file access ACLs.
@@ -417,7 +417,7 @@ time. This is only useful to be open during for bootstrapping these
 hosts. As the comments say, empty it after your hosts have been
 bootstrapped to avoid unpleasant surprises.
 
-###### services_autorun (class)
+###### services_autorun class
 
 Off by default.
 
@@ -427,7 +427,7 @@ example of such a bundle in `services/autorun/hello.cf`:
 
 [%CFEngine_include_snippet(masterfiles/services/autorun/hello.cf, .*)%]
 
-###### cfengine_internal_rotate_logs (class)
+###### cfengine_internal_rotate_logs class
 
 On by default.
 
@@ -442,7 +442,7 @@ On by default.
 
 This class enables agent email output from `cf-execd`.
 
-###### cfengine_internal_encrypt_transfers (class)
+###### cfengine_internal_encrypt_transfers class
 
 Duplicate of the one in `update.cf`. They should be set in unison or
 you may get unexpected behavior.


### PR DESCRIPTION
Sections with () in the title are problematic to link to, try without
().