### PR TITLE
Add: Note about time horizon for hostswithclass()

### DIFF
--- a/reference/functions/hostswithclass.markdown
+++ b/reference/functions/hostswithclass.markdown
@@ -13,9 +13,11 @@ tags: [reference, communication functions, functions, hostswithclass]
 `field` of hosts on which `classs` is set.
 
 On CFEngine Enterprise, this function can be used to return a list of 
-hostnames or ip-addresses of hosts that have a given class set. Note that this 
-function only works locally on the hub, but allows the hub to construct custom 
-configuration files for (classes of) hosts.
+hostnames or ip-addresses of hosts that have a given class.
+
+**Note:** This function only works locally on the hub, but allows the hub to construct custom 
+configuration files for (classes of) hosts. Hosts are selected based on the
+classes set during the most recently collected agent run.
 
 [%CFEngine_function_attributes(class, field)%]
 


### PR DESCRIPTION
It's important to document the timescale for this function. In earlier
enterprise versions (2.x) this was based on any class that had been
defined within lastseenexpireafter.

(cherry picked from commit d7247b5f4cd81fa839c39b2b5dbc6d4cfccb73c1)