### PR TITLE
Allow some functions to take inline JSON: mapdata, mergedata, and others

### DIFF
--- a/reference/functions/data_expand.markdown
+++ b/reference/functions/data_expand.markdown
@@ -12,6 +12,10 @@ tags: [reference, data functions, functions, json, container, expand]
 This function will take a data container and expand variable
 references **once** in all keys and values.
 
+**NOTE** that the `data_container` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 Any compound (arrays or maps) data structures will be expanded
 recursively, so for instance data in a map inside another map will be
 expanded.
@@ -33,4 +37,4 @@ Output:
    
 **History:** Was introduced in version 3.7.0 (2015)
 
-**See also:** `readcsv()`, `readjson()`, `readyaml()`, and `data` documentation.
+**See also:** `readcsv()`, `readjson()`, `readyaml()`, `mergedata()`, and `data` documentation.

--- a/reference/functions/length.markdown
+++ b/reference/functions/length.markdown
@@ -9,6 +9,12 @@ tags: [reference, data functions, functions, length]
 
 **Description:** Returns the length of `list`.
 
+`list` can be a data container or a regular list.
+
+**NOTE** that the `list` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 [%CFEngine_function_attributes(list)%]
 
 **Example:**
@@ -19,4 +25,4 @@ Output:
 
 [%CFEngine_include_snippet(length.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** [`nth()`][nth].
+**See also:** [`nth()`][nth], `mergedata()`.

--- a/reference/functions/mapdata.markdown
+++ b/reference/functions/mapdata.markdown
@@ -15,6 +15,10 @@ or parsed as JSON when `interpretation` is `json`.
 
 `array_or_container` can be a data container.
 
+**NOTE** that the `array_or_container` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 The `$(this.k)` and `$(this.v)` variables expand to the key and value
 of the current element, similar to the way `this` is available for
 `maplist`.

--- a/reference/functions/mean.markdown
+++ b/reference/functions/mean.markdown
@@ -11,6 +11,10 @@ tags: [reference, data functions, functions, mean]
 
 `list` can be a data container or a regular list.
 
+**NOTE** that the `list` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 [%CFEngine_function_attributes(list)%]
 
 **Example:**
@@ -25,4 +29,4 @@ Output:
    
 **History:** Was introduced in version 3.6.0 (2014)
 
-**See also:** `sort()`, `variance()`, `sum()`, `max()`, `min()`
+**See also:** `sort()`, `variance()`, `sum()`, `max()`, `min()`, `mergedata()`.

--- a/reference/functions/mergedata.markdown
+++ b/reference/functions/mergedata.markdown
@@ -31,17 +31,25 @@ a JSON array, then merged as above.
 If any CFEngine "classic" array (`array[key]`) is named, it's first
 converted to a JSON object, then merged as above.
 
+If a literal JSON string like `[ 1,2,3 ]` is provided, it will be
+parsed and used.
+
+If any of the above-mentioned ways to reference variables are used
+**inside** a literal JSON string they will be expanded (or the
+function call will fail). This is similar to the behavior of
+Javascript, for instance.
+
+For example, `mergedata('[ thing, { "mykey": otherthing[123] } ]')`
+will wrap the `thing` in a JSON array; then the contents of
+`otherthing[123]` will be wrapped in a JSON map which will also go in
+the array.
+
+**NOTE** that the inline JSON behavior is standard across many
+CFEngine functions and not specific to `mergedata()`.
+
 `mergedata()` is thus a convenient way, together with `getindices()` and
 `getvalues()`, to bridge the gap between data container and the
 traditional list and array data types in CFEngine.
-
-If any of the above-mentioned variables are named inside brackets like
-`[ thing ]` then the `thing` will be wrapped in a JSON array and
-**then** merged..
-
-If any of the above-mentioned variables are named inside braces with a
-key like `{ "newkey": thing }` then the `thing` will be wrapped
-in a JSON object under key `newkey` and **then** merged.
 
 [%CFEngine_function_attributes()%]
 
@@ -52,5 +60,7 @@ in a JSON object under key `newkey` and **then** merged.
 Output:
 
 [%CFEngine_include_snippet(mergedata.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**History:** Was introduced in CFEngine 3.6.0 (2014). The inline JSON behavior was added in 3.9.
 
 **See also:** `getindices()`, `getvalues()`, `readjson()`, `parsejson()`, `readyaml()`, `parseyaml()`, and `data` documentation.

--- a/reference/functions/parsejson.markdown
+++ b/reference/functions/parsejson.markdown
@@ -16,6 +16,10 @@ Please note that because JSON uses double quotes, it's usually most
 convenient to use single quotes for the string (CFEngine allows both
 types of quotes around a string).
 
+**NOTE** that the `json_data` can contain variable references. This is
+standard across many CFEngine functions and explained in the
+`mergedata()` documentation.
+
 **Example:**
 
 ```cf3

--- a/reference/functions/url_get.markdown
+++ b/reference/functions/url_get.markdown
@@ -11,6 +11,10 @@ tags: [reference, communication functions, functions, url, www, file, ftp, http,
   a data container. The data is returned in a
   data container.
 
+**NOTE** that the `options_container` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 Currently only `file`, `http`, and `ftp` URLs are supported.
 Internally, `libcurl` is used.
 

--- a/reference/functions/variance.markdown
+++ b/reference/functions/variance.markdown
@@ -11,6 +11,10 @@ tags: [reference, data functions, functions, variance]
 
 `list` can be a data container or a regular list.
 
+**NOTE** that the `list` can be specified as inline JSON
+instead of a separate variable. This is standard across many CFEngine
+functions and explained in the `mergedata()` documentation.
+
 [%CFEngine_function_attributes(list)%]
 
 Use the `eval()` function to easily get the standard deviation (square root of the variance).


### PR DESCRIPTION
As requested in https://github.com/cfengine/core/pull/2454

This is a snapshot of the current state, putting all the docs in `mergedata()`. But when https://dev.cfengine.com/issues/7871 is done, we'll add a new `Inline JSON` section to the vars documentation and move all this information there. We can't do it yet because not all functions have been converted.