### PR TITLE
CFE-2725: Note that modules can only define classes and vars in the default namespace

### DIFF
--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -439,6 +439,10 @@ This attribute determines whether or not to expect the CFEngine module protocol.
 These variables end up in a context that has the same name as the
 module, unless the `^context` extension is used.
 
+**NOTE**: All variables and classes defined by the module protocol are defined
+in the ```default``` namespace. It is not possible to define variables and
+classes in any other namespace.
+
 All the variables and classes will have at least the tag
 `source=module` in addition to any tags you may set.
 


### PR DESCRIPTION
(cherry picked from commit cb8c1564ec6b61bfb561e3be4159440d950de50a)