### PR TITLE
Change: Hub administration docs orginization

### DIFF
--- a/enterprise-cfengine-guide/hub_administration.markdown
+++ b/enterprise-cfengine-guide/hub_administration.markdown
@@ -5,30 +5,6 @@ published: true
 tags: [cfengine enterprise, hub administration]
 ---
 
-# Reset administrative credentials #
-
-The default `admin` user can be reset to defaults using the following SQL
-
-cfsettings-setadminpassword.sql:
-
-```sql
-UPDATE "users"
-	SET password='SHA=aa459b45ecf9816d472c2252af0b6c104f92a6faf2844547a03338e42e426f52',
-	    salt='eWAbKQmxNP',
-	    name='admin',
-	    email='admin@organisation.com',
-	    active='1',
-	    roles='{admin,cf_remoteagent}',
-            changetimestamp = now()
-	WHERE username='admin';
-INSERT INTO "users" ("username", "password", "salt", "name", "email", "external", "active", "roles", "changetimestamp")
-       SELECT 'admin', 'SHA=aa459b45ecf9816d472c2252af0b6c104f92a6faf2844547a03338e42e426f52', 'eWAbKQmxNP', 'admin',  'admin@organisation.com', false, '1',  '{admin,cf_remoteagent}', now()
-       WHERE NOT EXISTS (SELECT 1 FROM users WHERE username='admin');
-```
-
-To reset the CFEngine admin user run the following sql as root on your hub
-
-```console
-root@hub:~# psql cfsettings < cfsettings-setadminpassword.sql
-```
+Find out how to perform common hub administration tasks like resetting the
+admin credentials, or using custom SSL certificates.
 

--- a/enterprise-cfengine-guide/hub_administration.markdown
+++ b/enterprise-cfengine-guide/hub_administration.markdown
@@ -5,6 +5,7 @@ published: true
 tags: [cfengine enterprise, hub administration]
 ---
 
-Find out how to perform common hub administration tasks like resetting the
-admin credentials, or using custom SSL certificates.
+Find out how to perform common hub administration tasks like
+[resetting admin credentials][Custom SSL Certificate], or
+[using custom SSL certificates][Custom SSL Certificate].
 

