### PR TITLE
Fix: string_mustache doc rendering

### DIFF
--- a/reference/functions/string_mustache.markdown
+++ b/reference/functions/string_mustache.markdown
@@ -14,8 +14,9 @@ The usual Mustache facilities like conditional evaluation and loops are availabl
 [%CFEngine_function_attributes(template_string, optional_data_container)%]
 
 **Example:**
-
+{%raw%}
 [%CFEngine_include_snippet(string_mustache.cf, #\+begin_src cfengine3, .*end_src)%]
+{%endraw}
 
 Output:
 

--- a/reference/functions/string_mustache.markdown
+++ b/reference/functions/string_mustache.markdown
@@ -16,7 +16,7 @@ The usual Mustache facilities like conditional evaluation and loops are availabl
 **Example:**
 {%raw%}
 [%CFEngine_include_snippet(string_mustache.cf, #\+begin_src cfengine3, .*end_src)%]
-{%endraw}
+{%endraw%}
 
 Output:
 


### PR DESCRIPTION
We must encapsulate in raw or mustache examples will not be rendered properly due to being interpreted by jekyll (part of our doc build system)