### PR TITLE
Fixed typo in example cf file

### DIFF
--- a/examples/tutorials/nfs_and_containers.cf
+++ b/examples/tutorials/nfs_and_containers.cf
@@ -61,7 +61,7 @@ bundle agent install_wget
       package_method => yum;
 
   reports:
-    "Installing the wget package is done here using CGEngine's 'packages' promise type. The installation of wget may not be necessary in many cases, as it might already be installed.";
+    "Installing the wget package is done here using CFEngine's 'packages' promise type. The installation of wget may not be necessary in many cases, as it might already be installed.";
 
 }
 


### PR DESCRIPTION
I'm unsure if this PR is needed as I've never heard to CGEngine, but I'm also new to cfengine. I'm assuming this is  a typo as G is next to F and could be an easy mistake to make.