### PR TITLE
Fix invalid data in api example

### DIFF
--- a/examples/enterprise-api-examples/managing-users-and-roles.markdown
+++ b/examples/enterprise-api-examples/managing-users-and-roles.markdown
@@ -78,15 +78,11 @@ credentials.
 
 **Request**
 
-    curl --user admin:admin http://test.cfengine.com/api/user/calvin -X POST -d
-    {
-      "name": "Calvin",
-    }
+    curl --user admin:admin http://test.cfengine.com/api/user/calvin -X POST -d '{ "name": "Calvin" }'
 
 **Response**
 
     204 No Content
-    }
 
 ## Example: Retrieving a User
 


### PR DESCRIPTION
The data previously contained a trailing comma which will not work
because it is invalid JSON.

(cherry picked from commit e2be23c7ac22233f410aa3bf06a5f683c6b79938)