### PR TITLE
Added documentation for readenvfile() (CFE-2650)

### DIFF
--- a/reference/functions/readcsv.markdown
+++ b/reference/functions/readcsv.markdown
@@ -5,10 +5,11 @@ published: true
 tags: [reference, io functions, functions, readcsv, CSV, container]
 ---
 
-<!--  %CFEngine_function_attributes(filename)% There was a problem with this macro -->
+[%CFEngine_function_prototype(filename, optional_maxbytes)%]
 
-**Description:** Parses CSV data from the first 1 MB of
-file `filename` and returns the result as a `data` variable.
+**Description:**
+Parses CSV data from the file `filename` and returns the result as a `data` variable.
+`maxbytes` is optional, if specified, only the first `maxbytes` bytes are read from `filename`.
 
 While it may seem similar to `data_readstringarrayidx()` and
 `data_readstringarray()`, the `readcsv()` function is more capable
@@ -20,7 +21,7 @@ The returned data is in the same format as
 `data_readstringarrayidx()`, that is, a data container that holds a
 JSON array of JSON arrays.
 
-<!--  %CFEngine_function_attributes(filename)% There was a problem with this macro -->
+[%CFEngine_function_attributes(filename, optional_maxbytes)%]
 
 **Example:**
 

--- a/reference/functions/readdata.markdown
+++ b/reference/functions/readdata.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: readdata
 published: true
-tags: [reference, io functions, functions, readcsv, readjson, readyaml, readdata, CSV, JSON, YAML, container]
+tags: [reference, io functions, functions, readcsv, readjson, readyaml, readdata, readenvfile, CSV, JSON, YAML, ENV, container]
 ---
 
 [%CFEngine_function_prototype(filename, filetype)%]
@@ -25,6 +25,10 @@ When `filetype` is `YAML`, this function behaves exactly like
 `readyaml()` and returns the same data structure, except there is no
 data size limit (`maxbytes` is `inf`).
 
+When `filetype` is `ENV`, this function behaves exactly like
+`readenvfile()` and returns the same data structure, except there is no
+data size limit (`maxbytes` is `inf`).
+
 [%CFEngine_function_attributes(filename, filetype)%]
 
 **Example:**
