### PR TITLE
CFE-2915 Align example in docs with bodies that exist in the stdlib

### DIFF
--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1460,41 +1460,9 @@ recursive deletion
      }
 ```
 
-Note the parent directory of a search is not deleted in recursive
-deletions. You must code a separate promise to delete the single parent
-object.
-
-```cf3
-     bundle agent cleanup
-     {
-     files:
-
-       # This will not delete the parent
-
-       "/home/mark/tmp/testcopy"
-
-         delete => tidy,
-         file_select => changed_within_1_year,
-         depth_search => recurse("inf");
-
-       # Now delete the parent.
-
-       "/home/mark/tmp/testcopy"
-         delete => tidy;
-     }
-
-     body delete tidy
-     {
-     dirlinks => "delete";
-     rmdirs   => "true";
-     }
-
-     body file_select changed_within_1_year
-     {
-     mtime     => irange(ago(1,0,0,0,0,0),now);
-     file_result => "mtime";
-     }
-```
+Note the parent directory of a search is not deleted in recursive deletions. You
+must code a separate promise to delete the single parent object. For an example
+see [`bundle agent rm_rf_depth` in the standard library][lib/bundles.cf#rm_rf_depth].
 
 **Default value** (only if body is present): `rmdirs = true`
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1473,17 +1473,17 @@ object.
 
        "/home/mark/tmp/testcopy"
 
-         delete => tidyfiles,
+         delete => tidy,
          file_select => changed_within_1_year,
          depth_search => recurse("inf");
 
        # Now delete the parent.
 
        "/home/mark/tmp/testcopy"
-         delete => tidyfiles;
+         delete => tidy;
      }
 
-     body delete tidyfiles
+     body delete tidy
      {
      dirlinks => "delete";
      rmdirs   => "true";


### PR DESCRIPTION
While the example is technically correct, using the body name from the stdlib
will encourage use of existing bodies instead of duplicating them as someone
trying to copy/paste will receive a duplicate definition of body error.

(cherry picked from commit fa0aecf34963189adfeefc9860d80fb1ee7d5278)