### PR TITLE
ENT-4343 Clarify documentation for minimum hub memory 3.7

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
@@ -129,9 +129,9 @@ agents).
 
 ### Memory
 
-Minimum 2GB memory, but not lower than **8MB per bootstrapped
-agent**. This means that, for a server with 5000 hosts, you should
-have at least 40GB of memory.
+Minimum 3GB memory (can run with less for small testing/lab environments), but
+not lower than **8MB per bootstrapped agent**. This means that, for a server
+with 5000 hosts, you should have at least 40GB of memory.
 
 ### Disk sizing and partitioning
 


### PR DESCRIPTION
The minimum recommended amount of memory for a customized PostgreSQL
configuration is 3 GB, below 2GB we warn about not being able to use large
buffers and the default PostgreSQL configuration is used.

Changelog: None
(cherry picked from commit 108c5b45b1d4b855189b5da438d7a1f5fd51abd2)