### PR TITLE
Fix tip in lsdir documentation (3.10)

### DIFF
--- a/reference/functions/lsdir.markdown
+++ b/reference/functions/lsdir.markdown
@@ -25,7 +25,7 @@ Output:
 **Tips:**
 
 * Filter out the current (```.```) and parent (```..```)directories with a
-  negative look ahead. ```lsdir( "/tmp", "^(?!(\.|\.\.)).*", false )```.
+  negative look ahead. ```lsdir( "/tmp", "^(?!(\.$|\.\.$)).*", false )```.
 
 **Notes:**
 


### PR DESCRIPTION
The previous tip would actually omit all files whose names start with a period, not just "." and ".."

(cherry picked from commit 3f4819e2f5da20b140c1539ea9eebb94430ae87a)