### PR TITLE
CFE-2513: New sysctlvalue() and data_sysctlvalues() functions from /proc/sys

### DIFF
--- a/reference/functions/data_sysctlvalues.markdown
+++ b/reference/functions/data_sysctlvalues.markdown
@@ -1,0 +1,36 @@
+---
+layout: default
+title: data_sysctlvalues
+published: true
+tags: [reference, system functions, functions, sysctl, data_sysctlvalues]
+---
+
+[%CFEngine_function_prototype()%]
+
+**Description:** Returns all sysctl values using `/proc/sys`.
+
+[%CFEngine_function_attributes()%]
+
+**Example:**
+
+```cf3
+    vars:
+      "sysctl" data => data_sysctlvalues(); # get everything!
+```
+
+Output:
+
+```
+{
+  "sysctl": {
+  ...
+    "net.unix.max_dgram_qlen": "512",
+  ...
+  }
+```
+
+**Notes:**
+
+**History:** Was introduced in version 3.11.0 (2017)
+
+**See also:** `sysctlvalue()`

--- a/reference/functions/sysctlvalue.markdown
+++ b/reference/functions/sysctlvalue.markdown
@@ -1,0 +1,33 @@
+---
+layout: default
+title: sysctlvalue
+published: true
+tags: [reference, system functions, functions, sysctl, sysctlvalue]
+---
+
+[%CFEngine_function_prototype(key)%]
+
+**Description:** Returns the sysctl value of `key` using `/proc/sys`.
+
+[%CFEngine_function_attributes(key)%]
+
+**Example:**
+
+```cf3
+    vars:
+      "tested" slist => { "net.ipv4.tcp_mem", "net.unix.max_dgram_qlen" };
+      "values[$(tested)]" string => sysctlvalue($(tested));
+```
+
+Output:
+
+```
+  "values[net.ipv4.tcp_mem]" = "383133\t510845\t766266"
+  "values[net.unix.max_dgram_qlen]" = "512"
+```
+
+**Notes:**
+
+**History:** Was introduced in version 3.11.0 (2017)
+
+**See also:** `data_sysctlvalues()`


### PR DESCRIPTION
@kacf as requested in https://github.com/cfengine/core/pull/2743