### PR TITLE
ENT-4090: Fix/update the HA installation guide

### DIFF
--- a/enterprise-cfengine-guide/high-availability/installation-guide.markdown
+++ b/enterprise-cfengine-guide/high-availability/installation-guide.markdown
@@ -7,20 +7,27 @@ tags: [cfengine enterprise, high availability]
 
 ## Overview ##
 
-This tutorial is describing the installation steps of the **CFEngine High Availability** feature. It is suitable for both upgrading existing CFEngine installations to HA and for installing HA from scratch.
-Before starting installation we strongly recommend reading the CFEngine High Availability overview. More detailed information can be found [here][High Availability].
+This tutorial is describing the installation steps of the **CFEngine High Availability** feature. It
+is suitable for both upgrading existing CFEngine installations to HA and for installing HA from
+scratch. Before starting installation we strongly recommend reading the [CFEngine High Availability
+overview][High Availability].
 
 ## Installation procedure ##
 
-As with most High Availability systems, setting it up requires carefully following a series of steps with dependencies on network components. The setup can therefore be error-prone, so if you are a CFEngine Enterprise customer we recommend that you contact support for assistance if you do not feel 100% comfortable of doing this on your own.
+As with most High Availability systems, setting it up requires carefully following a series of steps
+with dependencies on network components. The setup can therefore be error-prone, so if you are a
+CFEngine Enterprise customer we recommend that you contact support for assistance if you do not feel
+100% comfortable of doing this on your own.
 
-Please also make sure you have a valid license for the passive hub so that it will be able to handle all your CFEngine clients in case of failover.
+Please also make sure you have a valid license for the passive hub so that it will be able to handle
+all your CFEngine clients in case of failover.
 
 ### Hardware configuration and OS pre-configuration steps ###
 
 * CFEngine 3.6.2 (or later) hub package for RHEL6 or CentOS6.
 * We recommend selecting dedicated interface used for PostgreSQL replication and optionally one for heartbeat.
-* We recommend having one shared IP address assigned for interface where MP is accessible (optionally) and one where PostgreSQL replication is configured (mandatory).
+* We recommend having one shared IP address assigned for interface where MP is accessible
+  (optionally) and one where PostgreSQL replication is configured (mandatory).
 * Both active and passive hub machines must be configured so that host names are different.
 * Basic hostname resolution works (hub names can be placed in */etc/hosts* or DNS configured).
 
@@ -29,8 +36,9 @@ Please also make sure you have a valid license for the passive hub so that it wi
 In this tutorial we use the following network configuration:
 
 * Two nodes, one acting as active (node1) and one acting as passive (node2).
-* Optinally a third node (node3) used as a database backup for offsite replication.
-* Each node having three NICs so that eth0 is used for heartbeat, eth1 is used for PostgreSQL replication and eth2 is used for MP and bootstrapping clients.
+* Optionally a third node (node3) used as a database backup for offsite replication.
+* Each node having three NICs so that eth0 is used for the heartbeat, eth1 is used for PostgreSQL
+  replication and eth2 is used for MP and bootstrapping clients.
 * IP addresses configured as follows:
 
 | Node            | eth0         | eth1           | eth2            |
@@ -38,7 +46,7 @@ In this tutorial we use the following network configuration:
 |node1            | 192.168.0.10 | 192.168.10.10  | 192.168.100.10  |
 |node2            | 192.168.0.11 | 192.168.10.11  | 192.168.100.11  |
 |node3 (optional) | ---          | 192.168.10.12  | 192.168.100.12  |
-|cluster shared   | ---          | 192.168.10.100 | 192.168.100.100 |
+|cluster shared   | ---          | ---            | 192.168.100.100 |
 
 Detailed network configuration is shown on the picture below:
 
@@ -47,63 +55,116 @@ Detailed network configuration is shown on the picture below:
 
 ## Install cluster management tools ##
 
