### PR TITLE
Remove: Bad example

### DIFF
--- a/examples/tutorials/nfs_and_containers.markdown
+++ b/examples/tutorials/nfs_and_containers.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: NFS and LXC
-published: true
+published: false
 sorting: 110
 tags: [examples, tutorials, nfs, lxc, containers]
 ---


### PR DESCRIPTION
The policy used in this example is really bad, and the instructions to run it are also
missing so it's being unpublished.

(cherry picked from commit 437f1ea2ee29a80c64cd27e89c727dddfa3f64b7)