### PR TITLE
Fix incorrect syntax documentation for packages -> options.

### DIFF
--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -99,7 +99,7 @@ rescue solution when a package module has added functionality which is not
 covered by the package promise API. As such there is no official documentation
 for this attribute, its usage depends on the package module in question.
 
-**Type:** `string`
+**Type:** `slist`
 
 **Allowed input range:** (arbitrary string)
 
@@ -110,7 +110,7 @@ for this attribute, its usage depends on the package module in question.
     "apache"
         policy => "present",
         package_module => my_package_module,
-        options => "repository=myrepo";
+        options => { "repository=myrepo" };
 ```
 
 
@@ -179,7 +179,7 @@ of the package module inside `/var/cfengine/modules/packages`.
 
 See the `options` attribute for details on what options do.
 
-**Type:** `string`
+**Type:** `slist`
 
 **Allowed input range:** (arbitrary string)
 
@@ -188,7 +188,7 @@ See the `options` attribute for details on what options do.
 ```cf3
 body package_module apt_get
 {
-    default_options => "use_curl=1";
+    default_options => { "use_curl=1" };
 }
 ```
 

--- a/reference/standard-library/package_modules.markdown
+++ b/reference/standard-library/package_modules.markdown
@@ -84,11 +84,13 @@ implemented, in order to facilitate a nice debugging cycle during development.
 All the API commands listed below, except `supports-api-version`, support the
 `options` attribute. This attribute will contain the contents from the `options`
 attribute in the promise, or the `default_options` in the package module body,
-if the former is unspecified. This attribute has no inherent meaning to
-CFEngine, and will be passed verbatim. It is meant as a mechanism to communicate
-special attributes to the package module that are not covered by the main
-API. For example, for certain package modules it may be used to pass a
-repository URL.
+if the former is unspecified. It may appear more than once if the `options` list
+has more than one element.
+
+This attribute has no inherent meaning to CFEngine, and will be passed
+verbatim. It is meant as a mechanism to communicate special attributes to the
+package module that are not covered by the main API. For example, for certain
+package modules it may be used to pass a repository URL.
 
 The `options` attribute will not be explicitly listed in the examples below, but
 it is valid in all of them except `supports-api-version`, even when the


### PR DESCRIPTION
It is an slist, not a string.