### PR TITLE
CFE-2928 Clarify behavior of module protocol extensions

### DIFF
--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -385,7 +385,7 @@ promises. Such a module may be written in any language.
 This attribute determines whether or not to expect the CFEngine module protocol. If true, the module protocol is supported for this command:
 
 * lines which begin with a `^` are protocol extensions
-  * `^context=xyz` sets the module context to `xyz` instead of the default
+  * `^context=xyz` sets the module context to `xyz` instead of the default for any following definitions
   * `^meta=a,b,c` sets the class and variable tags for any following definitions to `a`, `b`, and `c`
 * lines which begin with a `+` are treated as classes to be defined (like -D). **NOTE:** classes are defined with the [`namespace` scope][Classes and Decisions].
 * lines which begin with a `-` are treated as classes to be undefined (like -N)
@@ -399,7 +399,9 @@ module, unless the `^context` extension is used.
 
 **NOTE**: All variables and classes defined by the module protocol are defined
 in the ```default``` namespace. It is not possible to define variables and
-classes in any other namespace.
+classes in any other namespace. Protocol extensions ( lines that start with `^`
+) apply until they are explicitly reset, or until the end of the modules
+execution.
 
 All the variables and classes will have at least the tag
 `source=module` in addition to any tags you may set.


### PR DESCRIPTION
Module protocol extensions (lines that start with ^) apply until the end of the
module execution unless they are explicitly set to something else.

(cherry picked from commit 89c813a6e1525c41fc55f28e3469bc86893a0209)