### PR TITLE
CFE-2915 Align example in docs with bodies that exist in the stdlib

### DIFF
--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1473,17 +1473,17 @@ object.
 
        "/home/mark/tmp/testcopy"
 
-         delete => tidyfiles,
+         delete => tidy,
          file_select => changed_within_1_year,
          depth_search => recurse("inf");
 
        # Now delete the parent.
 
        "/home/mark/tmp/testcopy"
-         delete => tidyfiles;
+         delete => tidy;
      }
 
-     body delete tidyfiles
+     body delete tidy
      {
      dirlinks => "delete";
      rmdirs   => "true";


### PR DESCRIPTION
While the example is technically correct, using the body name from the stdlib will encourage use of existing bodies instead of duplicating them as someone trying to copy/paste will receive a duplicate definition of body error.