### PR TITLE
Remove tag potentially causing build errors

### DIFF
--- a/cheatsheet.markdown
+++ b/cheatsheet.markdown
@@ -393,8 +393,7 @@ Sometimes it's nice to include an external file
 
 Referencing a version of CFEngine? Consider if that appearance should be updated with each new version. For example on the title page.
 
-Will it expand mustache?
-{% site.CFE_manuals_version %}
+Will it expand liquid (mustache) variables?
 
 {% raw %}
 site.CFE_manuals_version double mustache {{ site.CFE_manuals_version }}


### PR DESCRIPTION
Trying to get rid of: 20:41:00 Liquid Exception: Unknown tag 'site' in
cheatsheet.markdown