### PR TITLE
Fix history on if/unless in ifvarclass section

### DIFF
--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -1175,7 +1175,7 @@ Notice that the function `canonify()` is provided to convert a general variable
 input into a string composed only of legal characters, using the same algorithm
 that CFEngine uses.
 
-**History:** Has the `if` alias (and `unless` opposite) since 3.6.1.
+**History:** Has the `if` alias (and `unless` opposite) since 3.7.0.
 
 ### if
 


### PR DESCRIPTION
According to ChangeLog in core, if/unless were introduced in 3.7.0,
not in 3.6.1:  https://github.com/cfengine/core/blob/master/ChangeLog#L759-L760