### PR TITLE
Fix: Attempt to fix ability to use attribute macro

### DIFF
--- a/reference/promise-types/reports.markdown
+++ b/reference/promise-types/reports.markdown
@@ -115,7 +115,10 @@ peers, report above
 
 **Type:** `body printfile`
 
+{% comment %}
+Commenting this inclusion of common body attributes out because it seems to mess with ability to use  [%CFEngine_promise_attribute(5)%] with body attributes (probably due to tree)
 [%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+{% endcomment %}
 
 #### file_to_print
 


### PR DESCRIPTION
The [%CFEngine_promise_attribute()%] macro depends on being in an expected
location within the tree. The build is failing when using it after incluion of
the common body attribute stub.