### PR TITLE
Add: Crossreference to bodies in the stdlib

### DIFF
--- a/reference/promise-types/edit_line/insert_lines.markdown
+++ b/reference/promise-types/edit_line/insert_lines.markdown
@@ -358,6 +358,14 @@ found in the secondary file, it is inserted into the file being edited.
 
 **Type:** `body location`
 
+**See Also:**
+[`location` bodies in the standard library][Files Bundles and Bodies#location-bodies]
+[`start` location body in the standard library][Files Bundles and Bodies#location-bodies]
+[`before(srt)` location body in the standard library][Files Bundles and Bodies#before]
+[`after(srt)` location body in the standard library][Files Bundles and Bodies#after]
+
+[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+
 #### before_after
 
 **Description:** Menu option, point cursor before of after matched line


### PR DESCRIPTION
(cherry picked from commit 23009dde35dda0b0287f4e14ebf466f24458c72d)

Conflicts:
	reference/promise-types/edit_line/insert_lines.markdown