### PR TITLE
Redmine#7435: add docs for json_pipe integration

### DIFF
--- a/reference/functions/mapdata.markdown
+++ b/reference/functions/mapdata.markdown
@@ -11,7 +11,8 @@ tags: [reference, data functions, functions, mapdata, inline_json]
 array is a map across each element of `array_or_container`, modified by
 a `pattern`. The map is either collected literally when `interpretation`
 is `none`, or canonified when `interpretation` is `canonify`,
-or parsed as JSON when `interpretation` is `json`.
+or parsed as JSON when `interpretation` is `json`, or collected from `pattern`,
+invoked as a program, when `interpretation` is `json_pipe`.
 
 This is a [collecting function][Functions#collecting functions] so it can accept many types of data parameters.
 
@@ -36,6 +37,28 @@ Output:
 
 [%CFEngine_include_snippet(mapdata.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**History:** Was introduced in 3.7.0. `canonify` mode was introduced in 3.9.0. The [collecting function][Functions#collecting functions] behavior was added in 3.9.
+**json_pipe**
+
+The `json_pipe` interpretation is intended to work with programs that take JSON
+as input and produce JSON as output. This is a standard tool convention in the
+Unix world. See the example below for the typical usage.
+
+[jq][https://stedolan.github.io/jq/] has a powerful programming language that
+fits the `json_pipe` interpretation well. It will take JSON input and product
+JSON output. Please read the [jq][https://stedolan.github.io/jq/] manual and
+cookbook to get a feel for the power of this tool. When available,
+[jq][https://stedolan.github.io/jq/] will offer tremendous data manipulation
+power for advanced cases where the built-in CFEngine functions are not enough.
+
+**Example with json_pipe:**
+
+[%CFEngine_include_snippet(mapdata_jsonpipe.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(mapdata_jsonpipe.cf, #\+begin_src\s+output\s*, .*end_src)%]
+
+
+**History:** Was introduced in 3.7.0. `canonify` mode was introduced in 3.9.0. The [collecting function][Functions#collecting functions] behavior was added in 3.9. The `json_pipe` mode was added in 3.9.
 
 **See also:** `maplist()`, `maparray()`, `canonify()`, [about collecting functions][Functions#collecting functions], and `data` documentation.

--- a/reference/special-variables.markdown
+++ b/reference/special-variables.markdown
@@ -33,6 +33,8 @@ Variables defined in a monitoring context.
 * [sys][sys]
 Variables defined in order to automate discovery of system values.
 
+* [def][def]
+Variables with some default value that can be defined by [augments file][Augments] or in policy.
+
 * [this][this]
 Variables used to access information about promises during their execution.
-

--- a/reference/special-variables/def.markdown
+++ b/reference/special-variables/def.markdown
@@ -31,3 +31,15 @@ bundle common def
   # ...
 }
 ```
+
+### def.jq
+
+This variable gives a convenient way to invoke
+[jq][https://stedolan.github.io/jq/] for the `mapdata()` function in `json_pipe`
+mode and elsewhere. Note the below is the **default** value defined in the C
+code that you can override in the `vars` section of the
+[augments file][Augments] or in policy as described above.
+
+```cf3
+    # def.jq = jq --compact-output --monochrome-output --ascii-output --unbuffered --sort-keys
+```


### PR DESCRIPTION
As requested in https://github.com/cfengine/core/pull/2572 and https://github.com/cfengine/core/pull/2319