-Before you begin you should have corosync (version 1.4.1 or higher) and pacemaker (version 1.1.10-14.el6_5.3 or higher) installed on both nodes. For your convenience we also recommend having pcs installed. Detailed instructions how to install and set up all components are accessible [here](http://clusterlabs.org/) and [here](http://corosync.github.io/corosync/). Please also note that for RHEL 6, additional components might be needed to create the cluster when using the recommendation from Red Hat. One of those components is cman.
+   **On both nodes:**
 
-Once pacemaker and corosync are successfully installed on both nodes please follow steps below to set up it as needed by CFEngine High Availability. Please note that most of those instructions follow the method recommended by the Red Hat High Availability project.
+   ```
+   yum -y install pcs pacemaker cman fence-agents
+   ```
 
-In order to operate cluster, proper fencing must be configured but description how to fence cluster and what mechanism use is out of the scope of this document. For reference please use [following guide](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/High_Availability_Add-On_Administration/s1-fenceconfig-HAAA.html).
+In order to operate cluster, proper fencing must be configured but description how to fence cluster
+and what mechanism use is out of the scope of this document. For reference please use the [Red Hat
+HA fencing guide](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/configuring_the_red_hat_high_availability_add-on_with_pacemaker/ch-fencing-haar).
 
 
-**IMPORTANT:** please carefully follow the indicators describing if the given step should be performed on active, passive or both nodes.
+**IMPORTANT:** please carefully follow the indicators describing if the given step should be
+               performed on the active (node1), the passive (node2) or both nodes.
 
-1. Make sure that the hostnames of all nodes nodes are node1, node2 and node3 respectively. Running the command ```uname -n | tr '[A-Z]' '[a-z]'``` should return the correct node name. Make sure that the DNS or entries in /etc/hosts are updated so that hosts can be accessed using their host names.
+1. Make sure that the hostnames of all nodes nodes are node1 and node2 respectively. Running
+   the command ```uname -n | tr '[A-Z]' '[a-z]'``` should return the correct node name. Make sure that
+   the DNS or entries in /etc/hosts are updated so that hosts can be accessed using their host names.
 
-2. In order to use pcs to manage the cluster, create the user designated to manage the cluster with ```passwd hacluster``` on both cluster nodes.
+2. In order to use *pcs* to manage the cluster, create the *hacluster* user designated to manage the
+   cluster with ```passwd hacluster``` **on both nodes**.
 
-3. Make sure that pcsd demon is started and configure both nodes so that it will be enabled to boot on startup on each node.
+3. Make sure that pcsd demon is started and configure both nodes so that it will be enabled to boot
+   on startup **on both nodes**.
 
-    On RHEL 7:
+   ```
+   service pcsd start
+   chkconfig pcsd on
+   ```
+
+4. Authenticate hacluster user for each node of the cluster. Run the command below **on the node1**:
+
+   ```
+   pcs cluster auth node1 node2 -u hacluster
+   ```
+
+   After entering password, you should see a message similar to one below:
+
+   ```
+   node1: Authorized
+   node2: Authorized
+   ````
+
+5. Create the cluster by running the following command **on the node1**:
+
+   ```
+   pcs cluster setup --name cfcluster node1 node2
+   ```
+
+   This will create the cluster ```cfcluster``` consisting of node1 and node2.
+
+6. Give the cluster time to settle (cca 1 minute) and then start the cluster by running the
+   following command **on the node1**:
+
+   ```
+   pcs cluster start --all
+   ```
+
+   This will start the cluster and all the necessary deamons on both nodes.
+
+7. At this point the cluster should be up and running. Running ```pcs status``` should print
+   something similar to the output below.
+
+   ```
+   Cluster name: cfcluster
+   WARNING: no stonith devices and stonith-enabled is not false
+   Stack: cman
+   Current DC: node2 (version 1.1.18-3.el6-bfe4e80420) - partition with quorum
+   Last updated: Wed Oct 17 12:25:42 2018
+   Last change: Wed Oct 17 12:24:52 2018 by root via crmd on node2
+
+   2 nodes configured
+   0 resources configured
+
+   Online: [ node1 node2 ]
+
+   No resources
+
+
+   Daemon Status:
+     cman: active/disabled
+     corosync: active/disabled
+     pacemaker: active/disabled
+     pcsd: active/enabled
+   ```
+
+8. If you are setting up just a **testing environment without fencing**, you should disable it now
+   (**on the node1**):
+
+   ```
+   pcs property set stonith-enabled=false
+   pcs property set no-quorum-policy=ignore
+   ```
+
+9. Before the PostgreSQL replication is setup, we need to set up a floating IP address that will
+   always point to the active node and configure some basic resource parameters (**on the node1**):
+
+   ```
+   pcs resource defaults resource-stickiness="INFINITY"
+   pcs resource defaults migration-threshold="1"
+   pcs resource create cfvirtip IPaddr2 ip=192.168.100.100 cidr_netmask=24 --group cfengine
+   pcs cluster enable --all node{1,2}
+   ```
+
+10. Verify that the cfvirtip resource is properly configured and running.
+
     ```
-    systemctl start pcsd.service;
-    systemctl enable pcsd.service
+    pcs status
     ```
 
-    On RHEL 6:
-    ```
-    /etc/init.d/pcsd start;
-    chkconfig pcsd on
-    ```
-
-4. Authenticate hacluster user for each node of the cluster. Run the command below only on the **active** node (node1):
-
-    ```
-    pcs cluster auth node1 node2
-    ```
-
-    As the result you should see a message similar to one below:
-
-    ```
-    Username: hacluster
-    Password:
-    node1: Authorized
-    node2: Authorized
-    ````
-
-5. Create the cluster by running the following command on the **active** node (node1):
-
-    ```
-    pcs cluster setup --start --name cfcluster node1 node2
-    ```
-
-    This will create the cluser ```cfcluster``` consisting of node1 and node2.
-
-6. Enable the cluster services to start on boot on both the cluster nodes:
-
-    ```
-    pcs cluster enable --all
-    ```
-
-7. At this point the cluster should be up and running without any resource nor STONITH/fencing configured. Running ```pcs status``` should print something similar to one below.
+    should give something like this:
 
     ```
     Cluster name: cfcluster
@@ -113,251 +174,7 @@ In order to operate cluster, proper fencing must be configured but description h
     Current DC: node1 - partition with quorum
     Version: 1.1.11-97629de
     2 Nodes configured
-    0 Resources configured
-
-    Online: [ node1 node2 ]
-
-    Full list of resources:
-    ```
-
-
-## PostgreSQL configuration ##
-
-**Before starting this make sure that cluster is not running.**
-
-1. Install the CFEngine hub package on both active and passive node.
-2. On the active node (node1) bootstrap the hub to itself so it starts acting as policy server (this step can be skipped if you are upgrading existing installation to High Availability).
-3. Bootstrap the passive node (node2) to the active hub. While bootstrapping, trust between both hubs will be established and keys will be exchanged.
-4. After successfully bootstrapping passive to active, bootstrap the passive node to itself. From now on it will start operate as a hub so that it will be capable of collecting reports and serve policy. Please note that while bootstrapping passive to itself you may see following message:
-
-    ```
-    "R: This host assumes the role of policy server
-    R: Updated local policy from policy server
-    R: Failed to start the server
-    R: Did not start the scheduler
-    R: You are running a hard-coded failsafe. Please use the following command instead.
-        "/var/cfengine/bin/cf-agent" -f /var/cfengine/inputs/update.cf
-    2015-06-29T17:36:24+0000   notice: Bootstrap to '10.100.100.116' completed successfully!"
-    ```
-
-5. Configure PostgreSQL on **active** node:
-   1. Create two directories owned by PostgreSQL user: /var/cfengine/state/pg/data/pg_archive and /var/cfengine/state/pg/tmp
-   2. Modify *postgresql.conf* configuration file
-
-        ```
-        echo "listen_addresses = '*'
-        wal_level = hot_standby
-        max_wal_senders=5
-        wal_keep_segments = 32
-        hot_standby = on
-        restart_after_crash = off
-
-        #not needed but makes failover faster and cluster more stable
-        checkpoint_segments = 8
-        wal_keep_segments = 8
-        archive_mode = on
-        archive_command = 'cp %p /var/cfengine/state/pg/pg_arch/%f'
-        " >> /var/cfengine/state/pg/data/postgresql.conf
-        ```
-
-        **NOTE:** In the above configuration, the *wal_keep_segments* value specifies the minimum number of segments (16 megabytes each) retained in PostgreSQL WAL logs directory in case a standby server needs to fetch them for streaming replication. It should be adjusted to number of clients handled by CFEngine hub and available disk space. In an installation with 1000 clients bootstrapped to the CFEngine hub and assuming passive hub should be able to catch up with the active one after 24 hours break, the value should be set close to 250 (4 GB of additional disk space).
-
-   3. Modify the *pg_hba.conf* configuration file to enable access to PostgreSQL form listed host. Please note that 192.168.10.10, 192.168.10.11 and 192.168.10.12 are IP addresses of node1, node2 and node3 respectively.
-
-        ```
-        echo "host replication all 192.168.10.10/32 trust
-        host replication all 192.168.10.11/32 trust
-        #use one below only in case of having 3rd node used as database backup
-        host replication all 192.168.10.12/32 trust
-        local replication all trust
-        host replication all 127.0.0.1/32 trust
-        host replication all ::1/128 trust
-        " >> /var/cfengine/state/pg/data/pg_hba.conf
-        ```
-
-        **IMPORTANT:** The above configuration allows accessing the hub using the cfpostgres user without any authentication from both cluster nodes. For security reasons we strongly advise to create a replication user in PostgreSQL and protect access using a password or certificate. Furthermore, we advise using ssl-secured replication instead of the unencrypted method described here if the hubs are in an untrusted network.
-
-   4. Create the PostgreSQL archive directory (```mkdir /var/cfengine/state/pg/pg_arch/```) and make the cfpostgres user the owner of it (```chown -R cfpostgres:cfpostgres /var/cfengine/state/pg/pg_arch/```).
-
-        **IMPORTANT:** If the archive directory location is different, make sure to change the archive_command entry in postgresql.conf and the restore_command command described later in this document.
-
-   5. Restart the PostgreSQL server so that the configuration changes take effect.
-
-        ```
-        cd /tmp && su cfpostgres -c "/var/cfengine/bin/pg_ctl -w -D /var/cfengine/state/pg/data stop -m fast"
-        cd /tmp && su cfpostgres -c "/var/cfengine/bin/pg_ctl -w -D /var/cfengine/state/pg/data -l /var/log/postgresql.log start"
-        ```
-
-6. Configure PostgreSQL on the **passive** node:
-   1. Remove the PostgreSQL directory by running `rm -rf /var/cfengine/state/pg/data/*`.
-   2. Do a database backup by running `su cfpostgres -c "cd /tmp && /var/cfengine/bin/pg_basebackup -h node1 -U cfpostgres -D /var/cfengine/state/pg/data -X stream -P"`.
-   3. Change the *recovery.conf* file to indicate that PostgreSQL is running as a hot-standby replica:
-
-        ```
-        echo "standby_mode = 'on'
-        #192.168.10.100 is the shared over cluster IP address of active/master cluster node
-        primary_conninfo = 'host=192.168.10.100 port=5432 user=cfpostgres application_name=node2'
-        #not needed but recommended for faster failover and more stable cluster operations
-        restore_command = 'cp /var/cfengine/state/pg/pg_arch/%f %p'
-        " > /var/cfengine/state/pg/data/recovery.conf
-        ```
-
-    **NOTE:** change host and application_name to point to host names of active and passive nodes respectively.
-
-7.  Start PostgreSQL on the passive node by running the following command:
-
-    ```
-    cd /tmp && su cfpostgres -c "/var/cfengine/bin/pg_ctl -w -D /var/cfengine/state/pg/data -l /var/log/postgresql.log start"
-    ```
-
-
-
-Verify the PostgreSQL status on the passive node by running `echo "select pg_is_in_recovery();" | /var/cfengine/bin/psql cfdb`.
-The command should return `t`, which indicates that the passive node is working in recovery mode.
-
-Verify that the passive node is connected to the active by running the following command on the active node: `echo "select * from pg_stat_replication;" | /var/cfengine/bin/psql cfdb`.
-The command should return one entry indicating that *node1* is connected to the database in streaming replication mode.
-
-
-### CFEngine configuration ###
-
-**Before starting this step make sure that PostgreSQL is running on both active and passive nodes and that the passive node is being replicated.**
-
-1. Create the HA configuration file on both active and passive nodes:
-
-    ```
-    echo "cmp_master: PRI
-    cmp_slave: HS:async,HS:sync,HS:alone
-    cmd: /usr/sbin/crm_attribute -l reboot -n cfpgsql-status -G -q" > /var/cfengine/ha.cfg
-    ```
-
-2. Create the HA JSON configuration file:
-
-    ```
-    echo "{
-    \"192.168.100.10\":
-    {
-     \"sha\": \"c14a17325b9a1bdb0417662806f579e4187247317a9e1739fce772992ee422f6\",
-     \"internal_ip\": \"192.168.100.10\",
-    },
-    \"192.168.100.11\":
-    {
-     \"sha\": \"b492eb4b59541c02a13bd52efe17c6a720e8a43b7c8f8803f3fc85dee7951e4f\",
-     \"internal_ip\": \"192.168.100.11\",
-    }
-    }" > /var/cfengine/masterfiles/cfe_internal/enterprise/ha/ha_info.json
-    ```
-
-    The `internal_ip` attribute is the IP address of the hub (the one you used to bootstrapped itself to) and `sha` is the key of the hub. The `sha` key can be found by running `cf-key -s` the on the respective hub and match that to the `internal_ip`.
-
-3. Modify */var/cfengine/masterfiles/controls/VERSION/def.cf* and */var/cfengine/masterfiles/controls/VERSION/update_def.cf* to enable HA by uncommenting the line `"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";` (also make sure to comment or remove the line `"enable_cfengine_enterprise_hub_ha" expression => "!any";`).
-
-4. Run `cf-agent -f update.cf` to make sure that the new policy is copied from *masterfiles* to *inputs* on the active node first and then on the passive node. From this point on, PostgreSQL will not be managed by CFEngine but it will be left unmanaged until the pgsql cluster resource is properly configured.
-
-
-### Cluster resource configuration ###
-
-1. Configure the shared cluster IP address used for PostgreSQL database replication:
-
-   ```
-   pcs resource create cfvirtip IPaddr2 ip=192.168.10.100 cidr_netmask=24 --group cfengine
-   ```
-
-   This will create a shared IP address at the appropriate interface (where the 192.168.10.x address already exists).
-
-2. Verify that the cfvirtip resource is properly configured and running.
-
-   ```
-   [root@node1] pcs status
-   Cluster name: cfcluster
-   Last updated: Tue Jul  7 09:29:10 2015
-   Last change: Fri Jul  3 08:41:24 2015
-   Stack: cman
-   Current DC: node1 - partition with quorum
-   Version: 1.1.11-97629de
-   2 Nodes configured
-   1 Resources configured
-
-   Online: [ node1 node2 ]
-
-   Full list of resources:
-
-   Resource Group: cfengine
-       cfvirtip   (ocf::heartbeat:IPaddr2):   Started node1
-   ```
-
-    **IMPORTANT** If fencing is not configured, resources might not be started by default. To enable resource start please run one of the following commands ``` pcs cluster enable --all``` or ```pcs resource debug-start cfvirtip```.
-
-3. Add global cluster configuration.
-
-   ```bash
-   pcs resource defaults resource-stickiness="INFINITY"
-   pcs resource defaults migration-threshold="1"
-   ```
-
-4. Stop PostgreSQL on all nodes.
-
-5. Download the latest version of PostgreSQL RA as the default one is known to have a bug while using Master/Slave configuration.
-
-    ```
-    wget https://raw.github.com/ClusterLabs/resource-agents/a6f4ddf76cb4bbc1b3df4c9b6632a6351b63c19e/heartbeat/pgsql
-    cp pgsql /usr/lib/ocf/resource.d/heartbeat/
-    chmod 755 /usr/lib/ocf/resource.d/heartbeat/pgsql
-    ```
-
-6. Create the PostgreSQL resource (recommended way with PostgreSQL archive mode enabled).
-
-    ```
-    pcs resource create cfpgsql pgsql pgctl="/var/cfengine/bin/pg_ctl" psql="/var/cfengine/bin/psql" pgdata="/var/cfengine/state/pg/data" pgdba="cfpostgres" repuser="cfpostgres" tmpdir="/var/cfengine/state/pg/tmp" rep_mode="async" node_list="node1 node2" primary_conninfo_opt="keepalives_idle=60 keepalives_interval=5 keepalives_count=5" master_ip="192.168.10.100" restart_on_promote="true" logfile="/var/log/postgresql.log" config="/var/cfengine/state/pg/data/postgresql.conf" check_wal_receiver=true restore_command="cp /var/cfengine/state/pg/pg_arch/%f %p" op monitor timeout="60s" interval="3s"  on-fail="restart" role="Master" op monitor timeout="60s" interval="4s" on-fail="restart"
-    ```
-
-    Alternatively, you can use following command for minimal setup (no archive enabled):
-
-    ```
-    pcs resource create cfpgsql pgsql pgctl="/var/cfengine/bin/pg_ctl" psql="/var/cfengine/bin/psql" pgdata="/var/cfengine/state/pg/data" pgdba="cfpostgres" repuser="cfpostgres" tmpdir="/var/cfengine/state/pg/tmp" rep_mode="async" node_list="node1 node2" primary_conninfo_opt="keepalives_idle=60 keepalives_interval=5 keepalives_count=5" master_ip="192.168.10.100" restart_on_promote="true" logfile="/var/log/postgresql.log" config="/var/cfengine/state/pg/data/postgresql.conf" op monitor timeout="60s" interval="3s"  on-fail="restart" role="Master" op monitor timeout="60s" interval="4s" on-fail="restart"
-    ```
-
-7. Configure PostgreSQL to work in Master/Slave (active/standby) mode:
-
-    ```
-    pcs resource master mscfpgsql cfpgsql master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true
-    ```
-
-8. Group previously configured shared IP address and PostgreSQL cluster resource to make sure both will always run on the same host and add migration rules to make sure that resources will be started and stopped in correct order.
-
-    ```bash
-    pcs constraint colocation add cfengine with Master mscfpgsql INFINITY
-    pcs constraint order promote mscfpgsql then start cfengine symmetrical=false score=INFINITY
-    pcs constraint order demote mscfpgsql then stop cfengine symmetrical=false score=0
-    ```
-
-9. Verify that constraints configuration is correct.
-
-    ```bash
-    [roott@node1] pcs constraint
-    Location Constraints:
-      Resource: mscfpgsql
-        Enabled on: node1 (score:INFINITY) (role: Master)
-    Ordering Constraints:
-      promote mscfpgsql then start cfengine (score:INFINITY) (non-symmetrical)
-      demote mscfpgsql then stop cfengine (score:0) (non-symmetrical)
-    Colocation Constraints:
-      cfengine with mscfpgsql (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
-
-    ```
-
-10. After these steps, the cluster should be up and running. To verify, run one of the commands below.
-
-    ```
-    [root@node1] pcs status
-    Cluster name: cfcluster
-    Last updated: Tue Jul  7 10:48:21 2015
-    Last change: Fri Jul  3 08:41:24 2015
-    Stack: cman
-    Current DC: node1 - partition with quorum
-    Version: 1.1.11-97629de
-    2 Nodes configured
-    3 Resources configured
+    1 Resources configured
 
     Online: [ node1 node2 ]
 
@@ -365,100 +182,409 @@ The command should return one entry indicating that *node1* is connected to the 
 
     Resource Group: cfengine
         cfvirtip   (ocf::heartbeat:IPaddr2):   Started node1
-    Master/Slave Set: mscfpgsql [cfpgsql]
-         Masters: [ node1 ]
-         Slaves: [ node2 ]
-
-    [root@node2 vagrant]# crm_mon -Afr1
-    Last updated: Tue Jul  7 10:50:07 2015
-    Last change: Tue Jul  7 10:30:03 2015
-    Stack: cman
-    Current DC: node2 - partition with quorum
-    Version: 1.1.11-97629de
-    2 Nodes configured
-    3 Resources configured
-
-    Online: [ node1 node2 ]
-
-    Full list of resources:
-
-    Resource Group: cfengine
-         cfvirtip   (ocf::heartbeat:IPaddr2):   Started node1
-    Master/Slave Set: mscfpgsql [cfpgsql]
-         Masters: [ node1 ]
-         Slaves: [ node2 ]
-
-    Node Attributes:
-        * Node node1:
-        + cfpgsql-data-status               : LATEST
-        + cfpgsql-master-baseline           : 000000000B000090
-        + cfpgsql-receiver-status           : ERROR
-        + cfpgsql-status                    : PRI
-        + master-cfpgsql                    : 1000
-
-    * Node node2:
-        + cfpgsql-data-status               : STREAMING|ASYNC
-        + cfpgsql-receiver-status           : normal
-        + cfpgsql-status                    : HS:alone
-        + master-cfpgsql                    : -INFINITY
     ```
 
-    **IMPORTANT:** Please make sure that *cfpgsql-status* for the active node is reported as *PRI* and passive as *HS:alone* or *HS:async*.
+## PostgreSQL configuration ##
 
-11. **Enjoy your working CFEngine High Availability setup!**
+1. Install the CFEngine hub package **on both node1 and node2**.
+2. Make sure CFEngine is not running (**on both node1 and node2**):
 
+   ```
+   service cfengine3 stop
+   ```
+
+3. Configure PostgreSQL **on node1**:
+   1. Create two special directories owned by the *cfpostgres* user:
+
+      ```
+      mkdir -p /var/cfengine/state/pg/{data/pg_arch,tmp}
+      chown -R cfpostgres:cfpostgres /var/cfengine/state/pg/{data/pg_arch,tmp}
+      ```
+
+   2. Modify the */var/cfengine/state/pg/data/postgresql.conf* configuration file to set the
+      following options accordingly (**uncomment the lines if they are commented out**):
+
+      ```
+      listen_addresses = '*'
+      wal_level = replica
+      max_wal_senders = 5
+      wal_keep_segments = 16
+      hot_standby = on
+      restart_after_crash = off
+      archive_mode = on
+      archive_command = 'cp %p /var/cfengine/state/pg/data/pg_arch/%f'
+      ```
+
+   3. Modify the *pg_hba.conf* configuration file to enable access to PostgreSQL for replication
+      between the nodes (note that the second pair of IP addresses, not the heartbeat pair, is used
+      here):
+
+      ```
+      echo "host replication all 192.168.100.10/32 trust" >> /var/cfengine/state/pg/data/pg_hba.conf
+      echo "host replication all 192.168.100.11/32 trust" >> /var/cfengine/state/pg/data/pg_hba.conf
+      ```
+
+      **IMPORTANT:** The above configuration allows accessing PostgreSQL without any authentication
+                     from both cluster nodes. For security reasons we strongly advise to create a
+                     replication user in PostgreSQL and protect access using a password or
+                     certificate. Furthermore, we advise using ssl-secured replication instead of
+                     the unencrypted method described here if the hubs are in an untrusted network.
+
+4. Do an initial sync of PostgreSQL:
+   1. Start PostgreSQL **on node1**:
+
+      ```
+      pushd /tmp; su cfpostgres -c "/var/cfengine/bin/pg_ctl -w -D /var/cfengine/state/pg/data -l /var/log/postgresql.log start"; popd
+      ```
+
+   2. **On node2**, initialize PostgreSQL from **node1** (again using the second IP, not the heartbeat IP):
+
+      ```
+      rm -rf /var/cfengine/state/pg/data/*
+      pushd /tmp; su cfpostgres -c "/var/cfengine/bin/pg_basebackup -h 192.168.10.10 -U cfpostgres -D /var/cfengine/state/pg/data -X stream -P"; popd
+      ```
+
+   3. **On node2**, create the *recovery.conf* file to configure PostgreSQL to run as a hot-standby replica:
+
+      ```
+      cat <<EOF > /var/cfengine/state/pg/data/recovery.conf
+      standby_mode = 'on'
+      #192.168.100.100 is the shared over cluster IP address of active/master cluster node
+      primary_conninfo = 'host=192.168.100.100 port=5432 user=cfpostgres application_name=node2'
+      restore_command = 'cp /var/cfengine/state/pg/pg_arch/%f %p'
+      EOF
+      chown --reference /var/cfengine/state/pg/data/postgresql.conf /var/cfengine/state/pg/data/recovery.conf
+      ```
+
+5. Start PostgreSQL on the **node2** by running the following command:
+
+    ```
+    pushd /tmp; su cfpostgres -c "/var/cfengine/bin/pg_ctl -D /var/cfengine/state/pg/data -l /var/log/postgresql.log start"; popd
+    ```
+
+6. Check that PostgreSQL replication is setup and working properly:
+   1. The **node2** should report it is in the recovery mode:
+
+      ```
+      /var/cfengine/bin/psql -x cfdb -c "SELECT pg_is_in_recovery();"
+      ```
+
+      should return:
+
+      ```
+      -[ RECORD 1 ]-----+--
+      pg_is_in_recovery | t
+      ```
+
+   2. The **node1** should report it is replicating to node2:
+
+      ```
+      /var/cfengine/bin/psql -x cfdb -c "SELECT * FROM pg_stat_replication;"
+      ```
+
+      should return something like this:
+
+      ```
+      -[ RECORD 1 ]----+------------------------------
+      pid              | 11401
+      usesysid         | 10
+      usename          | cfpostgres
+      application_name | node2
+      client_addr      | 192.168.100.11
+      client_hostname  | node2-pg
+      client_port      | 33958
+      backend_start    | 2018-10-16 14:19:04.226773+00
+      backend_xmin     |
+      state            | streaming
+      sent_lsn         | 0/61E2C88
+      write_lsn        | 0/61E2C88
+      flush_lsn        | 0/61E2C88
+      replay_lsn       | 0/61E2C88
+      write_lag        |
+      flush_lag        |
+      replay_lag       |
+      sync_priority    | 0
+      sync_state       | async
+      ```
+
+7. Stop PostgreSQL **on both nodes**:
+
+   ```
+   pushd /tmp; su cfpostgres -c "/var/cfengine/bin/pg_ctl -D /var/cfengine/state/pg/data -l /var/log/postgresql.log stop"; popd
+   ```
+
+### Cluster resource configuration ###
+
+1. Download the PostgreSQL resource agent supporting the CFEngine HA setup **on both nodes**.
+
+   ```
+   wget https://raw.githubusercontent.com/cfengine/core/master/contrib/pgsql_RA
+   /bin/cp pgsql_RA /usr/lib/ocf/resource.d/heartbeat/pgsql
+   chown --reference /usr/lib/ocf/resource.d/heartbeat/{IPaddr2,pgsql}
+   chmod --reference /usr/lib/ocf/resource.d/heartbeat/{IPaddr2,pgsql}
+   ```
+
+2. Create the PostgreSQL resource (**on node1**).
+
+   ```
+   pcs resource create cfpgsql pgsql  \
+     pgctl="/var/cfengine/bin/pg_ctl" \
+     psql="/var/cfengine/bin/psql"    \
+     pgdata="/var/cfengine/state/pg/data" \
+     pgdb="cfdb" pgdba="cfpostgres" repuser="cfpostgres" \
+     tmpdir="/var/cfengine/state/pg/tmp" \
+     rep_mode="async" node_list="node1 node2" \
+     primary_conninfo_opt="keepalives_idle=60 keepalives_interval=5 keepalives_count=5" \
+     master_ip="192.168.100.100" restart_on_promote="true" \
+     logfile="/var/log/postgresql.log" \
+     config="/var/cfengine/state/pg/data/postgresql.conf" \
+     check_wal_receiver=true restore_command="cp /var/cfengine/state/pg/data/pg_arch/%f %p" \
+     op monitor timeout="60s" interval="3s" on-fail="restart" role="Master" \
+     op monitor timeout="60s" interval="4s" on-fail="restart" --disable
+   ```
+
+3. Configure PostgreSQL to work in Master/Slave (active/standby) mode (**on node1**).
+
+   ```
+   pcs resource master mscfpgsql cfpgsql master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true
+   ```
+
+4. Tie the previously configured shared IP address and PostgreSQL cluster resources to make sure
+   both will always run on the same host and add migration rules to make sure that resources will be
+   started and stopped in the correct order (**on node1**).
+
+   ```
+   pcs constraint colocation add cfengine with Master mscfpgsql INFINITY
+   pcs constraint order promote mscfpgsql then start cfengine symmetrical=false score=INFINITY
+   pcs constraint order demote mscfpgsql then stop cfengine symmetrical=false score=0
+   ```
+
+5. Enable and start the new resource now that it is fully configured (**on node1**).
+
+   ```
+   pcs resource enable mscfpgsql --wait=30
+   ```
+
+6. Verify that the constraints configuration is correct.
+
+   ```
+   pcs constraint
+   ```
+
+   should give:
+
+   ```
+   Location Constraints:
+     Resource: mscfpgsql
+       Enabled on: node1 (score:INFINITY) (role: Master)
+   Ordering Constraints:
+     promote mscfpgsql then start cfengine (score:INFINITY) (non-symmetrical)
+     demote mscfpgsql then stop cfengine (score:0) (non-symmetrical)
+   Colocation Constraints:
+     cfengine with mscfpgsql (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+   ```
+
+7. Verify that the cluster is now fully setup and running.
+
+   ```
+   crm_mon -Afr1
+   ```
+
+   should give something like:
+
+   ```
+   Stack: cman
+   Current DC: node1 (version 1.1.18-3.el6-bfe4e80420) - partition with quorum
+   Last updated: Tue Oct 16 14:19:37 2018
+   Last change: Tue Oct 16 14:19:04 2018 by root via crm_attribute on node1
+
+   2 nodes configured
+   3 resources configured
+
+   Online: [ node1 node2 ]
+
+   Full list of resources:
+
+    Resource Group: cfengine
+        cfvirtip	(ocf::heartbeat:IPaddr2):	Started node1
+    Master/Slave Set: mscfpgsql [cfpgsql]
+        Masters: [ node1 ]
+        Slaves: [ node2 ]
+
+   Node Attributes:
+   * Node node1:
+       + cfpgsql-data-status             	: LATEST
+       + cfpgsql-master-baseline         	: 0000000004000098
+       + cfpgsql-receiver-status         	: normal (master)
+       + cfpgsql-status                  	: PRI
+       + master-cfpgsql                  	: 1000
+   * Node node2:
+       + cfpgsql-data-status             	: STREAMING|ASYNC
+       + cfpgsql-receiver-status         	: normal
+       + cfpgsql-status                  	: HS:async
+       + master-cfpgsql                  	: 100
+   ```
+
+   **IMPORTANT:** Please make sure that there's one Master node and one Slave node and that the
+                  *cfpgsql-status* for the active node is reported as *PRI* and passive as
+                  *HS:async* or *HS:alone*.
+
+
+### CFEngine configuration ###
+
+1. Create the HA configuration file **on both nodes**.
+
+   ```
+   cat <<EOF > /var/cfengine/ha.cfg
+   cmp_master: PRI
+   cmp_slave: HS:async,HS:sync,HS:alone
+   cmd: /usr/sbin/crm_attribute -l reboot -n cfpgsql-status -G -q
+   EOF
+   ```
+
+2. Bootstrap the nodes.
+
+   Bootstrap the **node1** to itself:
+
+   ```
+   cf-agent --bootstrap 192.168.100.10
+   ```
+
+   Bootstrap the **node2** to node1 (to establish trust) and then to itself:
+
+   ```
+   cf-agent --bootstrap 192.168.100.10
+   cf-agent --bootstrap 192.168.100.11
+   ```
+
+3. Stop CFEngine **on both nodes**.
+
+   ```
+   service cfengine3 stop
+   ```
+
+4. Create the HA JSON configuration file **on both nodes**.
+
+   ```
+   cat <<EOF > /var/cfengine/masterfiles/cfe_internal/enterprise/ha/ha_info.json
+   {
+     "192.168.100.10":
+       {
+        "sha": "@NODE1_PKSHA@",
+        "internal_ip": "192.168.100.10"
+       },
+     "192.168.100.11":
+       {
+        "sha": "@NODE2_PKSHA@",
+        "internal_ip": "192.168.100.11"
+       }
+   }
+   EOF
+   ```
+
+   The `@NODE1_PKSHA@` and `@NODE2_PKSHA@` strings are placeholders for the host key hashes of the
+   nodes. Replace the placeholders with real values obtained by (on any node):
+
+   ```
+   cf-key -s
+   ```
+
+   **IMPORTANT:** Copy over only the hashes, without the `SHA=` prefix.
+
+5. **On both nodes,** modify the */var/cfengine/masterfiles/controls/def.cf* and
+   */var/cfengine/masterfiles/controls/update_def.cf* files to enable HA by uncommenting the
+   following line:
+
+   ```
+   "enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
+   ```
+
+   and commenting or removing the line
+
+   ```
+   "enable_cfengine_enterprise_hub_ha" expression => "!any";`
+   ```
+
+6. **On both nodes,** run `cf-agent -Kf update.cf` to make sure that the new policy is copied from
+   *masterfiles* to *inputs*.
+
+7. Start CFEngine **on both nodes**.
+
+   ```
+   service cfengine3 start
+   ```
+
+8. Check that the CFEngine HA setup is working by logging in to the Mission Portal at the
+   https://192.168.100.100 address in your browser. Note that it takes up to 15 minutes for
+   everything to settle and the `OK` HA status being reported in the Mission Portal's header.
 
 
 ### Configuring 3rd node as disaster-recovery or database backup (optional) ###
 
-1. Install the CFEngine hub package on node which will be used as disaster-recovery or database backup node (node3).
+1. Install the CFEngine hub package on the node which will be used as disaster-recovery or database
+   backup node (node3).
 
-2. Bootstrap the disaster-recovery node to active node first (establish trust between hubs) and then bootstrap it to itself. At this point hub will be capable of collecting reports and serve policy.
+2. Bootstrap the disaster-recovery node to active node first (establish trust between hubs) and then
+   bootstrap it to itself. At this point hub will be capable of collecting reports and serve policy.
 
 3. Stop cf-execd and cf-hub processes.
 
-4. Make sure that PostgreSQL configuration allows database replication connection from 3rd node (see PostgreSQL configuration section, point 5.3 for more details).
+4. Make sure that PostgreSQL configuration allows database replication connection from 3rd node (see
+   PostgreSQL configuration section, point 5.3 for more details).
 
-5. Repeat steps 6 - 7 from PostgreSQL configuration to enable and verify database replication connection from 3rd node. Make sure that both second cluster node (passive) and 3rd node (disaster-recovery) are connected to active database node and streaming replication is in progress.
+5. Repeat steps 4 - 6 from PostgreSQL configuration to enable and verify database replication
+   connection from the node3. Make sure that both the node2 and node3 are connected to active
+   database node and streaming replication is in progress.
 
-    ```
-    [root@node1 tmp]# echo "select * from pg_stat_replication;" | /var/cfengine/bin/psql cfdb
-    pid  | usesysid |  usename   | application_name |  client_addr  | client_hostname | client_port |         backend_start         |   state   | sent_location | write_location | flush_location | replay_location | sync_priority | sync_state
-   ------+----------+------------+------------------+---------------+-----------------+-------------+-------------------------------+-----------+---------------+----------------+----------------+-----------------+---------------+------------
-    9252 |       10 | cfpostgres | node2            | 192.168.10.11 |                 |       58919 | 2015-08-24 07:14:45.925341+00 | streaming | 0/2A7034D0    | 0/2A7034D0     | 0/2A7034D0     | 0/2A7034D0      |             0 | async
-    9276 |       10 | cfpostgres | node3            | 192.168.10.12 |                 |       52202 | 2015-08-24 07:14:46.038676+00 | streaming | 0/2A7034D0    | 0/2A7034D0     | 0/2A7034D0     | 0/2A7034D0      |             0 | async
+   Running the following command **on node1**:
 
-    (2 rows)
-    ```
+   ```
+   /var/cfengine/bin/psql cfdb -c "SELECT * FROM pg_stat_replication;"
+   ```
 
-6. Modify HA JSON configuration file to contain information about 3rd node (see CFEngine configuration, point 2). You should have configuration similar to one below:
+   Should give:
+   ```
+   pid  | usesysid |  usename   | application_name |  client_addr   | client_hostname | client_port |         backend_start         |   state   | sent_location | write_location | flush_location | replay_location | sync_priority | sync_state
+  ------+----------+------------+------------------+----------------+-----------------+-------------+-------------------------------+-----------+---------------+----------------+----------------+-----------------+---------------+------------
+   9252 |       10 | cfpostgres | node2            | 192.168.100.11 |                 |       58919 | 2015-08-24 07:14:45.925341+00 | streaming | 0/2A7034D0    | 0/2A7034D0     | 0/2A7034D0     | 0/2A7034D0      |             0 | async
+   9276 |       10 | cfpostgres | node3            | 192.168.100.12 |                 |       52202 | 2015-08-24 07:14:46.038676+00 | streaming | 0/2A7034D0    | 0/2A7034D0     | 0/2A7034D0     | 0/2A7034D0      |             0 | async
 
-    ```
-    [root@node3 masterfiles]# cat /var/cfengine/masterfiles/cfe_internal/enterprise/ha/ha_info.json
+   (2 rows)
+   ```
+
+6. Modify HA JSON configuration file to contain information about the node3 (see CFEngine
+   configuration, step 2). You should have configuration similar to one below:
+
+   ```
+   [root@node3 masterfiles]# cat /var/cfengine/masterfiles/cfe_internal/enterprise/ha/ha_info.json
+   {
+    "192.168.100.10":
     {
-     "192.168.100.10":
-     {
-      "sha": "b1463b08a89de98793d45a52da63d3f100247623ea5e7ad5688b9d0b8104383f",
-      "internal_ip": "192.168.100.10",
-      "is_in_cluster" : true,
-     },
-     "192.168.100.11":
-     {
-      "sha": "b13db51615afa409a22506e2b98006793c1b0a436b601b094be4ee4b32b321d5",
-      "internal_ip": "192.168.100.11",
-     },
-     "192.168.100.12":
-     {
-      "sha": "98f14786389b2fe5a93dc3ef4c3c973ef7832279aa925df324f40697b332614c",
-      "internal_ip": "192.168.100.12",
-      "is_in_cluster" : false,
-     }
+     "sha": "b1463b08a89de98793d45a52da63d3f100247623ea5e7ad5688b9d0b8104383f",
+     "internal_ip": "192.168.100.10",
+     "is_in_cluster" : true,
+    },
+    "192.168.100.11":
+    {
+     "sha": "b13db51615afa409a22506e2b98006793c1b0a436b601b094be4ee4b32b321d5",
+     "internal_ip": "192.168.100.11",
+    },
+    "192.168.100.12":
+    {
+     "sha": "98f14786389b2fe5a93dc3ef4c3c973ef7832279aa925df324f40697b332614c",
+     "internal_ip": "192.168.100.12",
+     "is_in_cluster" : false,
     }
-    ```
+   }
+   ```
 
-    Please note that ```is_in_cluster``` parameter is optional for 2 nodes HA clusters and by default is set to true. For 3 nodes setup, the node which is not part od pacemaker/corosync cluster setup MUST be marked with ```"is_in_cluster" : false``` configuration parameter.
+   Please note that ```is_in_cluster``` parameter is optional for the 2 nodes in the HA cluster and
+   by default is set to true. For the 3-node setup, the node3, which is not part of the cluster,
+   **MUST** be marked with `"is_in_cluster" : false` configuration parameter.
 
-7. Start cf-execd process (don't start cf-hub process as this is not needed while manual failover to 3rd node is not performed). Please also note, that during normal operations cf-hub process should not be running on 3rd HA node.
+7. Start the cf-execd process (don't start cf-hub process as this is not needed while manual
+   failover to the node3 is not performed). Please also note that during normal operations the
+   cf-hub process should not be running on the node3.
 
 
 
@@ -541,4 +667,3 @@ The command should return one entry indicating that *node1* is connected to the 
     [root@node2]# pcs cluster start
     Starting Cluster...
     ```
-


### PR DESCRIPTION
1) Reformatted the file to not use horribly long lines.

2) Rearranged the steps so they follow the logical order of
   setting the base things *before* the things that build on top
   of the base. So now the cluster is built first then the
   PostgreSQL replication is setup then the PG replication is
   integrated with the cluster and finally CFEngine is pulled
   into the game with its own stuff.

3) Modified the steps to use our tailored Resource Agent which
   supports both RHEL 6 and PostgreSQL 10 and to avoid some
   issues with things happening automatically in the background
   in between the individual steps.

4) Simplified some steps and tried to make it clearer which
   commands need to be run where.

(cherry picked from commit 1e488ea2e396c8507516cbe9c3b54ac6ca559f35)