### PR TITLE
ARCHIVE-1619: allow maplist(), maparray(), and mapdata() to evaluate function calls during iteration

### DIFF
--- a/reference/functions.markdown
+++ b/reference/functions.markdown
@@ -123,6 +123,20 @@ will wrap the `thing` in a JSON array; then the contents of
 `otherthing[123]` will be wrapped in a JSON map which will also go in
 the array.
 
+### Delayed Evaluation Functions
+
+Since CFEngine 3.10, some functions are marked as *delayed evaluation* which
+means they can evaluate a function call across every element of a collection.
+This makes intuitive sense for the collection traversing functions `maparray()`,
+`maplist()`, and `mapdata()`.
+
+The practical use is for instance `maplist(format("%03d", $(this)), mylist)`
+which will evaluate that `format()` call once for every element of `mylist`.
+
+Before 3.10, the same call would have resulted in running the `format()`
+function **before** the list is traversed, which is almost never what the user
+wants.
+
 ## List of all functions
 
 There are a large number of functions built into CFEngine. The following

--- a/reference/functions/maparray.markdown
+++ b/reference/functions/maparray.markdown
@@ -12,6 +12,8 @@ modified by a `pattern`.
 
 [This function can accept many types of data parameters.][Functions#collecting functions]
 
+[This function can delay the evaluation of its first parameter, which can therefore be a function call.][Functions#delayed evaluation functions]
+
 The `$(this.k)` and `$(this.v)` variables expand to the key and value
 of the current element, similar to the way `this` is available for
 `maplist`.
@@ -36,6 +38,6 @@ Output:
 
 [%CFEngine_include_snippet(maparray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**History:** The [collecting function][Functions#collecting functions] behavior was added in 3.9.
+**History:** The [collecting function][Functions#collecting functions] behavior was added in 3.9. The delayed evaluation behavior was introduced in 3.10.
 
 **See also:** `maplist()`, `mapdata()`, [about collecting functions][Functions#collecting functions], and `data` documentation.

--- a/reference/functions/mapdata.markdown
+++ b/reference/functions/mapdata.markdown
@@ -16,6 +16,8 @@ invoked as a program, when `interpretation` is `json_pipe`.
 
 [This function can accept many types of data parameters.][Functions#collecting functions]
 
+[This function can delay the evaluation of its second parameter, which can therefore be a function call.][Functions#delayed evaluation functions]
+
 The `$(this.k)` and `$(this.v)` variables expand to the key and value
 of the current element, similar to the way `this` is available for
 `maplist`.
@@ -59,6 +61,6 @@ Output:
 [%CFEngine_include_snippet(mapdata_jsonpipe.cf, #\+begin_src\s+output\s*, .*end_src)%]
 
 
-**History:** Was introduced in 3.7.0. `canonify` mode was introduced in 3.9.0. The [collecting function][Functions#collecting functions] behavior was added in 3.9. The `json_pipe` mode was added in 3.9.
+**History:** Was introduced in 3.7.0. `canonify` mode was introduced in 3.9.0. The [collecting function][Functions#collecting functions] behavior was added in 3.9. The `json_pipe` mode was added in 3.9. The delayed evaluation behavior was introduced in 3.10.
 
 **See also:** `maplist()`, `maparray()`, `canonify()`, [about collecting functions][Functions#collecting functions], and `data` documentation.

--- a/reference/functions/maplist.markdown
+++ b/reference/functions/maplist.markdown
@@ -12,6 +12,8 @@ pattern.
 
 [This function can accept many types of data parameters.][Functions#collecting functions]
 
+[This function can delay the evaluation of its first parameter, which can therefore be a function call.][Functions#delayed evaluation functions]
+
 The `$(this)` variable expands to the currently processed entry from `list`.
 This is essentially like the map() function in Perl, and applies to
 lists.
@@ -26,6 +28,6 @@ Output:
 
 [%CFEngine_include_snippet(maplist.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**History:** Was introduced in 3.3.0, Nova 2.2.0 (2011). The [collecting function][Functions#collecting functions] behavior was added in 3.9.
+**History:** Was introduced in 3.3.0, Nova 2.2.0 (2011). The [collecting function][Functions#collecting functions] behavior was added in 3.9. The delayed evaluation behavior was introduced in 3.10.
 
 **See also:** `maplist()`, `maparray()`, [about collecting functions][Functions#collecting functions], and `data` documentation.


### PR DESCRIPTION
For https://github.com/cfengine/core/pull/2683#event-814928613