### PR TITLE
Change: Clarify potential return strings from and, not, and or functions

### DIFF
--- a/reference/functions/and.markdown
+++ b/reference/functions/and.markdown
@@ -7,18 +7,25 @@ tags: [reference, data functions, functions, and]
 
 [%CFEngine_function_prototype(...)%]
 
-**Description:** Returns whether all arguments evaluate to true.
+**Description:** Returns `any` if all arguments evaluate to true and `!any` if
+any argument evaluates to false.
 
-**Arguments**: A list of classes and class expressions
+**Arguments**: A list of classes, class expressions, or functions that return
+classes.
 
 **Example:**
 
 ```cf3
     commands:
       "/usr/bin/generate_config $(config)"
-        ifvarclass => and(not(fileexists("/etc/config/$(config)")), "generating_configs");
+        ifvarclass => and( "generating_configs",
+                           not(fileexists("/etc/config/$(config)"))
+                         );
 ```
 
-**Notes:**  
+**Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
+promise attributes.
    
+**See Also:** `and`, `or`, `not`
+
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/reference/functions/not.markdown
+++ b/reference/functions/not.markdown
@@ -7,7 +7,8 @@ tags: [reference, data functions, functions, not]
 
 [%CFEngine_function_prototype(expression)%]
 
-**Description:** Calculate whether `expression` is false
+**Description:** Returns `any` if all arguments evaluate to false and `!any` if
+any argument evaluates to true.
 
 [%CFEngine_function_attributes(expression)%]
 
@@ -16,9 +17,12 @@ tags: [reference, data functions, functions, not]
 ```cf3
 commands:
   "/usr/bin/generate_config $(config)"
-    ifvarclass => not(fileexists("/etc/config/$(config)"));
+    ifvarclass => not( fileexists("/etc/config/$(config)") );
 ```
 
-**Notes:**  
-   
+**Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
+promise attributes.
+
+**See Also:** `and`, `or`, `not`
+
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/reference/functions/or.markdown
+++ b/reference/functions/or.markdown
@@ -7,16 +7,22 @@ tags: [reference, data functions, functions, or]
 
 [%CFEngine_function_prototype(...)%]
 
-**Description:** Calculate whether any argument evaluates to true
+**Description:** Returns `any` if any argument evaluates to true and `!any` if
+any argument evaluates to false.
 
 **Example:**
 
 ```cf3
     commands:
       "/usr/bin/generate_config $(config)"
-        ifvarclass => or(not(fileexists("/etc/config/$(config)")), "force_configs");
+        ifvarclass => or( "force_configs",
+                          not(fileexists("/etc/config/$(config)"))
+                        );
 ```
 
-**Notes:**  
+**Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
+promise attributes.
+
+**See Also:** `and`, `or`, `not`
 
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)


### PR DESCRIPTION
(cherry picked from commit f9eeb5e17172867576790674266129f4f38f0962)