### PR TITLE
Don't use frequency about a time interval

### DIFF
--- a/reference/enterprise-api-ref/sql-schema.markdown
+++ b/reference/enterprise-api-ref/sql-schema.markdown
@@ -516,7 +516,7 @@ their last reported `cf-agent` execution.
     Time when the connection was established.
 
 * **LastSeenInterval** *(real)*
-    Average frequency in seconds between connections for the given `LastSeenDirection` with the host.
+    Average time period (seconds) between connections for the given `LastSeenDirection` with the host.
 
 **Example query:**
 


### PR DESCRIPTION
This is minor, but it is wrong and confusing to use frequency about a length of time. (This is from a support case).

@nickanderson Please review.