### PR TITLE
ENT-3945 Update supported platforms for 3.12.x

### DIFF
--- a/guide/latest-release/supported-platforms.markdown
+++ b/guide/latest-release/supported-platforms.markdown
@@ -22,18 +22,18 @@ Any supported host can be a policy server in Community installations of CFEngine
 
 ## Hosts ##
 
-| Platform    | Versions                   | Architectures   |
-| :-----:     | :----------:               | :-----------:   |
-| AIX         | 6, 7                       | PowerPC         |
-| CentOS/RHEL | 4, 5, 6, 7                 | x86-64, x86     |
-| Debian      | 4, 5, 6, 7, 8              | x86-64, x86     |
-| HP-UX       | 11.23+                     | Itanium         |
-| SLES        | 10, 11                     | x86-64, x86     |
-| Solaris     | 11                         | UltraSparc      |
-| Solaris     | 10                         | UltraSparc, x86 |
-| Ubuntu      | 10.04, 12.04, 14.04, 16.04 | x86-64, x86     |
-| Windows     | 2008                       | x86-64, x86     |
-| Windows     | 2008, 2012                 | x86-64          |
+| Platform    | Versions     | Architectures   |
+| :-----:     | :----------: | :-----------:   |
+| AIX         | 7.1, 7.2     | PowerPC         |
+| CentOS/RHEL | 5, 6, 7      | x86-64, x86     |
+| Debian      | 7, 8         | x86-64, x86     |
+| HP-UX       | 11.31+       | Itanium         |
+| SLES        | 11           | x86-64, x86     |
+| Solaris     | 11           | UltraSparc      |
+| Solaris     | 10           | UltraSparc, x86 |
+| Ubuntu      | 14.04, 16.04 | x86-64, x86     |
+| Windows     | 2008         | x86-64, x86     |
+| Windows     | 2008, 2012   | x86-64          |
 
 
 [Known Issues][] also includes platform-specific notes.


### PR DESCRIPTION
Support for the following platform versions was removed because they have not been supported by their vendor for at least one year.

- AIX 5.3, 6 (PowerPC)
- CentOS/RHEL 4 (x86-64, x86)
- HP-UX 11.23 (Itanium)
- SLES 10 (x86-64, x86)
- Solaris 9 (UltraSparc)
- Ubuntu 10.04, 12.04 (x86-64, x86)