### PR TITLE
Fix typo in Enterprise Installation Guide. (Too many m's in "recommmended")

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
@@ -130,7 +130,7 @@ For 5000 bootstrapped agents, the disk that serves PostgreSQL
 (`$(sys.workdir)/state/pg`) should be able to perform at least **1000
 IOPS** (in 16KiB block size) and 10 MB/s. The disk mounted on
 `$(sys.workdir)` should be able to perform at least 500 IOPS and 0.5
-MB/s. **SSD is recommmended** for the disk that serves PostgreSQL
+MB/s. **SSD is recommended** for the disk that serves PostgreSQL
 (`$(sys.workdir)/state/pg`).
 
 If you do not have separate partitions for `$(sys.workdir)` and


### PR DESCRIPTION
(cherry picked from commit 268ff42bfee4b59ba5f8f28de6929073d1784230)