### PR TITLE
Redact known issue for editing directory users with dots in username

### DIFF
--- a/guide/latest-release/known-issues.markdown
+++ b/guide/latest-release/known-issues.markdown
@@ -100,8 +100,3 @@ platforms than Debian, Ubuntu and Red Hat/CentOS.
 In order to add software inventory for other platforms,
 please contact support for a custom policy.
 
-### Enterprise - Unable to edit directory based users with dots in username
-
-Mission Portal does not allow users from a directory to be edited if they have
-dots in their username.
-


### PR DESCRIPTION
This was fixed in 3.10.2