### PR TITLE
Remove reference to Redis cache from Enterprise documentation

### DIFF
--- a/guide/faq/enterprise-report-collection.markdown
+++ b/guide/faq/enterprise-report-collection.markdown
@@ -3,7 +3,7 @@ layout: default
 title: Enterprise report collection
 published: true
 sorting: 90
-tags: [ FAQ, Enterprise, reporting, health, cf-hub, cf-consumer, redis-server  ]
+tags: [ FAQ, Enterprise, reporting, health, cf-hub ]
 ---
 
 ## What are reports?
@@ -229,40 +229,3 @@ and collect only the output from the most recent run.
 **Note:** The Enterprise hub automatically schedules rebase queries if it has
 been unable to collect from a given candidate for `client_history_timeout`
 hours.
-
-If a manual rebase collection does not restore reporting functionality for a
-host continue on to restarting the report collection components.
-
-### Restart report collection components
-
-Sometimes it is necessary to restart the report collection subsystem in order to
-re-synchronize the caching layer with the database. To restart the report
-collection subsystem simply kill `cf-hub`, `cf-consumer`, `redis-server`, and
-run the update policy.
-
-For systemd hosts this can be accomplished by simply restarting the `cf-hub`
-service. The related component restarts are automatically handled via the unit
-dependencies:
-
-```console
-[root@hub ~]# systemctl restart cf-hub
-```
-
-For non-systemd hosts:
-
-```console
-[root@hub ~]# pkill cf-consumer
-[root@hub ~]# pkill cf-hub
-[root@hub ~]# pkill redis-server
-[root@hub ~]# cf-agent -KIf update.cf
-    info: Executing 'no timeout' ... '/var/cfengine/bin/redis-server /var/cfengine/config/redis.conf'
-    info: Command related to promiser '/var/cfengine/bin/redis-server /var/cfengine/config/redis.conf' returned code defined as promise kept 0
-    info: Completed execution of '/var/cfengine/bin/redis-server /var/cfengine/config/redis.conf'
-    info: Executing 'no timeout' ... '/var/cfengine/bin/cf-consumer'
-    info: Command related to promiser '/var/cfengine/bin/cf-consumer' returned code defined as promise kept 0
-    info: Completed execution of '/var/cfengine/bin/cf-consumer'
-    info: Executing 'no timeout' ... '"/var/cfengine/bin/cf-hub"'
-    info: Command related to promiser '"/var/cfengine/bin/cf-hub"' returned code defined as promise kept 0
-    info: Completed execution of '"/var/cfengine/bin/cf-hub"'
-```
-

--- a/guide/faq/enterprise-report-collection.markdown
+++ b/guide/faq/enterprise-report-collection.markdown
@@ -134,10 +134,6 @@ of oxygen, where oxygen is access to latest policy) to indicate a health issue.
 
 **See Also**: `Enterprise API Reference`, `Enterprise API Examples`, [Enterprise Settings][Settings#preferences]
 
-## Are there supposed to be so many cf-consumer processes?
-
-Yes, `cf-consumer` will spawn 25 threads for report collection processing.
-
 ## Which hosts are pending trust revocation?
 
 When a host is removed using the delete API its key is placed in a queue for

--- a/guide/introduction/directory-structure.markdown
+++ b/guide/introduction/directory-structure.markdown
@@ -38,7 +38,6 @@ The CFEngine application is fully contained within the /var/cfengine directory t
 * `cf-monitord`: Collects system statistics
 * `cf-serverd`: Provides network services; used to distribute policy and data files
 * `runalerts.sh`: Updates Mission Portal status and activates alert actions (Enterprise only)
-* `cf-consumer`: Responsible for moving collected reports from the redis queue into the postgres database. (CFEngine Enterprise only)
 * `cf-hub`: Responsible for collecting reports from remote agents. (CFEngine Enterprise only)
 
 See Also: [CFEngine Component Applications and Daemons][Introduction and System Overview#CFEngine Component Applications and Daemons]
@@ -243,14 +242,6 @@ IP address of the policy server
 * `bin/psql`
 * `bin/reindexdb`
 * `bin/vacuumdb`
-
-## Redis in /var/cfengine/bin ##
-
-* `bin/redis-benchmark`
-* `bin/redis-check-aof`
-* `bin/redis-check-dump`
-* `bin/redis-cli`
-* `bin/redis-server`
 
 
 ## Not Verified ##

--- a/guide/introduction/directory-structure.markdown
+++ b/guide/introduction/directory-structure.markdown
@@ -178,7 +178,6 @@ default. Other checks can be instrumented by setting a
 The CFEngine components keep their current process identifier number in
 `pid files' in the work directory.
 
-* `cf-consumer.pid`
 * `cf-execd.pid`
 * `cf-hub.pid`
 * `cf-monitord.pid`


### PR DESCRIPTION
Redis cache was refactored out in 3.12 LTS.