### PR TITLE
[3.12.x] Remove an old exception in hard classes usable in augments

### DIFF
--- a/reference/language-concepts/augments.markdown
+++ b/reference/language-concepts/augments.markdown
@@ -88,8 +88,7 @@ if they match as a class name or a regular expression. Thus:
 
 results in `my_always` being always defined. `my_other_apache` will be defined
 if the classes `server3` or `server4` are defined, or if any class starting
-with `debian` is defined. You can use any [**hard** classes][Classes and Decisions]
-with the exception of `am_policy_hub` and `policy_server`.
+with `debian` is defined. You can use any [**hard** classes][Classes and Decisions].
 
 You can see the list of classes thus defined through `def.json` in the output
 of `cf-promises --show-classes` (see [Components and Common Control][]). They


### PR DESCRIPTION
cfengine/core@5214d9347 changed the order in which things are
evaluated so now even the `am_policy_hub` and `policy_server`
hard classes can be used in augments.

Ticket: CFE-2941
(cherry picked from commit d3d1a1534c600f00fd6498b4ecbcc755fa7aa04f)