### PR TITLE
Change: Indicate parse array function comment fields are multiline regex

### DIFF
--- a/reference/functions/parseintrealstringarray.markdown
+++ b/reference/functions/parseintrealstringarray.markdown
@@ -19,6 +19,10 @@ These functions mirror the exact behavior of their
 instead of a file. By making data readable from a variable, data driven
 policies can be kept inline.
 
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
 **Arguments**:
 
 * `array` : Array identifier to populate, in the range


### PR DESCRIPTION
(cherry picked from commit ed95883d28794d13b5f3aaaa498d1a006d13f852)