### PR TITLE
Make it clear that Python is required for new package modules.

### DIFF
--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -24,6 +24,9 @@ following package managers:
 * ``yum``: YUM package manager and accompanying rpm package manager.
 * ``apt_get``: Apt package manager and accompanying dpkg package manager.
 
+Both ``yum`` and ``apt_get`` package managers require Python to be installed on
+the host.
+
 
 ```cf3
   packages:


### PR DESCRIPTION
Redmine #7820.