### PR TITLE
Removed rendering of prep section for example

### DIFF
--- a/reference/functions/execresult_as_data.markdown
+++ b/reference/functions/execresult_as_data.markdown
@@ -17,10 +17,6 @@ you to test, store, or inspect both exit code and output from the samme command 
 
 **Example:**
 
-Prepare:
-
-[%CFEngine_include_snippet(execresult_as_data.cf, #\+begin_src prep, .*end_src)%]
-
 Policy:
 
 [%CFEngine_include_snippet(execresult_as_data.cf, #\+begin_src cfengine3, .*end_src)%]


### PR DESCRIPTION
There is no prep section in the example, this causes the doc build to fail:

,#+begin_example
18:44:59 Unexpanded macro in '/home/jenkins/workspace/build-documentation-master/label/DOCUMENTATION_x86_64_linux_ubuntu_16/documentation/reference/functions/execresult_as_data.markdown', html-line '<p>[%CFEngine_include_snippet(execresult_as_data.cf, #+begin_src prep, .*end_src)%]</p>
18:44:59 '
18:44:59
18:44:59       Exception: (<type 'exceptions.Exception'>, Exception('1 errors while processing HTML files',), <traceback object at 0x7fc70a5b1bd8>)
18:44:59 + '[' 1 -gt 0 ']'
,#+end_example