### PR TITLE
Added documentation for new function, execresult_as_data()

### DIFF
--- a/reference/functions/execresult.markdown
+++ b/reference/functions/execresult.markdown
@@ -5,7 +5,7 @@ published: true
 tags: [reference, utility functions, functions, execresult, cached function]
 ---
 
-[%CFEngine_function_prototype(command, shell)%]
+[%CFEngine_function_prototype(command, shell, output)%]
 
 **Description:** Execute `command` and return output (both `stdout` and `stderr`) as `string`.
 
@@ -17,7 +17,10 @@ remember that each command requires a new process that reads in files beyond
 CFEngine's control. Thus using a shell is both a performance hog and a
 potential security issue.
 
-[%CFEngine_function_attributes(command, shell)%]
+The optional `output` argument allows you to select which output will be
+included, betweeen `stdout`, `stderr`, or `both`. The default is `both`.
+
+[%CFEngine_function_attributes(command, shell, output)%]
 
 **Example:**
 
@@ -25,7 +28,7 @@ Prepare:
 
 [%CFEngine_include_snippet(execresult.cf, #\+begin_src prep, .*end_src)%]
 
-Run:
+Policy:
 
 [%CFEngine_include_snippet(execresult.cf, #\+begin_src cfengine3, .*end_src)%]
 
@@ -43,8 +46,7 @@ only.  Effectively calls to this function will be also repeatedly
 executed by `cf-promises` when it does syntax checking, which is
 highly undesirable if the command is expensive.  Consider using
 `commands` promises instead, which have locking and are not evaluated
-by `cf-promises`. If capturing stderr is undesirable, consider **useshell** and
-redirecting it to `/dev/null`.
+by `cf-promises`.
 
 **See also:** [`returnszero()`][returnszero].
 

--- a/reference/functions/execresult.markdown
+++ b/reference/functions/execresult.markdown
@@ -48,7 +48,7 @@ highly undesirable if the command is expensive.  Consider using
 `commands` promises instead, which have locking and are not evaluated
 by `cf-promises`.
 
-**See also:** [`returnszero()`][returnszero].
+**See also:** [`returnszero()`][returnszero], [`execresult_as_data()`][execresult_as_data].
 
 **Change:** policy change in CFEngine 3.0.5. Previously newlines were
 changed for spaces, now newlines are preserved.

--- a/reference/functions/execresult_as_data.markdown
+++ b/reference/functions/execresult_as_data.markdown
@@ -1,0 +1,41 @@
+---
+layout: default
+title: execresult_as_data
+published: true
+tags: [reference, utility functions, functions, execresult_as_data, cached function]
+---
+
+[%CFEngine_function_prototype(command, shell, output)%]
+
+**Description:** Execute `command` and return a data container including command output and exit code.
+
+Functions in the same way as [`execresult()`][execresult], and takes the same parameters.
+Unlike [`execresult()`][execresult], and [`returnszero()`][returnszero], this function allows
+you to test, store, or inspect both exit code and output from the samme command execution.
+
+[%CFEngine_function_attributes(command, shell, output)%]
+
+**Example:**
+
+Prepare:
+
+[%CFEngine_include_snippet(execresult_as_data.cf, #\+begin_src prep, .*end_src)%]
+
+Policy:
+
+[%CFEngine_include_snippet(execresult_as_data.cf, #\+begin_src cfengine3, .*end_src)%]
+
+Output:
+
+[%CFEngine_include_snippet(execresult_as_data.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+
+**Notes:** you should never use this function to execute commands that
+make changes to the system, or perform lengthy computations. Consider using
+`commands` promises instead, which have locking and are not evaluated
+by `cf-promises`.
+
+**See also:** [`execresult()`][execresult].
+
+**History:**
+
+* Introduced in 3.17.0


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/core/pull/4268
https://github.com/cfengine/nova/pull/1695
https://github.com/cfengine/documentation/pull/2344