### PR TITLE
Change: Indicate multiline regex for peer functions

### DIFF
--- a/reference/functions/peerleader.markdown
+++ b/reference/functions/peerleader.markdown
@@ -27,6 +27,10 @@ expression `regex`, CFEngine partitions the host list into groups of
 up to `groupsize`. Each group's peer leader is the first host in the
 group.
 
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
 The current host (unqualified or fully qualified) should belong to
 this file if it is expected to interact with the others. The function
 fails otherwise.

--- a/reference/functions/peerleaders.markdown
+++ b/reference/functions/peerleaders.markdown
@@ -31,6 +31,10 @@ The current host name does not need to belong to this file.  If it's
 found (fully qualified or unqualified), the string `localhost` is used
 instead of the host name.
 
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
 [%CFEngine_function_attributes(filename, regex, groupsize)%]
 
 `groupsize` must be between 2 and 64 to avoid nonsensical promises.

--- a/reference/functions/peers.markdown
+++ b/reference/functions/peers.markdown
@@ -27,6 +27,10 @@ expression `regex`, CFEngine partitions the host list into groups of
 up to `groupsize`. Each group's peer leader is the first host in the
 group.
 
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
 The current host (unqualified or fully qualified) should belong to
 this file if it is expected to interact with the others. The function
 returns an empty list otherwise.


### PR DESCRIPTION
(cherry picked from commit b558fc5764901eaef13acf3c864f310c82470f0b)