### PR TITLE
fix endraw tag

### DIFF
--- a/cheatsheet.markdown
+++ b/cheatsheet.markdown
@@ -525,7 +525,7 @@ show the actual variables will need to be inside of raw tags.
 
 {% raw %}
 site.CFE_manuals_version {{ site.CFE_manuals_version }}
-{% endraw %**
+{% endraw %}
 
 # Testing
 ## Indention with included markdown


### PR DESCRIPTION
The `endraw` tag is wrong and leads to the following error when running `jekyll build`:

  Liquid Exception: Liquid syntax error (line 518): 'raw' tag was never closed in cheatsheet.markdown
