### PR TITLE
CFE-2853 Note that cf-execd and cf-serverd respond to SIGHUP

### DIFF
--- a/reference/components/cf-execd.markdown
+++ b/reference/components/cf-execd.markdown
@@ -18,6 +18,12 @@ network.
 `cf-execd` keeps the promises made in `common` bundles, and is affected by
 `common` and `executor` control bodies.
 
+**Note:** This daemon reloads it's config when the SIGHUP signal is received.
+
+**History:**
+
+- SIGHUP behavior added in 3.7.0
+
 ## Command reference ##
 
 [%CFEngine_include_snippet(cf-execd.help, [\s]*--[a-z], ^$)%]

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -18,6 +18,12 @@ requests.
 `cf-serverd` keeps the promises made in `common` and `server` bundles, and is
 affected by `common` and `server` control bodies.
 
+**Note:** This daemon reloads it's config when the SIGHUP signal is received.
+
+**History:**
+
+- SIGHUP behavior added in 3.7.0
+
 ## Command reference ##
 
 [%CFEngine_include_snippet(cf-serverd.help, [\s]*--[a-z], ^$)%]


### PR DESCRIPTION
This behavior was added in 3.7.0 as part of CFE-1698