### PR TITLE
CFE-2772: Document removal of body agent control syslog

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -1086,21 +1086,8 @@ it will warn about them.
 
 ### syslog
 
-**Description:** The `syslog` menu option policy determines whether to
-switch on output to syslog at the inform level.
-
-**Type:** [`boolean`][boolean]
-
-**Default value:** false
-
-**Example:**
-
-```cf3
-    body agent control
-    {
-    syslog => "true";
-    }
-```
+**Deprecated:** This menu option policy is deprecated as of 3.6.0. It performs
+no action and is kept for backward compatibility.
 
 ### track_value
 


### PR DESCRIPTION
This was removed in 3.6.0, but the documentation was never updated.

(cherry picked from commit bfcd07e8b0cb26a1135598c419368ed87c93222f)
(cherry picked from commit 8ee80590c0747e599d9e1ee01dce73a90b3d4512)