### PR TITLE
Redmine#7885: add documentation and links for variablesmatching_as_data

### DIFF
--- a/reference/functions/variablesmatching.markdown
+++ b/reference/functions/variablesmatching.markdown
@@ -23,10 +23,13 @@ with one tag in each call and use the `intersection` function on the return valu
 
 Variable tags are set using the [`meta`][Promise Types and Attributes#meta] attribute.
 
+This function behaves exactly like `variablesmatching_as_data()` but returns
+just the list of all the variables. If you want their contents as well, see that
+function.
+
 [%CFEngine_function_attributes(regex, tag1, tag2, ...)%]
 
 **Example:**
-
 
 [%CFEngine_include_snippet(variablesmatching.cf, #\+begin_src cfengine3, .*end_src)%]
 
@@ -34,6 +37,6 @@ Output:
 
 [%CFEngine_include_snippet(variablesmatching.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** [classesmatching()][classesmatching], [bundlesmatching()][bundlesmatching]
+**See also:** [classesmatching()][classesmatching], [bundlesmatching()][bundlesmatching], [variablesmatching_as_data()][variablesmatching_as_data]
 
 **History:** Introduced in CFEngine 3.6

--- a/reference/functions/variablesmatching_as_data.markdown
+++ b/reference/functions/variablesmatching_as_data.markdown
@@ -1,0 +1,43 @@
+---
+layout: default
+title: variablesmatching_as_data
+published: true
+tags: [reference, utility functions, functions, variablesmatching, variablesmatching_as_data]
+---
+
+[%CFEngine_function_prototype(name, tag1, tag2, ...)%]
+
+**Description:** Return a data container with the map of variables matching
+`name` and any tags given to the variable contents. Both `name` and tags are
+regular expressions.
+
+This function searches for the given [anchored][anchored] `name` and
+`tag1`, `tag2`, ... regular expressions in the list of currently defined
+variables.
+
+When one or more tags are given, the variables with tags matching any
+of the given [anchored][anchored] regular expressions are returned (logical OR semantics).
+For example, if one variable has tag `inventory`, a second variable has tag `time_based`
+but not `inventory`, *both* are returned by variablesmatching_as_data(".*", "inventory", "time_based").
+If you want logical AND semantics instead, you can make two calls to the function
+with one tag in each call and use the `intersection` function on the return values.
+
+Variable tags are set using the [`meta`][Promise Types and Attributes#meta] attribute.
+
+This function behaves exactly like `variablesmatching()` but returns a data
+container with the full contents of all the variables instead of just their
+names.
+
+[%CFEngine_function_attributes(regex, tag1, tag2, ...)%]
+
+**Example:**
+
+[%CFEngine_include_snippet(variablesmatching_as_data.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(variablesmatching_as_data.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See also:** [classesmatching()][classesmatching], [bundlesmatching()][bundlesmatching], [variablesmatching()][variablesmatching]
+
+**History:** Introduced in CFEngine 3.10


### PR DESCRIPTION
Added in https://github.com/cfengine/core/pull/2471

Requires https://github.com/cfengine/core/pull/2708