### PR TITLE
Fix: Common body attributes

### DIFF
--- a/reference/common-body-attributes-include.markdown
+++ b/reference/common-body-attributes-include.markdown
@@ -6,8 +6,6 @@ body attributes can be found in the
 of the [Promise Types and Attributes] page. The common attributes are as
 follows:
 
-##### [inherit_from][Promise Types and Attributes#inherit_from]
-
 ##### [meta][Promise Types and Attributes#meta] 
 
 <hr>

--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -34,6 +34,29 @@ depends on the [bundle][bundles] type:
 See each promise type's reference documentation for detailed lists of available
 attributes.
 
+## Common Body Attributes
+
+The following attributes are available to all body types.
+
+### meta
+
+**Description:** A list of meta attributes.
+
+**Type:** `slist`
+
+**Allowed input range:** (arbitrary string list)
+
+**Example:**
+
+```cf3
+    body ANYTYPE mybody
+    {
+      meta => { "deprecated" };
+    }
+```
+
+**History:** Was introduced in 3.7.0.
+
 ## Common Attributes
 
 The following attributes are available to all promise types.


### PR DESCRIPTION
- inherit_from slipped in accidentally from 3.8
- The common body attribute section was missing