--- a/enterprise-cfengine-guide/hub_administration/adjusting-schedules.markdown
+++ b/enterprise-cfengine-guide/hub_administration/adjusting-schedules.markdown
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Adjusting Schedules
+published: true
+tags: [cfengine enterprise, hub administration, scheduling, cf-execd, cf-agent, cf-hub]
+---
+
+## Set cf-execd agent execution schedule
+
+By default `cf-execd` is configured to run `cf-agent` every 5 minutes. This can
+be adjusted by tuning the [schedule][cf-execd#schedule] in `body executor
+control`. In the [Masterfiles Policy Framework][The Policy Framework] body
+executor control can be found in `controls/cf_execd.cf`
+
+## Set cf-hub hub_schedule
+
+`cf-hub` the CFEngine Enterprise report collection component has a
+[hub_schedule][cf-hub#hub_schedule] defined in `body hub control` which also
+defaults to a 5 minute schedule. It can be adjusted to control how frequently
+hosts should be collected from. In the
+[Masterfiles Policy Framework][The Policy Framework] `body hub control` can be
+found in `controls/cf_hub.cf`
+
+**Note:** Mission Portal has an "Unreachable host threshold" that defaults to 15
+minutes. When a host has not been collected from within this window the host is
+added to the "Hosts not reporting" report. When adjusting the `cf-hub`
+`hub_schedule` consider adjusting the Unreachable host threshold proportionally.
+For example, if you change the `hub_schedule` to execute only once every 15
+minutes, then the Unreachable host threshold should be adjusted to 45 minutes
+(2700 seconds).
+
+### Set Unreachable host threshold via API
+
+**Note:** This example uses [jq](https://stedolan.github.io/jq/) to filter API
+results to only the relevant values. It is a 3rd party tool, and not shipped
+with CFEngine.
+
+Here we create a JSON payload with the new value for the Unreachable host
+threshold (`blueHostHorizon`). We post the new settings and finally query the
+API to validate the change in settings.
+
+```console
+[root@hub ~]# echo '{ "blueHostHorizon": 2700 }' > payload.json
+[root@hub ~]# cat payload.json
+{ "blueHostHorizon": 2700 }
+[root@hub ~]# curl -u admin:admin http://localhost:80/api/settings -X POST -d @./payload.json
+[root@hub ~]# curl -s -u admin:admin http://localhost:80/api/settings/ | jq '.data[0]|.blueHostHorizon'
+2700
+```

--- a/enterprise-cfengine-guide/hub_administration/custom-https-certificate.markdown
+++ b/enterprise-cfengine-guide/hub_administration/custom-https-certificate.markdown
@@ -1,0 +1,26 @@
+---
+layout: default
+title: Custom SSL Certificate
+published: true
+tags: [cfengine enterprise, hub administration, SSL]
+---
+
+When first installed a self-signed ssl certificate is automatically generated
+and used to secure Mission Portal and API communications. You can change this
+certificate out with a custom one by replacing
+`/var/cfengine/httpd/ssl/certs/<hostname>.cert` and
+`/var/cfengine/httpd/ssl/private/<hostname>.cert` where hostname is the fully
+qualified domain name of the host.
+
+You can get the fully qualified hostname on your hub by running the following
+commands.
+
+```console
+[root@hub ~]# cf-promises --show-vars | grep "default:sys\.fqhost"
+default:sys.fqhost                       hub                                                          inventory,source=agent,attribute_name=Host name
+```
+
+```console
+[root@hub ~]# hostname -f
+hub
+```

--- a/enterprise-cfengine-guide/hub_administration/enable-plain-http.markdown
+++ b/enterprise-cfengine-guide/hub_administration/enable-plain-http.markdown
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Enable plain http
+published: true
+tags: [cfengine enterprise, hub administration, SSL]
+---
+
+By default HTTPS is enforced by redirecting any non secure connection requests.
+
+If you would like to enable plain HTTP you can do so by defining
+`cfe_enterprise_enable_plain_http` from an [augments file][Augments].
+
+For example, simply place the following inside `def.json` in the root of your
+masterfiles.
+
+```
+{
+  "classes": {
+    "cfe_enterprise_enable_plain_http": [ "any" ]
+    }
+
+}
+```

--- a/enterprise-cfengine-guide/hub_administration/reset-admin-creds.markdown
+++ b/enterprise-cfengine-guide/hub_administration/reset-admin-creds.markdown
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Reset administrative credentials
+published: true
+tags: [cfengine enterprise, hub administration, credentials]
+---
+
+The default `admin` user can be reset to defaults using the following SQL.
+
+cfsettings-setadminpassword.sql:
+
+```sql
+UPDATE "users"
+	SET password='SHA=aa459b45ecf9816d472c2252af0b6c104f92a6faf2844547a03338e42e426f52',
+	    salt='eWAbKQmxNP',
+	    name='admin',
+	    email='admin@organisation.com',
+	    active='1',
+	    roles='{admin,cf_remoteagent}',
+            changetimestamp = now()
+	WHERE username='admin';
+INSERT INTO "users" ("username", "password", "salt", "name", "email", "external", "active", "roles", "changetimestamp")
+       SELECT 'admin', 'SHA=aa459b45ecf9816d472c2252af0b6c104f92a6faf2844547a03338e42e426f52', 'eWAbKQmxNP', 'admin',  'admin@organisation.com', false, '1',  '{admin,cf_remoteagent}', now()
+       WHERE NOT EXISTS (SELECT 1 FROM users WHERE username='admin');
+```
+
+To reset the CFEngine admin user run the following sql as root on your hub
+
+```console
+root@hub:~# psql cfsettings < cfsettings-setadminpassword.sql
+```
+


### PR DESCRIPTION
Split hub administration tasks into individual pages.
Add instructions for enabling plain http for Mission Portal.
Add instructions for installing custom SSL Certificates.