### PR TITLE
Fix documentation for audit in action bodies

### DIFF
--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -411,26 +411,8 @@ no action and is kept for backward compatibility.
 
 #### audit
 
-**Description:** A true/false switch for detailed audit records of a promise.
-
-If this is set, CFEngine will perform auditing on this specific promise. This
-means that all details surrounding the verification of the current promise will
-be recorded in the audit database.
-
-**Type:** [`boolean`][boolean]
-
-**Default value:** false
-
-**Example:**
-
-```cf3
-     body action example
-     {
-     # ...
-
-     audit => "true";
-     }
-```
+**Deprecated:** This menu option policy is deprecated as of 3.6.0. It performs
+no action and is kept for backward compatibility.
 
 #### background
 


### PR DESCRIPTION
This attribute was removed for 3.6.0 as part of a massive cleanup. Related
attributes that were removed at the same time include value_kept, value_notkept,
and value_repaired.

They were intended to allow the encoding of business value into the policy, but
were removed to improve maintainability, and because at the time, there was a
low level of utilization, finally, similar data can be tracked in other metadata
like meta tags, comments, and promisees/stakeholders.

(cherry picked from commit 40268b3b42ee9fcdad9021133dbfd43431741411)