### PR TITLE
CFE-3033 Document correct expected value and provenance of sys.policy_hub (3.10)

### DIFF
--- a/reference/special-variables/sys.markdown
+++ b/reference/special-variables/sys.markdown
@@ -1173,10 +1173,9 @@ The name of the directory where CFEngine saves the daemon pid files.
 
 ### sys.policy_hub
 
-Hostname or IP of the machine acting as the policy server. This value is set
-during bootstrap and is stored in ```$(sys.workdir)/policy_server.dat```. If
-```$(sys.workdir)/policy_server.dat``` does not exist or is empty, then the
-variable is undefined.
+IP of the machine acting as the policy server.
+
+```$(sys.workdir)/policy_server.dat``` stores bootstrap information. If bootstrapped to a hostname, the value is the current IP the hostname resolves to. If bootstrapped to an IP, the value is the stored IP. The variable is undefined if ```$(sys.workdir)/policy_server.dat``` does not exist or is empty.
 
 ```cf3
     reports:
@@ -1184,17 +1183,21 @@ variable is undefined.
      "Policy hub is $(sys.policy_hub)";
 ```
 
-**History:** Was introduced in version 3.1.0b1,Enterprise 2.0.0b1 (2010).
-Available in Community since 3.2.0
+**History:**
+
+- Introduced in version 3.1.0b1,Enterprise 2.0.0b1 (2010).
+- Available in Community since 3.2.0
 
 ### sys.policy_hub_port
 
 The default port which ```cf-agent``` will use by default when making outbound
 connections to ```cf-serverd```. This defaults to ```5308``` but can be
-overridden based on the data in ```$(sys.workdir)/policy_server.dat``` which is
-created during bootstrap.
+overridden based on the data provided during bootstrap stored in
+```$(sys.workdir)/policy_server.dat```.
 
-**History:** Introduced in version 3.10.0 (2016).
+**History:**
+
+- Introduced in version 3.10.0 (2016).
 
 ### sys.release
 


### PR DESCRIPTION
Changelog: None

This change corrects the documented expected value of sys.policy_hub, fixes some
small formatting issues and removes the duplicate entry for sys.policy_hub in
the docs.

(manually picked from commit fb853c7)