### PR TITLE
Cleanup bad example and fixing tags

### DIFF
--- a/examples/tutorials/nfs_and_containers.markdown
+++ b/examples/tutorials/nfs_and_containers.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: NFS and LXC
-published: true
+published: false
 sorting: 110
 tags: [examples, tutorials, nfs, lxc, containers]
 ---

--- a/reference/functions/string_mustache.markdown
+++ b/reference/functions/string_mustache.markdown
@@ -16,7 +16,7 @@ The usual Mustache facilities like conditional evaluation and loops are availabl
 **Example:**
 {%raw%}
 [%CFEngine_include_snippet(string_mustache.cf, #\+begin_src cfengine3, .*end_src)%]
-{%endraw}
+{%endraw%}
 
 Output:
 


### PR DESCRIPTION
The tutorial/example showed some really ugly policy, and it also did not include any instructions to use it so it was unpublished, probably it should just be removed all together.

Another page was missing a closing tag.