### PR TITLE
Add: Note about logencryptedtransfers being noop with protocol_version 2

### DIFF
--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -145,6 +145,8 @@ body server control
 }
 ```
 
+**Note:** When used with [`protocol_version`][Components and Common Control#protocol_version] 2 or greater this is a noop as all transfers are encrypted.
+
 **See also:** [`protocol_version`][Components and Common Control#protocol_version], [`tls_ciphers`][Components and Common Control#tls_ciphers], [`tls_min_version`][Components and Common Control#tls_min_version], [`allowtlsversion`][cf-serverd#allowtlsversion], [`encrypt`][files#encrypt], [`logencryptedtransfers`][cf-serverd#logencryptedtransfers], [`ifencrypted`][access#ifencrypted]
 
 **History:** Introduced in CFEngine 3.6.0


### PR DESCRIPTION
(cherry picked from commit 11a9422034dbbe818af83e8da2a0d75381469988)