### PR TITLE
Add: Crosslinking of encrypt related attributes

### DIFF
--- a/reference/components.markdown
+++ b/reference/components.markdown
@@ -477,11 +477,11 @@ body common control
 * 2 - TLS
 * latest - Alias to protocol 2
 
-**Note:** If `protocol_version` is specified in a [`body copy_from`][files#copy_from],
-then the value there will override this setting.
+**Note:** `protocol_version` can be specified at the individual promise level
+using the [`body copy_from protocol_version`][files#protocol_version]
+attribute.
 
-**See also:** [`protocol_version`][files#protocol_version] in
-[`body copy_from`][files#copy_from], `allowlegacyconnects`
+**See also:**  [`body copy_from protocol_version`][files#protocol_version], `allowlegacyconnects`, [`allowtlsversion`][cf-serverd#allowtlsversion], [`allowciphers`][cf-serverd#allowciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 **History:** Introduced in CFEngine 3.6.0
 
@@ -608,7 +608,7 @@ body common control
 }
 ```
 
-**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`allowciphers`][cf-serverd#allowciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowtlsversion`][cf-serverd#allowtlsversion]
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`allowciphers`][cf-serverd#allowciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowtlsversion`][cf-serverd#allowtlsversion], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 **History:** Introduced in CFEngine 3.7.0
 
@@ -626,7 +626,7 @@ body common control
 }
 ```
 
-**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`allowciphers`][cf-serverd#allowciphers], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`allowtlsversion`][cf-serverd#allowtlsversion]
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`allowciphers`][cf-serverd#allowciphers], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`allowtlsversion`][cf-serverd#allowtlsversion], [`encrypt`][files#encrypt], [`ifencrypted`][access#ifencrypted], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers]
 
 **History:** Introduced in CFEngine 3.7.0
 

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -145,7 +145,7 @@ body server control
 }
 ```
 
-**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowtlsversion`][cf-serverd#allowtlsversion]
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowtlsversion`][cf-serverd#allowtlsversion], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 **History:** Introduced in CFEngine 3.6.0
 
@@ -165,7 +165,10 @@ body server control
 }
 ```
 
-**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowciphers`][cf-serverd#allowciphers]
+**Note:** When used with `protocol_version` 2 or greater this attribute is a
+noop as the entire session is encrypted.
+
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowciphers`][cf-serverd#allowciphers], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 **History:** Introduced in CFEngine 3.7.0
 
@@ -539,6 +542,8 @@ to syslog. These files are deemed to be particularly sensitive.
     logencryptedtransfers => "true";
     }
 ```
+
+**See also:** [`ifencrypted`][access#ifencrypted], [`encrypt`][files#encrypt], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowciphers`][cf-serverd#allowciphers], [`allowtlsversion`][cf-serverd#allowtlsversion], [`protocol_version`][Components and Common Control#protocol_version]
 
 ### maxconnections
 

--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -406,6 +406,11 @@ access:
     ifencrypted => "true";
 ```
 
+**Note:** This attribute is a noop when used with
+[`protocol_version`][Components and Common Control#protocol_version] 2 or
+greater.
+
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`allowtlsversion`][cf-serverd#allowtlsversion], [`allowciphers`][cf-serverd#allowciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 ### report_data_select
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -863,6 +863,11 @@ for the client and server hosts.
      }
 ```
 
+**Note:** When used with `protocol_version` 2 or greater this attribute is a
+noop as the entire session is encrypted.
+
+**See also:** [`protocol_version`][Components and Common Control#protocol_version], [`ifencrypted`][access#ifencrypted], [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowciphers`][cf-serverd#allowciphers], [`allowtlsversion`][cf-serverd#allowtlsversion]
+
 #### check_root
 
 **Description:** The `check_root` menu option policy checks permissions on the 


### PR DESCRIPTION
- protocol 2 causes noop for following attributes:
  - ifencrypted
  - logencryptedtransfers
  - encrypt

- crosslink
  - ifencryped
  - logencruptedtransfers
  - encrypt
  - tls_ciphers
  - tls_min_version
  - allowciphers
  - allowtlsversion
  - protocol_version