### PR TITLE
Change: Move information about cf-promsies --show classes to faq

### DIFF
--- a/guide/faq.markdown
+++ b/guide/faq.markdown
@@ -233,6 +233,12 @@ cf-agent --define my_class,my_other_class
 
 Multiple `-D` flags are not supported, you have to put all the classes in one comma-separated list.
 
+### Showing Classes and variables with cf-promsies
+
+`cf-promises --show-classes` and `cf-promises --show-vars` will only show
+classes and variables found on a first pass through the policy, since
+`cf-promises` does not evaluate agent promises.
+
 ### Agent Email Reports ###
 
 #### How do I set the email where agent reports are sent ####

--- a/guide/latest-release/known-issues.markdown
+++ b/guide/latest-release/known-issues.markdown
@@ -13,13 +13,6 @@ bug reports.
 The items below highlight issues that require additional awareness when starting
 with CFEngine or when upgrading from a previous version.
 
-
-### Showing Classes and variables with cf-promsies
-
-`cf-promises --show-classes` and `cf-promises --show-vars` will only show
-classes and variables found on a first pass through the policy, since
-`cf-promises` does not evaluate agent promises.
-
 ### Protocol incompatibility between
 
 The CFEngine protocol versions 1 and 2 are incompatible (the latter is based


### PR DESCRIPTION
This is more appropriate for the FAQ as it works as intended within the
design limitations.