### PR TITLE
Change: Improve history for sort() and eval()

### DIFF
--- a/reference/functions/eval.markdown
+++ b/reference/functions/eval.markdown
@@ -106,3 +106,7 @@ Output:
 2013-09-14T08:34:16-0400   notice: R: math/prefix eval('3^3') = '27.000000'
 ```
 
+**History:**
+ - Function added in 3.6.0.
+ - `mode` and `options` optional and default to `math` and `infix`, respectively
+    as of 3.9.0.

--- a/reference/functions/sort.markdown
+++ b/reference/functions/sort.markdown
@@ -39,6 +39,9 @@ Output:
 2013-09-05T14:05:04-0400   notice: R: sorted MACs '00:14:BF:F7:23:1D,0:14:BF:F7:23:1D,:14:BF:F7:23:1D,00:014:BF:0F7:23:01D,00:14:BF:F7:23:1D,0:14:BF:F7:23:1D,:14:BF:F7:23:1D,00:014:BF:0F7:23:01D,01:14:BF:F7:23:1D,1:14:BF:F7:23:1D,01:14:BF:F7:23:2D,1:14:BF:F7:23:2D,-1,where are the MAC addresses?' => '-1,:14:BF:F7:23:1D,:14:BF:F7:23:1D,where are the MAC addresses?,00:014:BF:0F7:23:01D,0:14:BF:F7:23:1D,00:14:BF:F7:23:1D,00:014:BF:0F7:23:01D,0:14:BF:F7:23:1D,00:14:BF:F7:23:1D,1:14:BF:F7:23:1D,01:14:BF:F7:23:1D,1:14:BF:F7:23:2D,01:14:BF:F7:23:2D'
 ```
 
-**History:** The [collecting function][Functions#collecting functions] behavior was added in 3.9.
+**History:**
+ - Function added in 3.6.0.
+ - [Collecting function][Functions#collecting functions] behavior added in 3.9.0.
+ - Optional `mode` defaulting to `lex` behavior added in 3.9.0.
 
 **See also:** `shuffle()`, [about collecting functions][Functions#collecting functions], and `data` documentation.


### PR DESCRIPTION
(cherry picked from commit 310261ec2600bb264ce7f7aec1f50a650e93bd2e)