### PR TITLE
ENT-3923 Remove AIX 5.3 and Solaris 9 from list of supported platforms

### DIFF
--- a/guide/latest-release/supported-platforms.markdown
+++ b/guide/latest-release/supported-platforms.markdown
@@ -24,18 +24,17 @@ Any supported host can be a policy server in Community installations of CFEngine
 
 | Platform    | Versions                   | Architectures   |
 | :-----:     | :----------:               | :-----------:   |
-| AIX         | 5.3*, 6, 7                 | PowerPC         |
+| AIX         | 6, 7                       | PowerPC         |
 | CentOS/RHEL | 4, 5, 6, 7                 | x86-64, x86     |
 | Debian      | 4, 5, 6, 7, 8              | x86-64, x86     |
 | HP-UX       | 11.23+                     | Itanium         |
 | SLES        | 10, 11                     | x86-64, x86     |
-| Solaris     | 9, 11                      | UltraSparc      |
+| Solaris     | 11                         | UltraSparc      |
 | Solaris     | 10                         | UltraSparc, x86 |
 | Ubuntu      | 10.04, 12.04, 14.04, 16.04 | x86-64, x86     |
 | Windows     | 2008                       | x86-64, x86     |
 | Windows     | 2008, 2012                 | x86-64          |
 
-\* AIX 5.3 is required to have "5300-05-CSP" or later
 
 [Known Issues][] also includes platform-specific notes.
 


### PR DESCRIPTION
We will continue to try to have it work, but we cannot guarantee that these olde
releases are possible to support for the next full three years.

Changelog: AIX 5.3 and Solaris 9 are not supported platforms as of 3.12.0