### PR TITLE
Change: Improve namespace description

### DIFF
--- a/reference/components/file_control_promises.markdown
+++ b/reference/components/file_control_promises.markdown
@@ -66,4 +66,6 @@ to switch to in order to protect the current file from duplicate definitions.
 
 This directive can be given within any file, outside of body and bundle 
 definitions, to change the [namespace][namespaces] of subsequent bundles 
-and bodies.
+and bodies. A namespace applies until the next namespace declaration in a
+file, or until the end of a file. This is similar to how class expressions
+apply until the next class expression or end of bundle.


### PR DESCRIPTION
Explain how namespaces apply until the next namespace definition or
until the end of the file, similar to how class expression work.