### PR TITLE
Remove markup that might be causing failure

### DIFF
--- a/cheatsheet.markdown
+++ b/cheatsheet.markdown
@@ -394,7 +394,6 @@ Sometimes it's nice to include an external file
 Referencing a version of CFEngine? Consider if that appearance should be updated with each new version. For example on the title page.
 
 Will it expand mustache?
-{% CFE_manuals_version %}
 {% site.CFE_manuals_version %}
 
 {% raw %}


### PR DESCRIPTION
Trying to solve:
18:45:24 Liquid Exception: Unknown tag 'CFE_manuals_version' in
cheatsheet.markdown