### PR TITLE
CFE-2850: Fixed wrong explanation of trivial option in regex_replace

### DIFF
--- a/reference/functions/regex_replace.markdown
+++ b/reference/functions/regex_replace.markdown
@@ -21,7 +21,7 @@ inside the regular expression, e.g. `(?s)`.
 * `s`: dot matches newlines too (`PCRE_DOTALL`)
 * `x`: extended regular expressions (`PCRE_EXTENDED`, very nice for readability)
 * `U`: ungreedy (`PCRE_UNGREEDY`)
-* `T`: this is not a regular expression, just replace the exact string
+* `T`: disables special characters and backreferences in the replacement string
 
 In the replacement, `$1` and `\1` refer to the first capture group.
 `$2` and `\2` refer to the second, and so on, except there is no `\10`


### PR DESCRIPTION
The documentation previously claimed that the trivial option `T'
disabled searching for regex patterns, only searching for exact
strings. What it is supposed to do, as per what PCRE defines, is
remove backreferences and special characters in the replacement
string.

Ticket: CFE-2850
Changelog: Title