### PR TITLE
Fix: Syntax error in markdown

### DIFF
--- a/examples/example-snippets/promise-patterns/example_enable_service.markdown
+++ b/examples/example-snippets/promise-patterns/example_enable_service.markdown
@@ -17,7 +17,7 @@ correct return codes for status checks.
 
 **See Also:**
 
-* [Services promise type reference][`services`]
+* [Services promise type reference][services]
 * [Services bundles and bodies in the standard library][Services Bundles and Bodies]
 
 ## Example usage on systemd


### PR DESCRIPTION
(cherry picked from commit 3341b5433a6478517737d85d63d2bdf285c6bd6e)