### PR TITLE
Change: Liquify reference to hard coded branch

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -74,7 +74,7 @@ CFEngine is decentralized and highly scalable. It is powered by autonomous agent
  <span style="font-weight: normal;" class="nv">links[9]</span>
  <span style="font-weight: normal;" class="p">"</span>   <span style="font-weight: normal;" class="kt">string </span>
  <span style="font-weight: normal;" class="o">=&gt; </span>
- <span style="font-weight: normal;" class="s" style="font-weight: normal;">"<a style="font-weight:bolder; color: #156a90; text-decoration:underline;font-size: 1.1em;line-height: 1.8; padding-left: 0.5em;" href="guide-latest-release-whatsnew.html">What's New in 3.7</a>";</span> <br/>
+ <span style="font-weight: normal;" class="s" style="font-weight: normal;">"<a style="font-weight:bolder; color: #156a90; text-decoration:underline;font-size: 1.1em;line-height: 1.8; padding-left: 0.5em;" href="guide-latest-release-whatsnew.html">What's New in {{site.cfengine.branch}}</a>";</span> <br/>
  
 <span style="font-weight: normal;" class="p">}</span> <br/>    
 </div>


### PR DESCRIPTION
Turn it into a variable thats defined from _config.yml in the
documentation-generator. This way we can have fewer things to change
during releases.

(cherry picked from commit fbb769bb3702c6c70f6a7cd9c6d2836e5bd916be)

Conflicts:
	index.markdown