### PR TITLE
CFE-1120: Backport improved docs related to detecting if files are symlinks

### DIFF
--- a/reference/functions/fileexists.markdown
+++ b/reference/functions/fileexists.markdown
@@ -12,6 +12,14 @@ tags: [reference, files functions, functions, fileexists]
 The file must exist, and the user must have access permissions to the file for
 this function to return true.
 
+**Notes:**
+
+- `fileexists()` does **not** resolve symlinks. If a broken symlink exists, the
+  file is seen to exist. For this functionality use `filestat("myfile", "link target")`
+  to see if a file resolves to a the expected target, and check if the
+  link target exists. Alternatively use `test` with `returnszero()`, for example
+  `returnszero("/bin/test -f myfile")`.
+
 [%CFEngine_function_attributes(filename)%]
 
 **Example:**
@@ -22,3 +30,4 @@ Output:
 
 [%CFEngine_include_snippet(fileexists.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
+**See Also:** `filestat()`, `isdir()`, `islink()`, `isplain()`, `returnszero()`

--- a/reference/functions/filestat.markdown
+++ b/reference/functions/filestat.markdown
@@ -61,6 +61,9 @@ Output:
 
 The list of fields may be extended as needed by CFEngine.
 
-**History:** Was introduced in version 3.5.0,Enterprise 3.1 (2013).  `linktarget` and `linktarget_shallow` were added in version 3.6.
+**History:**
 
-**See also:** `lastnode()`, `dirname()`, `splitstring()`.
+- function introduced in version 3.5.0.
+- `linktarget` and `linktarget_shallow` field options added in 3.6.0.
+
+**See also:** `dirname()`, `fileexists()`, `isdir()`, `islink()`, `isplain()`, `lastnode()`, `returnszero()`, `splitstring()`.

--- a/reference/functions/isdir.markdown
+++ b/reference/functions/isdir.markdown
@@ -20,3 +20,5 @@ The CFEngine process must have access to `filename` in order for this to work.
 Output:
 
 [%CFEngine_include_snippet(isdir.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** `fileexists()`, `filestat()`, `islink()`, `isplain()`, `returnszero()`

--- a/reference/functions/islink.markdown
+++ b/reference/functions/islink.markdown
@@ -13,6 +13,14 @@ link.
 The link node must both exist and be a symbolic link. Hard links cannot
 be detected using this function.
 
+**Notes:**
+
+- `islink()` does **not** resolve symlinks as part of it's test. If a broken
+  symlink exists, the file is still seen to be a symlink. Use
+  `filestat("myfile", "link target")` to see if a file resolves to a the
+  expected target, and check if the link target exists. Alternatively use `test`
+  with `returnszero()`, for example `returnszero("/bin/test -f myfile")`.
+
 [%CFEngine_function_attributes(filename)%]
 
 **Example:**
@@ -28,3 +36,5 @@ Run:
 Output:
 
 [%CFEngine_include_snippet(islink.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** `fileexists()`, `filestat()`, `isdir()`, `isplain()`, `returnszero()`

--- a/reference/functions/isplain.markdown
+++ b/reference/functions/isplain.markdown
@@ -19,3 +19,5 @@ plain/regular file.
 Output:
 
 [%CFEngine_include_snippet(isplain.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**See Also:** `fileexists()`, `filestat()`, `isdir()`, `islink()`, `returnszero()`

--- a/reference/functions/returnszero.markdown
+++ b/reference/functions/returnszero.markdown
@@ -35,4 +35,4 @@ highly undesirable if the command is expensive.  Consider using
 `commands` promises instead, which have locking and are not evaluated
 by `cf-promises`.
 
-**See also:** [`execresult()`][execresult].
+**See also:** `execresult()`.


### PR DESCRIPTION
The fileexists() function tells you if a file exists, if it is checking
a broken symlink, that broken symlink exists and therefore the function
returns true.

Checking if a symlink is broken or if it resolves to a specific target
can be accomplished using filestat() combined with fileexists or by
calling out to test binary with returnszero().

(cherry picked from commit e0ddd80313f12c5decda6444d7d9b3a94b63f305)