### PR TITLE
Document the host properties used by select_class

### DIFF
--- a/reference/promise-types/classes.markdown
+++ b/reference/promise-types/classes.markdown
@@ -314,7 +314,8 @@ on [Negative Knowledge][classes and decisions].
 ### select_class
 
 **Description:** Select one of the named list of classes to define based on
-host identity
+host's fully qualified domain name, the primary IP address and the UID that
+cf-agent is running under.
 
 The class is chosen deterministically (not randomly) but it is not
 possible to say which host will end up in which class in advance. Only


### PR DESCRIPTION
Instead of saying 'host identity' explicitly list out the 3 properties that are use to create the hash select_class will use to pick a class.