### PR TITLE
Seperate parse*array and read*array into seperate documents

### DIFF
--- a/reference/functions/parseintarray.markdown
+++ b/reference/functions/parseintarray.markdown
@@ -1,0 +1,43 @@
+---
+layout: default
+title: "parseintarray"
+published: true
+tags: [reference, io functions, functions, parseintarray]
+---
+
+**Prototype:** `parseintarray(array, input, comment, split, maxentries, maxbytes)`<br>
+**Return type:** `int`
+
+**Description:** Parses up to `maxentries` values from the first `maxbytes`
+bytes in string `input` and populates `array`. Returns the dimension.
+
+This function mirrors the exact behavior of
+[`readintarray()`][readintarray], but reads data from a variable
+instead of a file. By making data readable from a variable, data driven
+policies can be kept inline.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range `[a-zA-Z0-9_$(){}\[\].:]+`
+* `input` : A string to parse for input data, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split data, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011**
+
+**See Also:** [`parsestringarray()`][parsestringarray], [`parserealarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/parserealarray.markdown
+++ b/reference/functions/parserealarray.markdown
@@ -1,0 +1,44 @@
+---
+layout: default
+title: "parserealarray"
+published: true
+tags: [reference, io functions, functions, parserealarray]
+---
+
+**Prototype:** `parserealarray(array, input, comment, split, maxentries, maxbytes)`<br>
+
+**Return type:** `int`
+
+**Description:** Parses up to `maxentries` values from the first `maxbytes`
+bytes in string `input` and populates `array`. Returns the dimension.
+
+This function mirrors the exact behavior of
+[`readrealarray()`][readrealarray], but read data from a variable
+instead of a file. By making data readable from a variable, data driven
+policies can be kept inline.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range `[a-zA-Z0-9_$(){}\[\].:]+`
+* `input` : A string to parse for input data, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split data, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
+
+**See Also:** [`parsestringarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/parsestringarray.markdown
+++ b/reference/functions/parsestringarray.markdown
@@ -1,0 +1,44 @@
+---
+layout: default
+title: "parsestringarray"
+published: true
+tags: [reference, io functions, functions, parseintarray, parserealarray, parsestringarray]
+---
+
+**Prototype:** `parsestringarray(array, input, comment, split, maxentries, maxbytes)`<br>
+
+**Return type:** `int`
+
+**Description:** Parses up to `maxentries` values from the first `maxbytes`
+bytes in string `input` and populates `array`. Returns the dimension.
+
+These functions mirrors the exact behavior of
+[`readstringarray()`][readstringarray], but read data from a variable
+instead of a file. By making data readable from a variable, data driven
+policies can be kept inline.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range `[a-zA-Z0-9_$(){}\[\].:]+`
+* `input` : A string to parse for input data, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split data, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
+
+**See Also:** [`parserealarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/readintarray.markdown
+++ b/reference/functions/readintarray.markdown
@@ -1,0 +1,51 @@
+---
+layout: default
+title: "readintarray"
+published: true
+tags: [reference, io functions, functions, readintarray]
+---
+
+**Prototype:** `readintarray(array, filename, comment, split, maxentries, maxbytes)`<br>
+
+**Return type:** `int`
+
+**Description:** Populates `array` with up to `maxentries` values, parsed from
+the first `maxbytes` bytes in file `filename`.
+
+Reads a two dimensional array from a file. One dimension is separated by the
+regex `split`, the other by the lines in the file. The first field of the
+lines names the first array argument.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+Returns the number of keys in the array, i.e., the number of
+lines matched.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range
+`[a-zA-Z0-9_$(){}\[\].:]+`
+* `filename` : File name to read, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split lines into fields, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+Prepare:
+
+[%CFEngine_include_snippet(readintarray.cf, #\+begin_src prep, .*end_src)%]
+
+Run:
+
+[%CFEngine_include_snippet(readintarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(readintarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** [`readstringarray()`][readstringarray], [`readrealarray()`][readrealarray], [`parseintarray()`][parseintarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 

--- a/reference/functions/readrealarray.markdown
+++ b/reference/functions/readrealarray.markdown
@@ -1,0 +1,127 @@
+---
+layout: default
+title: "readrealarray"
+published: true
+tags: [reference, io functions, functions, readintarray, readrealarray, readstringarray]
+---
+
+**Prototype:** `readrealarray(array, filename, comment, split, maxentries, maxbytes)`<br>
+
+**Return type:** `int`
+
+**Description:** Populates `array` with up to `maxentries` values, parsed from
+the first `maxbytes` bytes in file `filename`.
+
+Reads a two dimensional array from a file. One dimension is separated by the
+regex `split`, the other by the lines in the file. The first field of the
+lines names the first array argument.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+Returns the number of keys in the array, i.e., the number of
+lines matched.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range
+`[a-zA-Z0-9_$(){}\[\].:]+`
+* `filename` : File name to read, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split lines into fields, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+```cf3
+    readintarray("array_name","/tmp/array","#[^\n]*",":",10,4000);
+```
+
+Input:
+
+```cf3
+     1: 5.0:7:21:13
+     2:19:8.1:14:14
+     3:45:1:78.2:22
+     4:64:2:98:99.3
+```
+
+Results in:
+
+```cf3
+     array_name[1][0]   1
+     array_name[1][1]   5
+     array_name[1][2]   7
+     array_name[1][3]   21
+     array_name[1][4]   13
+     array_name[2][0]   2
+     array_name[2][1]   19
+     array_name[2][2]   8
+     array_name[2][3]   14
+     array_name[2][4]   14
+     array_name[3][0]   3
+     array_name[3][1]   45
+     array_name[3][2]   1
+     array_name[3][3]   78
+     array_name[3][4]   22
+     array_name[4][0]   4
+     array_name[4][1]   64
+     array_name[4][2]   2
+     array_name[4][3]   98
+     array_name[4][4]   99
+```
+
+```cf3
+    readstringarray("array_name","/tmp/array","\s*#[^\n]*",":",10,4000);
+```
+
+Input:
+
+```cf3
+     at:x:25:25:Batch jobs daemon:/var/spool/atjobs:/bin/bash
+     avahi:x:103:105:User for Avahi:/var/run/avahi-daemon:/bin/false    # Disallow login
+     beagleindex:x:104:106:User for Beagle indexing:/var/cache/beagle:/bin/bash
+     bin:x:1:1:bin:/bin:/bin/bash
+     # Daemon has the default shell
+     daemon:x:2:2:Daemon:/sbin:
+```
+
+Results in a systematically indexed map of the file:
+
+```cf3
+     ...
+     array_name[daemon][0]   daemon
+     array_name[daemon][1]   x
+     array_name[daemon][2]   2
+     array_name[daemon][3]   2
+     array_name[daemon][4]   Daemon
+     array_name[daemon][5]   /sbin
+     array_name[daemon][6]   /bin/bash
+     ...
+     array_name[at][3]       25
+     array_name[at][4]       Batch jobs daemon
+     array_name[at][5]       /var/spool/atjobs
+     array_name[at][6]       /bin/bash
+     ...
+     array_name[games][3]    100
+     array_name[games][4]    Games account
+     array_name[games][5]    /var/games
+     array_name[games][6]    /bin/bash
+     ...
+```
+Prepare:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src prep, .*end_src)%]
+
+Run:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 

--- a/reference/functions/readstringarray.markdown
+++ b/reference/functions/readstringarray.markdown
@@ -1,0 +1,127 @@
+---
+layout: default
+title: "readstringarray"
+published: true
+tags: [reference, io functions, functions, readstringarray]
+---
+
+**Prototype:** `readstringarray(array, filename, comment, split, maxentries, maxbytes)`
+
+**Return type:** `int`
+
+**Description:** Populates `array` with up to `maxentries` values, parsed from
+the first `maxbytes` bytes in file `filename`.
+
+Reads a two dimensional array from a file. One dimension is separated by the
+regex `split`, the other by the lines in the file. The first field of the
+lines names the first array argument.
+
+The `comment` field is a multiline regular expression and will strip out
+unwanted patterns from the file being read, leaving unstripped characters to be
+split into fields. Using the empty string (`""`) indicates no comments.
+
+Returns the number of keys in the array, i.e., the number of
+lines matched.
+
+**Arguments**:
+
+* `array` : Array identifier to populate, in the range
+`[a-zA-Z0-9_$(){}\[\].:]+`
+* `filename` : File name to read, in the range `"?(/.*)`
+* `comment` : [Unanchored][unanchored] regex matching comments, in the range `.*`
+* `split` : [Unanchored][unanchored] regex to split lines into fields, in the range `.*`
+* `maxentries` : Maximum number of entries to read, in the range
+`0,99999999999`
+* `maxbytes` : Maximum bytes to read, in the range `0,99999999999`
+
+**Example:**
+
+```cf3
+    readintarray("array_name","/tmp/array","#[^\n]*",":",10,4000);
+```
+
+Input:
+
+```cf3
+     1: 5:7:21:13
+     2:19:8:14:14
+     3:45:1:78:22
+     4:64:2:98:99
+```
+
+Results in:
+
+```cf3
+     array_name[1][0]   1
+     array_name[1][1]   5
+     array_name[1][2]   7
+     array_name[1][3]   21
+     array_name[1][4]   13
+     array_name[2][0]   2
+     array_name[2][1]   19
+     array_name[2][2]   8
+     array_name[2][3]   14
+     array_name[2][4]   14
+     array_name[3][0]   3
+     array_name[3][1]   45
+     array_name[3][2]   1
+     array_name[3][3]   78
+     array_name[3][4]   22
+     array_name[4][0]   4
+     array_name[4][1]   64
+     array_name[4][2]   2
+     array_name[4][3]   98
+     array_name[4][4]   99
+```
+
+```cf3
+    readstringarray("array_name","/tmp/array","\s*#[^\n]*",":",10,4000);
+```
+
+Input:
+
+```cf3
+     at:x:25:25:Batch jobs daemon:/var/spool/atjobs:/bin/bash
+     avahi:x:103:105:User for Avahi:/var/run/avahi-daemon:/bin/false    # Disallow login
+     beagleindex:x:104:106:User for Beagle indexing:/var/cache/beagle:/bin/bash
+     bin:x:1:1:bin:/bin:/bin/bash
+     # Daemon has the default shell
+     daemon:x:2:2:Daemon:/sbin:
+```
+
+Results in a systematically indexed map of the file:
+
+```cf3
+     ...
+     array_name[daemon][0]   daemon
+     array_name[daemon][1]   x
+     array_name[daemon][2]   2
+     array_name[daemon][3]   2
+     array_name[daemon][4]   Daemon
+     array_name[daemon][5]   /sbin
+     array_name[daemon][6]   /bin/bash
+     ...
+     array_name[at][3]       25
+     array_name[at][4]       Batch jobs daemon
+     array_name[at][5]       /var/spool/atjobs
+     array_name[at][6]       /bin/bash
+     ...
+     array_name[games][3]    100
+     array_name[games][4]    Games account
+     array_name[games][5]    /var/games
+     array_name[games][6]    /bin/bash
+     ...
+```
+Prepare:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src prep, .*end_src)%]
+
+Run:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(readrealarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** [`readrealarray()`][readrealarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 


### PR DESCRIPTION
This is inteneded to make it easier to find the functions in the
reference manual.