### PR TITLE
CFE-2995 Crossreferences for cf-runagent, resource_type, and cfruncommand

### DIFF
--- a/reference/components/cf-runagent.markdown
+++ b/reference/components/cf-runagent.markdown
@@ -19,6 +19,8 @@ which hosts `cf-agent` will be started, and classes that the user requests
 
 [%CFEngine_include_snippet(cf-runagent.help, [\s]*--[a-z], ^$)%]
 
+**See also**: [bundle resource_type in server access promises][access#resource_type], [cfruncommand in body server control][cf-serverd#cfruncommand]
+
 ## Control Promises
 
 Settings describing the details of the fixed behavioral promises made by

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -280,6 +280,7 @@ shell command at your own risk.
     }
 ```
 
+**See also**: [cf-runagent][cf-runagent], [bundle resource_type in server access promises][access#resource_type]
 
 ### call_collect_interval
 

--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -707,6 +707,8 @@ access:
 }
 ```
 
+**See also**: [--remote-bundles option for cf-runagent][cf-runagent], [cfruncommand in body server control][cf-serverd#cfruncommand]
+
 **History:**
 
 - ```bundle``` `resource_type` added in 3.9.0


### PR DESCRIPTION
When your looking at one of these things, you might need to know about
the other.

Changelog: None