### PR TITLE
Added "target_state" to federation-config.json

### DIFF
--- a/enterprise-cfengine-guide/federated-reporting.markdown
+++ b/enterprise-cfengine-guide/federated-reporting.markdown
@@ -262,6 +262,7 @@ $ cat > federation-config.json
 {
   "hostname": null,
   "role": "feeder",
+  "target_state": "on",
   "remote_hubs": []
 }
 $


### PR DESCRIPTION
Need this for pre 3.14 hubs in order to enable federated reporting manually.