### PR TITLE
Replace bundle edit_line with edit_line

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -1041,9 +1041,9 @@ owned by a privileged user.
 #### select_end_match_eof
 
 **Description:** When `select_end_match_eof` is set to true `select_end` will consider end of file as the end region if it is unable to match
-the end pattern. For more details see [`edit_line`][bundle edit_line] promise.
+the end pattern. For more details see [`edit_line`][edit_line] promise.
 
-**Note:** [bundle edit_line select_end_match_eof][bundle edit_line#select_end_match_eof] can override this setting at the individual promise level.
+**Note:** [edit_line select_end_match_eof][edit_line#select_end_match_eof] can override this setting at the individual promise level.
 
 **Type:** [`boolean`][boolean]
 

--- a/reference/language-concepts/normal-ordering.markdown
+++ b/reference/language-concepts/normal-ordering.markdown
@@ -125,7 +125,7 @@ following, converging towards a final state:
     databases
     reports
 
-Within [`edit_line` bundles in files promises][bundle edit_line],
+Within [`edit_line` bundles in files promises][edit_line],
 the normal ordering is:
 
     meta

--- a/reference/masterfiles-policy-framework/lib-files.markdown
+++ b/reference/masterfiles-policy-framework/lib-files.markdown
@@ -6,7 +6,7 @@ sorting: 160
 tags: [reference, standard library, files, MPF]
 ---
 
-See the [`files` promises][files] and [`edit_line` bundles][bundle edit_line]
+See the [`files` promises][files] and [`edit_line` bundles][edit_line]
 documentation for a comprehensive reference on
 the bundles, body types, and attributes used here.
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1922,7 +1922,7 @@ deleted (that is, it "falls off the end" of the rotation).
 
 ### edit_line
 
-**Type:** [`bundle edit_line`][bundle edit_line]
+**Type:** [`edit_line`][edit_line]
 
 ### edit_template
 

--- a/reference/promise-types/files/edit_line.markdown
+++ b/reference/promise-types/files/edit_line.markdown
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: bundle edit_line
+title: edit_line
 published: true
-tags: [reference, bundle agent, bundle edit_line, files promises, file editing]
+tags: [reference, bundle agent, edit_line, files promises, file editing]
 ---
 
 Line based editing is a simple model for editing files. Before XML, and

--- a/reference/promise-types/files/edit_line/delete_lines.markdown
+++ b/reference/promise-types/files/edit_line/delete_lines.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: delete_lines
 published: true
-tags: [reference, bundle agent, bundle edit_line, files promises, file editing, delete_lines]
+tags: [reference, bundle agent, edit_line, files promises, file editing, delete_lines]
 ---
 
 This promise assures that certain lines exactly matching regular

--- a/reference/promise-types/files/edit_line/field_edits.markdown
+++ b/reference/promise-types/files/edit_line/field_edits.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: field_edits
 published: true
-tags: [reference, bundle agent, bundle edit_line, files promises, file editing, field_edits]
+tags: [reference, bundle agent, edit_line, files promises, file editing, field_edits]
 ---
 
 Certain types of text files are tabular in nature, with field separators (e.g.

--- a/reference/promise-types/files/edit_line/insert_lines.markdown
+++ b/reference/promise-types/files/edit_line/insert_lines.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: insert_lines
 published: true
-tags: [reference, bundle agent, bundle edit_line, files promises, file editing, insert_lines]
+tags: [reference, bundle agent, edit_line, files promises, file editing, insert_lines]
 ---
 
 This promise type is part of the line-editing model. It inserts lines into

--- a/reference/promise-types/files/edit_line/replace_patterns.markdown
+++ b/reference/promise-types/files/edit_line/replace_patterns.markdown
@@ -2,7 +2,7 @@
 layout: default
 title: replace_patterns
 published: true
-tags: [reference, bundle agent, bundle edit_line, files promises, file editing]
+tags: [reference, bundle agent, edit_line, files promises, file editing]
 ---
 
 This promise refers to arbitrary text patterns in a file. The pattern is


### PR DESCRIPTION
This change renames the bundle edit_line page to edit_line as well as associated
references. It brings the page in line with other page titles.