### PR TITLE
Fix: description of regular expression matching for packagesmatching

### DIFF
--- a/reference/functions/packagesmatching.markdown
+++ b/reference/functions/packagesmatching.markdown
@@ -7,12 +7,14 @@ tags: [reference, utility functions, functions, packages, inventory, packagesmat
 
 [%CFEngine_function_prototype(package_regex, version_regex, arch_regex, method_regex)%]
 
-**Description:** Return a data container with the list of installed packages matching the parameters.
+**Description:** Return a data container with the list of installed packages
+matching the parameters.
 
-This function searches for the [unanchored][unanchored] regular expressions in
-the list of currently installed packages.
+This function searches for the [anchored][anchored] regular expressions in the
+list of currently installed packages.
 
-The return is a data container with a list of package descriptions, looking like this:
+The return is a data container with a list of package descriptions, looking like
+this:
 
 ```
 [

--- a/reference/functions/packageupdatesmatching.markdown
+++ b/reference/functions/packageupdatesmatching.markdown
@@ -7,12 +7,14 @@ tags: [reference, utility functions, functions, packages, inventory, packageupda
 
 [%CFEngine_function_prototype(package_regex, version_regex, arch_regex, method_regex)%]
 
-**Description:** Return a data container with the list of available packages matching the parameters.
+**Description:** Return a data container with the list of available packages
+matching the parameters.
 
-This function searches for the [unanchored][unanchored] regular expressions in
-the list of currently available packages.
+This function searches for the [anchored][anchored] regular expressions in the
+list of currently available packages.
 
-The return is a data container with a list of package descriptions, looking like this:
+The return is a data container with a list of package descriptions, looking like
+this:
 
 ```json
 [


### PR DESCRIPTION
functions

My testing shows that this is indeed an anchored regular expression and not
an unanchored regular expression. Some discussion with Eystein results in
the conculsion that the implementation is correct, and the documentation
needs updating.

(cherry picked from commit d2285ae1d0ba48256964e5ba50379dfba1ec9fd6)