### PR TITLE
CFE-3225/3.10: Added note indicating interface names are canonified in some sys vars

### DIFF
--- a/reference/special-variables/sys.markdown
+++ b/reference/special-variables/sys.markdown
@@ -248,6 +248,8 @@ This contains the MAC address of the named interface. For example:
         "Tell me $(sys.hardware_mac[eth0])";
 ```
 
+**Note:** The *keys* in this array are [canonified][canonify]. For example, the entry for `wlan0.1` would be found under the `wlan0_1` key. Ref: [CFE-3224](https://tracker.mender.io/browse/CFE-3224).
+
 **History:** Was introduced in 3.3.0, Enterprise 2.2.0 (2011)
 
 ### sys.host
@@ -970,12 +972,13 @@ e.g. `$(sys.ip2iface[1.2.3.4])`.
     # sys.ip2iface[10.12.7.254] = xr1
 ```
 
-**Note**:
+**Notes:**
 
-The list of addresses may be acquired with
-`getindices("sys.ip2iface")` (or from any of the other associative
-arrays). Only those interfaces which are marked as "up" and have an IP
-address will have entries.
+- The list of addresses may be acquired with `getindices("sys.ip2iface")` (or
+from any of the other associative arrays). Only those interfaces which are
+marked as "up" and have an IP address will have entries.
+
+- The *values* in this array are [canonified][canonify]. For example, the entry for `wlan0.1` would be `wlan0_1`. Ref: [CFE-3224](https://tracker.mender.io/browse/CFE-3224).
 
 **History:** Was introduced in 3.9.
 
@@ -1024,13 +1027,19 @@ are marked as "up" and have an IP address will be listed.
 The first octet of the IPv4 address of the system interface named as the
 associative array index, e.g. `$(ipv4_1[le0])` or `$(ipv4_1[xr1])`.
 
+**Note:** The *keys* in this array are [canonified][canonify]. For example, the entry for `wlan0.1` would be found under the `wlan0_1` key. Ref: [CFE-3224](https://tracker.mender.io/browse/CFE-3224).
+
 ### sys.ipv4_2[interface_name]
 
 The first two octets of the IPv4 address of the system interface named as the associative array index, e.g. `$(ipv4_2[le0])` or `$(ipv4_2[xr1])`.
 
+**Note:** The *keys* in this array are [canonified][canonify]. For example, the entry for `wlan0.1` would be found under the `wlan0_1` key. Ref: [CFE-3224](https://tracker.mender.io/browse/CFE-3224).
+
 ### sys.ipv4_3[interface_name]
 
 The first three octets of the IPv4 address of the system interface named as the associative array index, e.g. `$(ipv4_3[le0])` or `$(ipv4_3[xr1])`.
+
+**Note:** The *keys* in this array are [canonified][canonify]. For example, the entry for `wlan0.1` would be found under the `wlan0_1` key. Ref: [CFE-3224](https://tracker.mender.io/browse/CFE-3224).
 
 ### sys.key_digest
 


### PR DESCRIPTION
Ticket: CFE-3225
Changelog: None
(cherry picked from commit 088c00c45ec4e38a90d6e2c2d598b4be068591ff)