### PR TITLE
Added panfs, cifs mount types

### DIFF
--- a/reference/promise-types/storage.markdown
+++ b/reference/promise-types/storage.markdown
@@ -85,25 +85,22 @@ The default behavior is to not place edits in the file system table.
 **Type:** (menu option)
 
 **Allowed input range:**
+{% comment %}cf-promises --syntax-description=json | jq '.bodyTypes.mount.attributes.mount_type.range|split(",")'{% endcomment %}
 
-```
-    nfs
-    nfs2
-    nfs3
-    nfs4
-```
+* `nfs`
+* `nfs2`
+* `nfs3`
+* `nfs4`
+* `panfs`
+* `cifs`
 
 **Example:**
 
-```cf3
-     body mount example
-     {
-     mount_type => "nfs3";
-     }
-```
+[%CFEngine_include_example(storage-cifs.cf)%]
 
-**Notes:**
-This field is mainly for future extensions.
+**History:**
+
+* `cifs`, `panfs` added in 3.15.0
 
 #### mount_source
 


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/core/pull/4174

Added cifs and panfs mount types new in 3.15.0.

Ticket: CFE-3187
Changelog: None
(cherry picked from commit 5d0d5cce03d7dda82da4afdbda194c9cf6dc6cca)