### PR TITLE
CFE-2722: Document removal of body agent control syslog

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -1144,21 +1144,8 @@ it will skip them and output a warning message.
 
 ### syslog
 
-**Description:** The `syslog` menu option policy determines whether to
-switch on output to syslog at the inform level.
-
-**Type:** [`boolean`][boolean]
-
-**Default value:** false
-
-**Example:**
-
-```cf3
-    body agent control
-    {
-    syslog => "true";
-    }
-```
+**Deprecated:** This menu option policy is deprecated as of 3.6.0. It performs
+no action and is kept for backward compatibility.
 
 ### track_value
 


### PR DESCRIPTION
This was removed in 3.6.0, but the documentation was never updated.