### PR TITLE
Fix typos and update the page on Content Driven Policies 

### DIFF
--- a/guide/special-topics/content-driven-policy.markdown
+++ b/guide/special-topics/content-driven-policy.markdown
@@ -84,15 +84,15 @@ like the following.
 # How do Content-Driven Policies work in detail?
 
 
-The text files inmasterfiles/cdp_inputs/(e.g. ‘registry_list.txt’) are parsed
-into CFEngine lists by correspondingcdp_*files inmasterfiles/(e.g.
+The text files in masterfiles/cdp_inputs/(e.g. ‘registry_list.txt’) are parsed
+into CFEngine lists by corresponding cdp_*files in masterfiles/(e.g.
 ‘cdp_registry.cf’). It is the latter set of files that actually implement the
 policies in the text files.
 
 The Knowledge Map contains reports specifically designed to match the
 Content-Driven Policies.
 
-# Can I make my own Content-Diven Policies?
+# Can I make my own Content-Driven Policies?
 
 
 It is possible to mimic the structure of the existing Content-Driven Policies to


### PR DESCRIPTION
Hello,

The page on Content-Driven Policy was added 3 years ago, and needs to be updated.

I'm opening this pull request to initiate that.  I've fixed a few obvious typos.

Here is what's left to fix:

1. Fix reference to cdp_inputs which is no longer present in "masterfiles".

Git history shows:

```
[d511695@cfedevdevlabc02:~/git/masterfiles] master+ 2s 141 ± git log -i -S  cdp_inputs
commit f9e45090dcf9220eac70f67b8d50d7317fd864ca
Author: Mikhail Gusarov <mikhail.gusarov@cfengine.com>
Date:   Tue Aug 9 10:50:33 2011 +0000

    Move Nova-specific masterfiles to Nova

commit f3b877d98978be5684c5dad92ca87480a69b1b77
Author: Mark Burgess <mark@cfengine.com>
Date:   Wed Jun 29 20:32:31 2011 +0000

    Put CDP back

commit 4d05f6154098624bc042fe02ff7a9d25b7a16b44
Author: Mark Burgess <mark@cfengine.com>
Date:   Wed Jun 29 17:54:40 2011 +0000

    Move cdp back out

commit 6def3cbf51dd41f0c3a67614714dcb097357c9a3
Author: Mark Burgess <mark@cfengine.com>
Date:   Wed Jun 29 13:27:50 2011 +0000

    Moving a generic base for community and Nova/Constellation to core for all users
[d511695@cfedevdevlabc02:~/git/masterfiles] master+ ±
```

Where is cdp_inputs now?

2. Remove reference to Knowledge Map reports -- AFAIK, the "Knowledge Map" feature was removed from CFEngine Nova a few years back.

3. Review the remaining content -- does anything else need to be updated?