### PR TITLE
Update documentation for policy framework changes in 3.7

### DIFF
--- a/guide/faq.markdown
+++ b/guide/faq.markdown
@@ -233,6 +233,12 @@ cf-agent --define my_class,my_other_class
 
 Multiple `-D` flags are not supported, you have to put all the classes in one comma-separated list.
 
+### Showing Classes and variables with cf-promsies
+
+`cf-promises --show-classes` and `cf-promises --show-vars` will only show
+classes and variables found on a first pass through the policy, since
+`cf-promises` does not evaluate agent promises.
+
 ### Agent Email Reports ###
 
 #### How do I set the email where agent reports are sent ####

--- a/guide/latest-release.markdown
+++ b/guide/latest-release.markdown
@@ -7,13 +7,12 @@ tags: [overviews, releases, latest release, "3.6", platforms, versions]
 ---
 
 * [New in CFEngine][New in CFEngine]
-  Learn about the newest features in CFEngine 3.6
+  Learn about the newest features in CFEngine 3.7
 
 * [Supported Platforms and Versions][Supported Platforms and Versions]
   These are the supported platforms for the current release.
 
 * [Policy Framework Updates][Policy Framework Updates]
-  3.6 introduces significant changes to the masterfiles policy framework. Read more about these changes.
 
 * [Known Issues][Known Issues]
   View any issues of which we are currently aware and investigating. View possible workarounds.

--- a/guide/latest-release/known-issues.markdown
+++ b/guide/latest-release/known-issues.markdown
@@ -13,13 +13,6 @@ bug reports.
 The items below highlight issues that require additional awareness when starting
 with CFEngine or when upgrading from a previous version.
 
