### PR TITLE
CFE-3040: Fix process promise example (3.10)

### DIFF
--- a/reference/promise-types/processes.markdown
+++ b/reference/promise-types/processes.markdown
@@ -33,7 +33,7 @@ bundle agent example
 {
   processes:
       "splunkd"
-        process_owner => { "root" },
+        process_select => by_owner( "root" ),
         handle => "example_splunk_stop_gracefully",
         process_stop => "/opt/splunkforwarder/bin/splunk stop",
         comment => "Find splunkd processes owned by root. Stop it gracefully


### PR DESCRIPTION
process_owner is not an attribute, it's part of the process_select body.

Ticket: CFE-3040
Changelog: None