@@ -41,6 +45,6 @@ Output:
 
 [%CFEngine_include_snippet(readdata.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** `readcsv()`, `readyaml()`, `readjson()`, and `data` documentation.
+**See also:** `readcsv()`, `readyaml()`, `readjson()`, `readenvfile()`, `data` documentation.
 
 **History:** Was introduced in 3.7.0.

--- a/reference/functions/readdata.markdown
+++ b/reference/functions/readdata.markdown
@@ -14,20 +14,10 @@ When `filetype` is `auto`, the file type is guessed from the extension
 (ignoring case): `.csv` means CSV; `.json` means JSON; `.yaml` means
 YAML. If the file doesn't match any of those names, JSON is used.
 
-When `filetype` is `CSV`, this function behaves exactly like
-`readcsv()` and returns the same data structure.
-
-When `filetype` is `JSON`, this function behaves exactly like
-`readjson()` and returns the same data structure, except there is no
-data size limit (`maxbytes` is `inf`).
-
-When `filetype` is `YAML`, this function behaves exactly like
-`readyaml()` and returns the same data structure, except there is no
-data size limit (`maxbytes` is `inf`).
-
-When `filetype` is `ENV`, this function behaves exactly like
-`readenvfile()` and returns the same data structure, except there is no
-data size limit (`maxbytes` is `inf`).
+When `filetype` is `CSV`,`JSON`,`YAML` or `ENV`,
+this function behaves like `readcsv()`, `readjson()`, `readyaml()` or `readenvfile()` respectively.
+These functions have an optional parameter `maxbytes` (default: `inf`).
+`maxbytes` can not be set using `readdata()`, if needed use one of the mentioned functions instead.
 
 [%CFEngine_function_attributes(filename, filetype)%]
 

--- a/reference/functions/readenvfile.markdown
+++ b/reference/functions/readenvfile.markdown
@@ -1,0 +1,43 @@
+---
+layout: default
+title: readenvfile
+published: true
+tags: [reference, io functions, functions, readenvfile, json, env, os-release, container]
+---
+
+[%CFEngine_function_prototype(filename, optional_maxbytes)%]
+
+**Description:**
+Parses key-value pairs from the file `filename` in env file format (`man os-release`).
+Returns the result as a `data` variable.
+Keys and values are interpreted as strings.
+`maxbytes` is optional, if specified, only the first `maxbytes` bytes are read from `filename`.
+[Details of the os-release/env file format on freedesktop.org](https://www.freedesktop.org/software/systemd/man/os-release.html)
+
+[%CFEngine_function_attributes(filename, otpional_maxbytes)%]
+
+**Syntax example:**
+Short syntax example:
+```cf3
+    vars:
+      "loadthis"
+         data => readenvfile("/etc/os-release");
+```
+
+**Complete example:**
+Prepare:
+
+[%CFEngine_include_snippet(readenvfile.cf, #\+begin_src prep, .*end_src)%] <!--**-->
+
+Run:
+
+[%CFEngine_include_snippet(readenvfile.cf, #\+begin_src cfengine3, .*end_src)%] <!--**-->
+
+Output:
+
+[%CFEngine_include_snippet(readenvfile.cf, #\+begin_src\s+example_output\s*, .*end_src)%] <!--**-->
+
+**Notes:**
+This function is used internally to load `/etc/os-release` into `sys.os_release`.
+
+**See also:** `readdata()`, `parsejson()`, `parseyaml()`, `storejson()`, `mergedata()`, and `data` documentation.

--- a/reference/functions/readfile.markdown
+++ b/reference/functions/readfile.markdown
@@ -5,13 +5,14 @@ published: true
 tags: [reference, io functions, functions, readfile]
 ---
 
-[%CFEngine_function_prototype(filename, maxbytes)%]
+[%CFEngine_function_prototype(filename, optional_maxbytes)%]
 
-**Description:** Returns the first `maxbytes` bytes from file
-`filename`.  When `maxbytes` is 0, the maximum possible bytes will be
-read from the file (but see **Notes** below).
+**Description:**
+Returns the first `maxbytes` bytes from file `filename`.
+`maxbytes` is optional, if specified, only the first `maxbytes` bytes are read from `filename`.
+When `maxbytes` is `0` or not specified, the whole file will be read (but see **Notes** below).
 
-[%CFEngine_function_attributes(filename, maxbytes)%]
+[%CFEngine_function_attributes(filename, optional_maxbytes)%]
 
 **Example:**
 

--- a/reference/functions/readjson.markdown
+++ b/reference/functions/readjson.markdown
@@ -5,13 +5,13 @@ published: true
 tags: [reference, io functions, functions, readjson, json, container]
 ---
 
-[%CFEngine_function_prototype(filename, maxbytes)%]
+[%CFEngine_function_prototype(filename, optional_maxbytes)%]
 
 **Description:** Parses JSON data from the file `filename` and returns the
 result as a `data` variable. `maxbytes` is optional, if specified, only the
 first `maxbytes` bytes are read from `filename`.
 
-[%CFEngine_function_attributes(filename, maxbytes)%]
+[%CFEngine_function_attributes(filename, optional_maxbytes)%]
 
 **Example:**
 

--- a/reference/functions/readyaml.markdown
+++ b/reference/functions/readyaml.markdown
@@ -5,13 +5,13 @@ published: true
 tags: [reference, io functions, functions, readyaml, yaml, json, container]
 ---
 
-[%CFEngine_function_prototype(filename, maxbytes)%]
+[%CFEngine_function_prototype(filename, optional_maxbytes)%]
 
 **Description:** Parses YAML data from the file `filename` and returns the
 result as a `data` variable. `maxbytes` is optional, if specified, only the
 first `maxbytes` bytes are read from `filename`.
 
-[%CFEngine_function_attributes(filename, maxbytes)%]
+[%CFEngine_function_attributes(filename, optional_maxbytes)%]
 
 **Example:**
 


### PR DESCRIPTION
Example does not work yet, see: https://tracker.mender.io/browse/CFE-2656