### PR TITLE
The timeout parameter is actually a connection + read timeout

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -517,7 +517,7 @@ identifying suffix.
 ### default_timeout
 
 **Description:** The value of `default_timeout` represents the maximum
-time a network connection should attempt to connect.
+time a network connection should attempt to connect or read from server.
 
 The time is in seconds. It is not a guaranteed number, since it
 depends on system behavior.


### PR DESCRIPTION
(cherry picked from commit 179568fabbb73e47fe30c248ab3028d0dd49a637)