### PR TITLE
Properly format as a nested list + Fix two typos

### DIFF
--- a/enterprise-cfengine-guide/hub_administration/policy-deployment.markdown
+++ b/enterprise-cfengine-guide/hub_administration/policy-deployment.markdown
@@ -8,7 +8,7 @@ tags: [cfengine enterprise, hub administration]
 By default CFEngine policy is distributed from `/var/cfengine/masterfiles` on
 the policy server. It is common (and recommended) for masterfiles to be backed
 with a version control system (VCS) such as git or subversion. This document
-details usage with git, but the tooling is desinged to be flexible and easily
+details usage with git, but the tooling is designed to be flexible and easily
 modified to support any upstream versioning system.
 
 CFEngine Enterprise ships with tooling to assist in the automated deployment of

--- a/guide/writing-and-serving-policy.markdown
+++ b/guide/writing-and-serving-policy.markdown
@@ -62,7 +62,9 @@ Writing, deploying, and using CFEngine `promises` will generally follow these si
 2. Create a bundle and promise in the file (see ["Hello World" Policy Example][Examples and Tutorials#"Hello World" Policy Example]).
 3. Save the file on the policy server somewhere under `/var/cfengine/masterfiles` (can be under a sub-directory).
 4. Let CFEngine know about the `promise` on the `policy server`, generally in the file `/var/cfengine/masterfiles/promises.cf`, or a file elsewhere but referred to in `promises.cf`.
-		* Optional: it is also possible to call a bundle manually, using `cf-agent`.
+
+    * Optional: it is also possible to call a bundle manually, using `cf-agent`.
+
 5. Verify the `policy file` was deployed and successfully run.
 
 See [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples] for a more detailed step by step tutorial.

--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -380,7 +380,7 @@ bundle agent example
 {
   packages:
 
-    # Enable the EPEL repo when making sure git is intalled
+    # Enable the EPEL repo when making sure git is installed
     # and up to date.
 
     "git"


### PR DESCRIPTION
* Properly format as a nested list
Without the blank line, both lists are showed in the same line.

* Fix two typos