### PR TITLE
Swap common-body-attributes-include with See also xref

### DIFF
--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -442,6 +442,8 @@ Here are the built-in `report_data_select` bodies `default_data_select_host()` a
 
 [%CFEngine_include_snippet(controls/reports.cf, .+default_data_select_policy_hub, \})%]
 
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
+
 **History:** Introduced in Enterprise 3.5.0
 
 #### metatags_exclude

--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -181,7 +181,7 @@ as a non-privileged user inside an isolated directory tree.
     }
 ```
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### useshell
 

--- a/reference/promise-types/databases.markdown
+++ b/reference/promise-types/databases.markdown
@@ -157,7 +157,7 @@ a hierarchy of depth 1.
 
 **Type:** `body database_server`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### db_server_owner
 

--- a/reference/promise-types/edit_line.markdown
+++ b/reference/promise-types/edit_line.markdown
@@ -273,7 +273,7 @@ and `select_end` regular expressions. If the beginning and ending regular
 expressions match more than one region only the first region will be
 selected for editing.
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### include_start_delimiter
 

--- a/reference/promise-types/edit_line/delete_lines.markdown
+++ b/reference/promise-types/edit_line/delete_lines.markdown
@@ -44,7 +44,7 @@ promise.
 
 **Type:** `body delete_select`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### delete_if_startwith_from_list
 

--- a/reference/promise-types/edit_line/field_edits.markdown
+++ b/reference/promise-types/edit_line/field_edits.markdown
@@ -115,7 +115,7 @@ ordering the items within them.
      }
 ```
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### allow_blank_fields
 

--- a/reference/promise-types/edit_line/insert_lines.markdown
+++ b/reference/promise-types/edit_line/insert_lines.markdown
@@ -204,7 +204,7 @@ file:
 
 **Type:** `body insert_select`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### insert_if_startwith_from_list
 
@@ -360,13 +360,7 @@ found in the secondary file, it is inserted into the file being edited.
 
 **Type:** `body location`
 
-**See Also:**
-[`location` bodies in the standard library](reference-standard-library-files.html#location-bodies)
-[`start` location body in the standard library](reference-standard-library-files.html#location-bodies)
-[`before(srt)` location body in the standard library](reference-standard-library-files.html#before)
-[`after(srt)` location body in the standard library](reference-standard-library-files.html#after)
-
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes], [`location` bodies in the standard library](reference-standard-library-files.html#location-bodies), [`start` location body in the standard library](reference-standard-library-files.html#location-bodies), [`before(srt)` location body in the standard library](reference-standard-library-files.html#before), [`after(srt)` location body in the standard library](reference-standard-library-files.html#after)
 
 #### before_after
 

--- a/reference/promise-types/edit_line/replace_patterns.markdown
+++ b/reference/promise-types/edit_line/replace_patterns.markdown
@@ -49,7 +49,7 @@ pattern will match.
 
 **Type:** `body replace_with`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### occurrences
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -295,7 +295,7 @@ body perms null_perms_body {
 }
 ```
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### aces
 
@@ -617,7 +617,7 @@ that do not have a clear inheritance policy.
 
 **Type:** `body changes`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### hash
 
@@ -739,7 +739,7 @@ The copy_from body specifies the details for making remote copies.
 are re-used. Currently connection caching is done per pass in each bundle
 activation.
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### source
 
@@ -900,7 +900,7 @@ body copy_from example
 }
 ```
 
-**See also:** [`default_repository` in ```body agent control```][cf-agent#default_repository], [`edit_backup` in ```body edit_defaults```][files#edit_backup]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes], [`default_repository` in ```body agent control```][cf-agent#default_repository], [`edit_backup` in ```body edit_defaults```][files#edit_backup]
 
 #### encrypt
 
@@ -1401,7 +1401,7 @@ comparison or linking operations).
 
 **Type:** `body delete`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### dirlinks
 
@@ -1506,7 +1506,7 @@ present. If there is no `delete` body then files (and directories) are
 
 **Type:** `body depth_search`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### depth
 
@@ -1659,7 +1659,7 @@ devices
 
 **Type:** `body edit_defaults`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### edit_backup
 
@@ -2036,7 +2036,7 @@ bundle agent example
 
 **Type:** `body file_select`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### leaf_name
 
@@ -2452,7 +2452,7 @@ specifying `fifo` in `file_type`.
 
 **Type:** `body link_from`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### copy_patterns
 
@@ -2732,7 +2732,7 @@ separator.
 
 **Type:** `body perms`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### bsdflags
 
@@ -2866,7 +2866,7 @@ This is ignored on Windows, as the permission model uses ACLs.
 
 **Type:** `body rename`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### disable
 

--- a/reference/promise-types/guest_environments.markdown
+++ b/reference/promise-types/guest_environments.markdown
@@ -94,7 +94,7 @@ This attribute is required.
 
 **Type:** `body environment_interface`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### env_addresses
 
@@ -182,7 +182,7 @@ identifier used as 'promiser' by the virtualization manager.
 
 **Type:** `body environment_resources`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### env_cpus
 

--- a/reference/promise-types/measurements.markdown
+++ b/reference/promise-types/measurements.markdown
@@ -217,7 +217,7 @@ This is an arbitrary string used in documentation only.
 
 **Type:** `body match_value`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### select_line_matching
 

--- a/reference/promise-types/packages-deprecated.markdown
+++ b/reference/promise-types/packages-deprecated.markdown
@@ -265,7 +265,7 @@ packages:
 
 **Type:** `body package_method`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### package_add_command
 

--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -205,7 +205,7 @@ platform dependent, see
 and Common Control. The name of the body is expected to be the same as the name
 of the package module inside `/var/cfengine/modules/packages`.
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### default_options
 

--- a/reference/promise-types/processes.markdown
+++ b/reference/promise-types/processes.markdown
@@ -99,7 +99,7 @@ promise together with that class.
 
 **Type:** `body process_count`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### in_range_define
 
@@ -168,7 +168,7 @@ failure to be kept.
 
 **Type:** `body process_select`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### command
 

--- a/reference/promise-types/reports.markdown
+++ b/reference/promise-types/reports.markdown
@@ -91,7 +91,7 @@ and has no effect. Deprecated in CFEngine 3.4.
 
 **Type:** `body printfile`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### file_to_print
 

--- a/reference/promise-types/services.markdown
+++ b/reference/promise-types/services.markdown
@@ -302,12 +302,12 @@ services:
 
 **Type:** `body service_method`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
-
 `service_method` bodies have access to `$(this.promiser)` (the promised service)
 and `$(this.service_policy)` (the policy state the service should have).
 
 **Notes:** `service_bundle` is not used when `service_type` is ```windows```.
+
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### service_args
 

--- a/reference/promise-types/storage.markdown
+++ b/reference/promise-types/storage.markdown
@@ -56,7 +56,7 @@ Storage promises refer to disks and filesystem properties.
 
 **Type:** `body mount`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### edit_fstab
 
@@ -183,7 +183,7 @@ options must be legal options for the system mount commands.
 
 **Type:** `body volume`
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### check_foreign
 

--- a/reference/promise-types/users.markdown
+++ b/reference/promise-types/users.markdown
@@ -205,7 +205,7 @@ that contains information about a user's password.
     }
 ```
 
-[%CFEngine_include_markdown(common-body-attributes-include.markdown)%]
+**See also:** [Common Body Attributes][Promise Types and Attributes#Common Body Attributes]
 
 #### format
 


### PR DESCRIPTION
The thought is that this will greatly improve readability for promise body attributes.