### PR TITLE
Fix note about regular expression for bundlesmatching being unanchored

### DIFF
--- a/reference/functions/bundlesmatching.markdown
+++ b/reference/functions/bundlesmatching.markdown
@@ -11,8 +11,8 @@ tags: [reference, utility functions, functions, bundlesmatching]
 tags given. Both bundlename and tags are regular expressions. `name` is
 required, tags are optional.
 
-This function searches for the given [unanchored][unanchored] `name` and
-`tag1, `tag2`,... regular expression in the list of currently defined bundles.
+This function searches for the given [anchored][anchored] `name` and `tag1`,
+`tag2`, ... regular expression in the list of currently defined bundles.
 
 Every bundle is prefixed with the namespace, usually `default:`.
 
@@ -28,7 +28,6 @@ accidental or intentional running of unwanted bundles.
 [%CFEngine_function_attributes(name, tag1, tag2, ...)%]
 
 **Example:**
-
 
 [%CFEngine_include_snippet(bundlesmatching.cf, #\+begin_src cfengine3, .*end_src)%]
 


### PR DESCRIPTION
It's really anchored.