-
-### Showing Classes and variables with cf-promsies
-
-`cf-promises --show-classes` and `cf-promises --show-vars` will only show
-classes and variables found on a first pass through the policy, since
-`cf-promises` does not evaluate agent promises.
-
 ### Protocol incompatibility between
 
 The CFEngine protocol versions 1 and 2 are incompatible (the latter is based

--- a/guide/latest-release/known-issues.markdown
+++ b/guide/latest-release/known-issues.markdown
@@ -14,10 +14,6 @@ The items below highlight issues that require additional awareness when starting
 with CFEngine or when upgrading from a previous version.
 
 
-### Constant variables do not work, variables are always overrideable
-
-https://dev.cfengine.com/issues/1492
-
 ### Showing Classes and variables with cf-promsies
 
 `cf-promises --show-classes` and `cf-promises --show-vars` will only show
@@ -28,14 +24,18 @@ classes and variables found on a first pass through the policy, since
 
 The CFEngine protocol versions 1 and 2 are incompatible (the latter is based
 on TLS). CFEngine 3.6 supports both protocol versions, but earlier versions
-only support protocol version 1. Protocol version 1 is still the default in
-3.6 but the default will change to 2 in future versions.
+only support protocol version 1. Protocol version 2 the default in
+3.7.
 
+### HP-UX specific
 
-### HP-UX specific ###
-
-* [Package promises][packages] do not have out-of-the-box support for the HP-UX specific package manager. The workaround is to call the package manager directly using [commands promises][commands].
-* Some important system information is missing from the HP-UX inventory report, as well as from CFEngine hard classes and system variables. The workaround is to use system tools to obtain the required information and set classes based on this.
+* [Package promises][packages] do not have out-of-the-box support for the HP-UX
+  specific package manager. The workaround is to call the package manager
+  directly using [commands promises][commands].
+* Some important system information is missing from the HP-UX inventory report,
+  as well as from CFEngine hard classes and system variables. The workaround is
+  to use system tools to obtain the required information and set classes based
+  on this.
         * Disk free
         * Memory size
         * Several OS and architecture specific attributes
@@ -45,34 +45,11 @@ only support protocol version 1. Protocol version 1 is still the default in
                 * CPU model
                 * BIOS version
                 * BIOS vendor
-* [Process promises][processes] depend on the `ps` native tool, which by default truncates lines at 128 columns on HP-UX. It is recommended to edit the file `/etc/default/ps` and increase the `DEFAULT_CMD_LINE_WIDTH` setting to 1024 to guarantee that process promises will work smoothly on the platform.
-
-
-### Enterprise Mission Portal is slow and/or /var/cfengine/state/pg consumes a lot of space/iops or CPU utilization is high ###
-
-With ceratin policies, the BenchmarksLog table in the PostgreSQL database is known to grow large with CFEngine versions from 3.6.0 to and including 3.6.5. This issue is resolved in CFEngine 3.6.6 and later versions.
-To test for the problem, run the following commands on the hub:
-
-```console
-# /var/cfengine/bin/psql cfdb
-SELECT nspname || '.' || relname AS "relation", pg_size_pretty(pg_total_relation_size(C.oid)) AS "total_size" FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND C.relkind <> 'i' ORDER BY pg_total_relation_size(C.oid) DESC LIMIT 20;
-```
-
-If the table public.__benchmarkslog is larger than 2-3 GB, you are likely affected by this isse. The table is not used unless you have created custom queries against it yourself. To resolve the issue, please run these commands after a fresh install of any hub prior to version 3.6.6:
-
-```console
-# /var/cfengine/bin/psql cfdb
-cfdb=# truncate table __benchmarkslog;
-cfdb=# create index benchmarks_subselect ON __benchmarkslog (hostkey, eventname, checktimestamp) WITH (FILLFACTOR = 70);
-```
-
-If your hub is still slow or BenchmarksLog was not the problem, please contact support.
-
-
-### Unsupported direct upgrade from CFEngine Enterprise 3.6.0 / 3.6.1 to 3.6.5 ###
-Due to an issue in Enterprise 3.6.5 direct upgrade from 3.6.0 and 3.6.1 may resolve with database schema curruption.
-Upgrade from 3.6.0 / 3.6.1 to 3.6.5 can be done by upgrading first to 3.6.2 / 3.6.3 / 3.6.4 and then to 3.6.5.
-
+* [Process promises][processes] depend on the `ps` native tool, which by
+  default truncates lines at 128 columns on HP-UX. It is recommended to edit
+  the file `/etc/default/ps` and increase the `DEFAULT_CMD_LINE_WIDTH` setting
+  to 1024 to guarantee that process promises will work smoothly on the
+  platform.
 
 ### Enterprise emails sent for alert noticies come from 'admin@organization.com'.
 There is currently no setting in Mission Portal to configure the sender email
@@ -87,14 +64,15 @@ To change the setting you must edit the from email address in
 $config['appemail'] = 'admin@organisation.com';
 ```
 
-### Enterprise monitoring graphs ###
+### Enterprise monitoring graphs
 
-Monitoring graphs are disabled by default in CFEngine Enterprise 3.6 and later versions.
-To enable them, change monitoring_include in masterfiles/controls/VERSION/reports.cf to e.g. ".*".
-Note that this has a significant impact on the resource consumption of your hub.
+Monitoring graphs are disabled by default in CFEngine Enterprise 3.6 and later
+versions.  To enable them, change monitoring_include in
+masterfiles/controls/VERSION/reports.cf to e.g. ".*".  Note that this has a
+significant impact on the resource consumption of your hub.
 
-Monitoring graphs are not supported on all platforms, currently Aix and Windows do not have this data.
-
+Monitoring graphs are not supported on all platforms, currently Aix and Windows
+do not have this data.
 
 ### Enterprise reports not collected from 3.5
 CFEngine Enterprise 3.6 has a new diff-based report collection mechanism,
@@ -103,8 +81,7 @@ and so a 3.7 hub cannot collect reports from 3.5 or earlier agents.
 Currently the 3.5 agents will not show in Mission Portal at all, but
 you will see them by running `cf-key -s` on the hub.
 
+### Enterprise software inventory is not out-of-the-box
 
-### Enterprise software inventory is not out-of-the-box ###
-
-Software inventory is not out-of-the-box for reporing from the hub on Windows platforms.
-In order to add it, please contact support for a custom policy.
+Software inventory is not out-of-the-box for reporing from the hub on Windows
+platforms.  In order to add it, please contact support for a custom policy.

--- a/guide/latest-release/policy-framework-updates.markdown
+++ b/guide/latest-release/policy-framework-updates.markdown
@@ -18,271 +18,31 @@ on top of the new masterfiles.
 3.7 introduces some minor re-orginization of policy, and some new
 features aimed at making policy framework upgrades easier.
 
-3.6 introduces significant changes to the masterfiles policy framework.
-Masterfiles was moved out from core into its own repository and was merged
-with the policy framework from CFEngine Enterprise. Now both the core
-(CFEngine Community) and CFEngine Enterprise ship with a common masterfiles
-policy framework. For us it makes maintanence easier, and for the community
-and customers it ensures that improvements that come into the framework are
-easily accessible from either product.
-
 Please consult [The Policy Framework] for a map to the policy framework.
 
-* [What is new in the 3.7 masterfiles policy framework][Policy Framework Updates#What is new in the 3.7 masterfiles policy framework]
-	* [Directories][Policy Framework Updates#Directories]
-		* [templates][Policy Framework Updates#templates]
-		* [cfe_internal][Policy Framework Updates#cfe_internal]
-		* [inventory][Policy Framework Updates#inventory]
-		* [sketches][Policy Framework Updates#sketches]
-		* [update][Policy Framework Updates#update]
-	* [Features defined in def.cf][Policy Framework Updates#Features defined in def.cf]
-	* [The Standard Library][Policy Framework Updates#The Standard Library]
-	* [update.cf][Policy Framework Updates#update.cf]
-* [Upgrade Gotchas][Policy Framework Updates#Upgrade Gotchas]
-	* [General][Policy Framework Updates#General]
-		* [Array Keys are not iterated in the decalred order any more][Policy Framework Updates#Array Keys are not iterated in the decalred order any more]
-		* [Function Caching][Policy Framework Updates#Function Caching]
-		* [Files considered by update.cf have moved and changed][Policy Framework Updates#Files considered by update.cf have moved and changed]
-	* [Enterprise Users][Policy Framework Updates#Enterprise Users]
-		* [Options controlling which variables to report have moved and changed][Policy Framework Updates#Options controlling which variables to report have moved and changed]
-		* [Host licenses paid deprecated][Policy Framework Updates#Host licenses paid deprecated]
-
 ## What is new in the 3.7 masterfiles policy framework ##
-		
-## Directories ##
 
-### templates ###
+## CHANGELOG.md
 
-Many users create a top level templates directory for global
-template distribution. We made it easy by creating a `templates/` directory 
-that's always copied for you.
+In 3.7 we have introduced a changelog to the masterfiles repository to make it
+easier to see what has changed in the Masterfiles Policy Framework between
+versions.
 
-### cfe_internal ###
+[%CFEngine_include_markdown(masterfiles/CHANGELOG.md)%]
 
-The `cfe_internal/` directory contains policies that manage how CFEngine
-runs, much of this is in relation to the Enterprise version.
+## Makefile
 
-### inventory ###
+The masterfiles now installs in the traditional UNIX way
+using autotools. For example to install it under `/my/path/to/masterfiles`,
+you should unpack it and do the following:
 
-The `inventory/` directory contains policies that do discovery of various
-inventory attributes.
-
-### sketches ###
-
-The `sketches/` directory is where Design Center sketches and their
-associated runfile get deployed.
-
-### update ###
-
-The `update/` directory contains policies that have been split out from
-the previously monolithic `update.cf`.
-
-### Features defined in def.cf ###
-
-`def.cf` has continued various global settings
-for some time, including various common directories, and simple access control
-list definition to control which remote hosts could connect. Comparing def.cf
-from 3.5 and 3.6 will reveal many additions
-
-* [services_autorun][The Policy Framework#services_autorun (class)] provides automatic loading and activation of policy.
-* [cfengine_internal_rotate_logs][The Policy Framework#cfengine_internal_rotate_logs (class)] Enables log rotation for CFEngines log files.
-* [cfengine_internal_encrypt_transfers][The Policy Framework#cfengine_internal_encrypt_transfers (class)] Enables encryption for policy and binary updates done during the update policy.
-
-  Note: This setting is mirrored from
-  update.cf for CFEngine enterprise reporting. This setting is superfluous
-  when `protocol_version` is set to 2 or higher which enables TLS encryption for
-  communication.
-* [cfengine_internal_purge_policies][The Policy Framework#cfengine_internal_purge_policies (class)]: Enables purging of policies that no longer exist in masterfiles.
-
-  Note: This setting is mirrored from update.cf for [CFEngine Enterprise][] reporting.
-  
-* postgresql_maintenance: Enables database maintenance for [CFEngine Enterprise][] Policy hubs.
-
-`def.cf` also sees the addition of `bundle common inventory_control` which is
-responsible for controlling the new inventory bundles. Inventory bundles
-provide variables and classes that can be useful for both Enterprise reporting
-and directly from within policy. LSB (Linux Standards Base), Dmidecode, LLDP
-(Link Layer Discovery Protocol), software installed, mounted filesystems
-(mtab), configured filesystems (fstab), and proc are some of the inventory
-policies provided out of the box.
-
-See [The Policy Framework] to understand inventory modules and learn how you
-can use the inventory information from within other policy and from the CFEngine Enterprise Mission Portal.
-
-## The Standard Library ##
-
-The standard library `lib/3.6/*.cf` has seen many improvements. First and foremost is the addition of doxygen
-style inline documentation. This inline documentation markup is levereged by
-our documentation system to provide a rendered version of the standard library
-which is included in the reference manual.
-
-You only need to include `$(sys.libdir)/stdlib.cf` to get the whole
-standard library. `sys.libdir` resolves to the right path for your
-installation, including the version (3.6, 3.7, etc.)
-
-Of special note: the
-`standard_services` has been improved to make it more dynamic, and now has
-support for systemd, sysvinitd, sysvservice, and chkconfig. New convenianence
-bundles and bodies for common patterns have been added including:
-
-* `dir_sync()`
-* `file_copy()`
-* `file_empty()`
-* `file_hardlink()`
-* `file_link()`
-* `file_make()`
-* `file_mustache_jsonstring()`
-* `file_mustache()`
-* `file_tidy()`
-* `converge()`
-* `fstab_option_editor()`
-* `insert_ini_section()`
-* `prepend_if_no_line()`
-* `resolvconf_o()`
-* `set_line_based()`
-* `fstab_options()`
-* `bigger_than()`
-* `linkfrom()`
-* `package_absent()`
-* `package_latest()`
-* `package_present()`
-* `package_specific_absent()`
-* `package_specific_latest()`
-* `package_specific()`
-* `package_specific_present()`
-* `brew()`
-* `npm()`
-* `pip()`
-* `process_kill()`
-* `by_owner()`
-* `logrotate()`
-* `prunedir()`
-* `cmerge()`
-* `rm_rf_depth()`
-* `url_ping()`
-* `setuidgid_dir()`
-* `setuid_gid_umask()`
-* `system_owned()`
-
-## update.cf ##
-
-The `update.cf` policy got broken up from its monolithic form and
-now has additional update policies included inside the `update` directory.
-bundle common update_def was added to provide a common place to enable
-features related to policy updates (much like body common def found in
-`def.cf`).  Please see [The Policy Framework] for the full details.
-
-* *cfengine_internal_masterfiles_update*: This class enables automatic policy
-deployment on the policy server. This is designed for use with CFEngine
-Enterprise.
-* *cfengine_internal_encrypt_transfers* Enables encryption for policy and
-binary updates done during the update policy. Note: This setting is mirrored
-in def.cf for CFEngine enterprise reporting. This setting is superfluous when
-`protocol_version` is set to 2 or higher which enables TLS encryption for
-communication.
-* *cfengine_internal_purge_policies*: Enables purging of policies that no
-longer exist in masterfiles. Note: This setting is mirrored in promises.cf for
-CFEngine enterprise reporting.
-* ...and much more!
-
-Now that you have an overview of whats new, lets cover a few things you need
-to watch our for when upgrading.
-
-## Upgrade Gotchas ##
-
-### General ###
-
-#### Array Keys are not iterated in the decalred order any more ####
-
-The order of results returned by getindices function is not necessarily
-returned in the order defined.
-**Example:**
-
-```cf3
-bundle agent example
-{
-  vars:
-    "array[key1]" string => "value1";
-    "array[key2]" string => "value2";
-    "array[key3]" string => "value3";
-
-    "keys" slist => getindices(array);
-
- reports:
-    "$(keys)";
-}
+```console
+./configure --prefix=/my/path/to
+make install
 ```
 
-The above policy will produce the following output on 3.5:
+## def.json
 
-```
-R: key1
-R: key2
-R: key3
-```
-
-The same policy in 3.6 will produce:
-
-```
-R: key1
-R: key3
-R: key2
-```
-
-If the resulting list order is important please consider the `sort()` and
-`reverse()` functions.
-
-
-#### Function Caching ####
-
-3.6 introduces function
-caching(https://docs.cfengine.com/docs/master/reference-functions.html#function-caching)
-to help further improve performance and execution speed.
-
-This behavior can be disabled by setting the `cache_system_functions` common
-control attribute to "false". A function is cached when it is first evaluated
-and it's cached result is used until the end of the agent execution. If have
-previously depended on function re-evaluation in order to have proper results
-after an action has been taken consider guarding the function call to only be
-evaluated after a pre-conditional promise using conventional class guards,
-or the `ifvarclass` and `depends_on` attributes.
-
-#### Files considered by update.cf have moved and changed ####
-
-Previously `body file_select u_input_files` controlled which files were
-considered when performing a policy update. That list of extensions has moved
-to `update_def.input_name_patterns`. '*.conf', and '*.mustache' files have
-been added to the default list.
-
-For more information, see the [FAQ][FAQ#i-have-added-new-files-in-masterfiles-but-my-remote-clients-are-not-getting-updates]
-
-### Enterprise Users ###
-
-#### Options controlling which variables to report have moved and changed ####
-
-In 3.6 we begin using tags to identify which variables and classes to report
-on. `report_data_select` has moved from `controls/cf_serverd.cf` to
-`lib/$(sys.cf_version_major).$(sys.cf_version_minor)/reports.cf`. In 3.6 we
-report on variables and `namespace` scope classes that are tagged with
-"inventory" or "report" using the new `metatags_include` and
-`metatags_exclude` attributes.
-
-The following attributes have been deprecated in 3.6.  Please tag the
-variables and classes you would like to report on appropriately. If you have
-any questions please contact support.
-
-* `classes_include`
-* `classes_exclude`
-* `variables_include`
-* `variables_exclude`
-* `promise_notkept_log_include`
-* `promise_notkept_log_exclude`
-* `promise_repaired_log_include`
-* `promise_repaired_log_exclude`
-
-#### Host licenses paid deprecated ####
-
-This option was deprecated in CFEngine 3.5 and is no longer valid syntax.
-
-This information is embedded in your Enterprise license, simply ensure that
-`host_license_paid` is not defined in your `body common control`.
+Many featues previously enabled in `def.cf` can now be enabled via this
+external data file. The benefit is fewer modificaitons to the policy frameowkr
+that need to be worked out during policy framework upgrades.


### PR DESCRIPTION
Fix: Remove outdated references to 3.6

(cherry picked from commit 11932eab604064ec77b53c05e3ce6bce0fdbce76)

Change: Move information about cf-promsies --show classes to faq
This is more appropriate for the FAQ as it works as intended within the
design limitations.

(cherry picked from commit b9b01ad6849034a596330982feca7365f10839a9)
Change: Documentation updates for 3.7

Update known issues Update policy framework updates

(cherry picked from commit 3dd83a5e5f0b116ba4c8756c8418a469e8f84dcd)