### PR TITLE
CFE-2965 Fix link to sys.uqhost on same page

### DIFF
--- a/reference/special-variables/sys.markdown
+++ b/reference/special-variables/sys.markdown
@@ -222,7 +222,7 @@ properly, the domain name must be defined.
     # fqhost = host.example.org
 ```
 
-**See also:** [`sys.uqhost`][sys#sys.uqhost]
+**See also:** [`sys.uqhost`][sys.uqhost]
 
 ### sys.fstab
 


### PR DESCRIPTION
sys.fqhost links to sys.uqhost, but the link is broken. Probably because it
falls later on the same page and it isn't properly resolved. We have had to do
similar for sys.policy_entry_dirname and sys.policy_entry_filename in the past.

This change alters the link target to use a reference from _references.md in the
documentation-generator repository.

(cherry picked from commit 80e98004d5628f42759d98a16dd9a77aff622168)