### PR TITLE
Backport typo fix for log_string

### DIFF
--- a/guide/reporting/command-line-reports.markdown
+++ b/guide/reporting/command-line-reports.markdown
@@ -283,7 +283,7 @@ commands:
 body action logme(x)
 {
 log_repaired => "stdout";
-logstring => " -> Started the $(x) (success)";
+log_string => " -> Started the $(x) (success)";
 }
 ```
 


### PR DESCRIPTION
(cherry picked from commit 57079f40bbebdc517f86c4103bd6fe8e58cbc939)