### PR TITLE
Standardized formatting of see also

### DIFF
--- a/cheatsheet.markdown
+++ b/cheatsheet.markdown
@@ -57,7 +57,7 @@ file.
 
 For example ```services_autorun``` in the MPF documentation the underscore needs to be escaped with a ```\```.
 
-**See Also:** [`services_autorun` in the Masterfiles Policy Framework][Masterfiles Policy Framework#services\_autorun]
+**See also:** [`services_autorun` in the Masterfiles Policy Framework][Masterfiles Policy Framework#services\_autorun]
 
 ### Link to CFEngine keyword
 

--- a/enterprise-cfengine-guide/settings.markdown
+++ b/enterprise-cfengine-guide/settings.markdown
@@ -198,7 +198,7 @@ Mission portal can authenticate against an external directory.
 
 - Default roles for users is configured under [Role Management][Settings#Role Management].
 
-**See Also:** [LDAP authentication REST API][LDAP authentication API]
+**See also:** [LDAP authentication REST API][LDAP authentication API]
 
 
 ## Role based access control ##
@@ -224,7 +224,7 @@ To restore the CFEngine admin role permissions run the following sql as root on 
 root@hub:~# /var/cfengine/bin/psql cfsettings -c "INSERT INTO rbac_role_permission (role_id, permission_alias) (SELECT 'admin'::text as role_id, alias as permission_alias FROM rbac_permissions) ON CONFLICT (role_id, permission_alias)  DO NOTHING;"
 ```
 
-**See Also:** [Web RBAC API][Web RBAC API]
+**See also:** [Web RBAC API][Web RBAC API]
 
 
 ## About CFEngine ##

--- a/examples/enterprise-api-examples.markdown
+++ b/examples/enterprise-api-examples.markdown
@@ -14,4 +14,4 @@ tags: [examples, enterprise, REST, API, reporting]
 * [Schedule reports][SQL Query Examples#Subscribed Query Example: Creating A Subscribed Query] for email and later download
 * [Tracking changes performed by CFEngine][Tracking changes]
 
-**See Also**: [Enterprise API Reference][Enterprise API Reference]
+**See also:** [Enterprise API Reference][Enterprise API Reference]

--- a/examples/example-snippets/promise-patterns/example_enable_service.markdown
+++ b/examples/example-snippets/promise-patterns/example_enable_service.markdown
@@ -15,7 +15,7 @@ This example shows how to ensure services are started or stopped appropriately.
 custom handling. For example it is not uncommon for some services to not provide
 correct return codes for status checks.
 
-**See Also:**
+**See also:**
 
 * [Services promise type reference][services]
 * [Services bundles and bodies in the standard library][lib/services.cf]

--- a/guide/faq/enterprise-report-collection.markdown
+++ b/guide/faq/enterprise-report-collection.markdown
@@ -21,7 +21,7 @@ tries to collect from up to the LICENSED number of hosts for each collection
 round as identified by `hub_schedule` as defined
 in [`body hub control`](cf-hub#control-promises).
 
-* **See Also:** `hostsseen()`, `hostswithclass()`
+* **See also:** `hostsseen()`, `hostswithclass()`
 
 ## How often does cf-hub re-check the LICENSE
 
@@ -111,7 +111,7 @@ $ curl -s -u admin:admin http://hub/api/query -X POST -d @agent_execution_time_i
 ]
 ```
 
-**See Also**: `Enterprise API Reference`, `Enterprise API Examples`
+**See also:** `Enterprise API Reference`, `Enterprise API Examples`
 
 ## How are hosts not reporting determined?
 
@@ -132,7 +132,7 @@ Note: It's called "blueHostHorizon" because older versions of Mission Portal
 would turn these hosts to a blue color as an indication of "hypoxia" (lack
 of oxygen, where oxygen is access to latest policy) to indicate a health issue.
 
-**See Also**: `Enterprise API Reference`, `Enterprise API Examples`, [Enterprise Settings][Settings#preferences]
+**See also:** `Enterprise API Reference`, `Enterprise API Examples`, [Enterprise Settings][Settings#preferences]
 
 ## Which hosts are pending trust revocation?
 

--- a/guide/faq/integrate-custom-policy.markdown
+++ b/guide/faq/integrate-custom-policy.markdown
@@ -22,7 +22,7 @@ The *autorun* feature in the Masterfiles Policy Framework automatically adds
 policy files found in `services/autorun` to inputs and executes bundles tagged
 with *autorun* as methods type promises in lexical order.
 
-**See Also:** [`services_autorun` in the Masterfiles Policy Framework][Masterfiles Policy Framework#services\_autorun]
+**See also:** [`services_autorun` in the Masterfiles Policy Framework][Masterfiles Policy Framework#services\_autorun]
 
 ## Using augments
 
@@ -55,7 +55,7 @@ To extend inputs in the update policy define `update_inputs`.
 }
 ```
 
-**See Also:** [Augments][Augments], [Extend inputs for update policy in the Masterfiles Policy Framework][Masterfiles Policy Framework#Append to inputs used by update policy]
+**See also:** [Augments][Augments], [Extend inputs for update policy in the Masterfiles Policy Framework][Masterfiles Policy Framework#Append to inputs used by update policy]
 
 ## Using body file control
 
@@ -102,7 +102,7 @@ other.
    }
    ```
 
-**See Also:** [`inputs` in `body file control`][file control#inputs]
+**See also:** [`inputs` in `body file control`][file control#inputs]
 
 ## Using body common control
 
@@ -110,5 +110,5 @@ other.
 make up the policy set ( *inputs* ), and the order of the bundles to be executed
 ( *bundlesequence* ).
 
-**See Also:** [`inputs` in `body common control`][Components and Common Control#inputs], [`bundlesequence` in `body common control`][Components and Common Control#bundlesequence]
+**See also:** [`inputs` in `body common control`][Components and Common Control#inputs], [`bundlesequence` in `body common control`][Components and Common Control#bundlesequence]
 

--- a/guide/faq/manual-execution.markdown
+++ b/guide/faq/manual-execution.markdown
@@ -101,5 +101,5 @@ This command will run `cf-agent` with the additional class `patch_and_reboot` on
 classes it is using must be resolvable during pre-evaluation as the full
 evaluation is only allowed when the classes are found to be defined.
 
-**See Also:** [How is "recently seen" determined][Components and Common Control#lastseenexpireafter], [`cf-runagent`][cf-runagent], [pre-evaluation][Normal Ordering#agent pre-evaluation step]
+**See also:** [How is "recently seen" determined][Components and Common Control#lastseenexpireafter], [`cf-runagent`][cf-runagent], [pre-evaluation][Normal Ordering#agent pre-evaluation step]
 

--- a/guide/faq/mustache-templating.markdown
+++ b/guide/faq/mustache-templating.markdown
@@ -15,7 +15,7 @@ CFEngine has several extensions to the mustache standard.
 * `$` variable prefix causing data to be rendered as compact json representation.
 * `@` expands the current key being iterated.
 
-**See Also:** [`template_method` `mustache` extensions][files#template_method mustache extensions]
+**See also:** [`template_method` `mustache` extensions][files#template_method mustache extensions]
 
 ## How can I pass a data variable to template_data?
 

--- a/guide/faq/output-email.markdown
+++ b/guide/faq/output-email.markdown
@@ -13,7 +13,7 @@ https://github.com/cfengine/masterfiles/blob/{{site.cfengine.branch}}/controls/c
 It defaults to `root@$(def.domain)` which is configured in `bundle common def`
 https://github.com/cfengine/masterfiles/blob/{{site.cfengine.branch}}/def.cf.
 
-**See Also:** [`def.mailto`][Masterfiles Policy Framework#mailto].
+**See also:** [`def.mailto`][Masterfiles Policy Framework#mailto].
 
 # How do I disable agent email output?
 

--- a/guide/installation-and-configuration/upgrading.markdown
+++ b/guide/installation-and-configuration/upgrading.markdown
@@ -65,7 +65,7 @@ anything goes wrong.
    root@hub:~# find /etc -name 'cfengine*' | tar cfz /tmp/$(date +%Y-%m-%d)-cfengine-init-backup.tar.gz -T -
    ```
 
-   **See Also:** [Hub administration backup and restore][Backup and Restore]
+   **See also:** [Hub administration backup and restore][Backup and Restore]
 
 3. Copy the archive to a safe location.
 

--- a/guide/latest-release/whatsnew/changelog-core.markdown
+++ b/guide/latest-release/whatsnew/changelog-core.markdown
@@ -6,7 +6,7 @@ sorting: 10
 tags: [what's new]
 ---
 
-**See Also:** [Enterprise Changelog][Enterprise Changelog], [Masterfiles Changelog][Masterfiles Changelog]
+**See also:** [Enterprise Changelog][Enterprise Changelog], [Masterfiles Changelog][Masterfiles Changelog]
 
 <pre>
 [%CFEngine_include_markdown(core/ChangeLog)%]

--- a/guide/latest-release/whatsnew/changelog-enterprise.markdown
+++ b/guide/latest-release/whatsnew/changelog-enterprise.markdown
@@ -6,7 +6,7 @@ sorting: 30
 tags: [what's new, enterprise]
 ---
 
-**See Also:** [Core Changelog][Changelog], [Masterfiles Changelog][Masterfiles Changelog]
+**See also:** [Core Changelog][Changelog], [Masterfiles Changelog][Masterfiles Changelog]
 
 <pre>
 [%CFEngine_include_markdown(enterprise/ChangeLog.Enterprise)%]

--- a/guide/latest-release/whatsnew/changelog-masterfiles-policy-framework.markdown
+++ b/guide/latest-release/whatsnew/changelog-masterfiles-policy-framework.markdown
@@ -6,7 +6,7 @@ sorting: 20
 tags: [what's new, MPF, masterfiles]
 ---
 
-**See Also:** [Core Changelog][Changelog], [Enterprise Changelog][Enterprise Changelog] 
+**See also:** [Core Changelog][Changelog], [Enterprise Changelog][Enterprise Changelog] 
 
 <pre>
 [%CFEngine_include_markdown(masterfiles/CHANGELOG.md)%]

--- a/reference/components.markdown
+++ b/reference/components.markdown
@@ -357,7 +357,7 @@ after which last-seen entries are purged. It is an **enterprise-only** feature.
     }
 ```
 
-**See Also:** [hostsseen()][hostsseen], [cf-hub][cf-hub]
+**See also:** [hostsseen()][hostsseen], [cf-hub][cf-hub]
 
 ### output_prefix
 

--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -331,7 +331,7 @@ syslog facility level.
 
 This is ignored on Windows, as CFEngine Enterprise creates event logs.
 
-**See Also**: Manual pages for syslog.
+**See also:** Manual pages for syslog.
 
 ### allclassesreport
 
@@ -572,7 +572,7 @@ body agent control
 }
 ```
 
-**See Also:** [body `copy_from` timeout][files#timeout], [`cf-runagent` timeout][cf-runagent#timeout]
+**See also:** [body `copy_from` timeout][files#timeout], [`cf-runagent` timeout][cf-runagent#timeout]
 
 **Notes:**
 
@@ -715,7 +715,7 @@ kill and restart its attempt to keep a promise.
     }
 ```
 
-**See Also:** [`body action expireafter`][Promise Types and Attributes#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
+**See also:** [`body action expireafter`][Promise Types and Attributes#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
 
 ### files_single_copy
 
@@ -831,7 +831,7 @@ another which is not tied to a specific time.
     }
 ```
 
-**See Also:** [Promise locking][Promises#Promise Locking], [ifelapsed action body attribute][Promise Types and Attributes#ifelapsed]
+**See also:** [Promise locking][Promises#Promise Locking], [ifelapsed action body attribute][Promise Types and Attributes#ifelapsed]
 
 ### inform
 
@@ -891,7 +891,7 @@ diminishing returns.
     }
 ```
 
-**See Also**: [`background` in action bodies][Promise Types and Attributes#background]
+**See also:** [`background` in action bodies][Promise Types and Attributes#background]
 
 ### maxconnections
 
@@ -1060,7 +1060,7 @@ body agent control
 }
 ```
 
-**See Also:** [select_end_match_eof in delete_lines][delete_lines], [select_end_match_eof in field_edits][field_edits], [select_end_match_eof in insert_lines][insert_lines], [select_end_match_eof in replace_patterns][replace_patterns]
+**See also:** [select_end_match_eof in delete_lines][delete_lines], [select_end_match_eof in field_edits][field_edits], [select_end_match_eof in insert_lines][insert_lines], [select_end_match_eof in replace_patterns][replace_patterns]
 
 ### sensiblecount
 

--- a/reference/components/cf-execd.markdown
+++ b/reference/components/cf-execd.markdown
@@ -82,7 +82,7 @@ set it to `120` and you are using a 5-minute agent schedule, a
 maximum of 120 / 5 = 24 agents should be enforced.
 
 
-**See Also:** [`body action expireafter`][Promise Types and Attributes#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter]
+**See also:** [`body action expireafter`][Promise Types and Attributes#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter]
 
 ### executorfacility
 

--- a/reference/components/cf-runagent.markdown
+++ b/reference/components/cf-runagent.markdown
@@ -19,7 +19,7 @@ which hosts `cf-agent` will be started, and classes that the user requests
 
 [%CFEngine_include_snippet(cf-runagent.help, [\s]*--[a-z], ^$)%]
 
-**See also**: [bundle resource_type in server access promises][access#resource_type], [cfruncommand in body server control][cf-serverd#cfruncommand]
+**See also:** [bundle resource_type in server access promises][access#resource_type], [cfruncommand in body server control][cf-serverd#cfruncommand]
 
 ## Control Promises
 
@@ -289,4 +289,4 @@ body runagent control
 }
 ```
 
-**See Also:** [body `copy_from` timeout][files#timeout], [agent `default_timeout`][cf-agent#default_timeout]
+**See also:** [body `copy_from` timeout][files#timeout], [agent `default_timeout`][cf-agent#default_timeout]

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -280,7 +280,7 @@ shell command at your own risk.
     }
 ```
 
-**See also**: [cf-runagent][cf-runagent], [bundle resource_type in server access promises][access#resource_type]
+**See also:** [cf-runagent][cf-runagent], [bundle resource_type in server access promises][access#resource_type]
 
 ### call_collect_interval
 

--- a/reference/components/file_control_promises.markdown
+++ b/reference/components/file_control_promises.markdown
@@ -108,4 +108,4 @@ and bodies. A namespace applies until the next namespace declaration in a
 file, or until the end of a file. This is similar to how class expressions
 apply until the next class expression or end of bundle.
 
-**See Also:** `namespaces`
+**See also:** `namespaces`

--- a/reference/enterprise-api-ref.markdown
+++ b/reference/enterprise-api-ref.markdown
@@ -11,7 +11,7 @@ number of URI resources that support one or more GET, PUT, POST, or
 DELETE operations. While reporting is done using SQL, this query is
 always wrapped in a JSON request.
 
-**See Also**: [Enterprise API Examples][Enterprise API Examples]
+**See also:** [Enterprise API Examples][Enterprise API Examples]
 
 ## Requests
 

--- a/reference/functions/accessedbefore.markdown
+++ b/reference/functions/accessedbefore.markdown
@@ -27,4 +27,4 @@ Output:
 
 [%CFEngine_include_snippet(accessedbefore.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `changedbefore()`, `isnewerthan()`
+**See also:** `changedbefore()`, `isnewerthan()`

--- a/reference/functions/and.markdown
+++ b/reference/functions/and.markdown
@@ -26,6 +26,6 @@ classes.
 **Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
 promise attributes.
 
-**See Also:** `and`, `or`, `not`
+**See also:** `and`, `or`, `not`
 
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/reference/functions/changedbefore.markdown
+++ b/reference/functions/changedbefore.markdown
@@ -39,4 +39,4 @@ Comparisons like this are normally used for updating files (like the
     }
 ```
 
-**See Also:** `accessedbefore()`, `isnewerthan()`
+**See also:** `accessedbefore()`, `isnewerthan()`

--- a/reference/functions/fileexists.markdown
+++ b/reference/functions/fileexists.markdown
@@ -30,4 +30,4 @@ Output:
 
 [%CFEngine_include_snippet(fileexists.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `filestat()`, `isdir()`, `islink()`, `isplain()`, `returnszero()`
+**See also:** `filestat()`, `isdir()`, `islink()`, `isplain()`, `returnszero()`

--- a/reference/functions/hash_to_int.markdown
+++ b/reference/functions/hash_to_int.markdown
@@ -31,4 +31,4 @@ Output:
 
 - Introduced in 3.12.0.
 
-**See Also:** `splayclass()`
+**See also:** `splayclass()`

--- a/reference/functions/host2ip.markdown
+++ b/reference/functions/host2ip.markdown
@@ -28,7 +28,7 @@ to debug the behavior of the resolver.
     }
 ```
 
-**See Also:** `ip2host()`, `isipinsubnet()`,  `iprange()`
+**See also:** `ip2host()`, `isipinsubnet()`,  `iprange()`
 
 **History:** This function was introduced in CFEngine version 3.0.4
 (2010)

--- a/reference/functions/hostsseen.markdown
+++ b/reference/functions/hostsseen.markdown
@@ -31,4 +31,4 @@ reports:
 }
 ```
 
-**See Also:** [lastseenexpireafter in body common control][Components and Common Control#lastseenexpireafter]
+**See also:** [lastseenexpireafter in body common control][Components and Common Control#lastseenexpireafter]

--- a/reference/functions/ip2host.markdown
+++ b/reference/functions/ip2host.markdown
@@ -27,6 +27,6 @@ Output:
 
 [%CFEngine_include_snippet(ip2host.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `host2ip()`, `iprange()`, `isipinsubnet()`
+**See also:** `host2ip()`, `iprange()`, `isipinsubnet()`
 
 **History:** Was introduced in version 3.1.3, Nova 2.0.2 (2010)

--- a/reference/functions/iprange.markdown
+++ b/reference/functions/iprange.markdown
@@ -39,7 +39,7 @@ reports:
 }
 ```
 
-**See Also:** `isipinsubnet()`, `host2ip()`, `ip2host()`
+**See also:** `isipinsubnet()`, `host2ip()`, `ip2host()`
 
 **History:** The optional `interface` parameter was introduced in CFEngine 3.9.
 

--- a/reference/functions/isdir.markdown
+++ b/reference/functions/isdir.markdown
@@ -21,4 +21,4 @@ Output:
 
 [%CFEngine_include_snippet(isdir.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `fileexists()`, `filestat()`, `islink()`, `isplain()`, `returnszero()`
+**See also:** `fileexists()`, `filestat()`, `islink()`, `isplain()`, `returnszero()`

--- a/reference/functions/isipinsubnet.markdown
+++ b/reference/functions/isipinsubnet.markdown
@@ -21,6 +21,6 @@ Output:
 
 [%CFEngine_include_snippet(isipinsubnet.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `iprange()`, `host2ip()`, `ip2host()`
+**See also:** `iprange()`, `host2ip()`, `ip2host()`
 
 **History:** Was introduced in CFEngine 3.10.

--- a/reference/functions/islink.markdown
+++ b/reference/functions/islink.markdown
@@ -37,4 +37,4 @@ Output:
 
 [%CFEngine_include_snippet(islink.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `fileexists()`, `filestat()`, `isdir()`, `isplain()`, `returnszero()`
+**See also:** `fileexists()`, `filestat()`, `isdir()`, `isplain()`, `returnszero()`

--- a/reference/functions/isnewerthan.markdown
+++ b/reference/functions/isnewerthan.markdown
@@ -29,4 +29,4 @@ Output:
 
 [%CFEngine_include_snippet(isnewerthan.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `accessedbefore()`, `changedbefore()`
+**See also:** `accessedbefore()`, `changedbefore()`

--- a/reference/functions/isplain.markdown
+++ b/reference/functions/isplain.markdown
@@ -20,4 +20,4 @@ Output:
 
 [%CFEngine_include_snippet(isplain.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `fileexists()`, `filestat()`, `isdir()`, `islink()`, `returnszero()`
+**See also:** `fileexists()`, `filestat()`, `isdir()`, `islink()`, `returnszero()`

--- a/reference/functions/not.markdown
+++ b/reference/functions/not.markdown
@@ -27,6 +27,6 @@ commands:
 **Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
 promise attributes.
 
-**See Also:** `and`, `or`, `not`
+**See also:** `and`, `or`, `not`
 
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/reference/functions/or.markdown
+++ b/reference/functions/or.markdown
@@ -26,6 +26,6 @@ classes.
 **Notes:** Introduced primarily for use with `ifvarclass`, `if`, and `unless`
 promise attributes.
 
-**See Also:** `and`, `or`, `not`
+**See also:** `and`, `or`, `not`
 
 **History:** Was introduced in 3.2.0, Nova 2.1.0 (2011)

--- a/reference/functions/parseintarray.markdown
+++ b/reference/functions/parseintarray.markdown
@@ -40,4 +40,4 @@ Output:
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011**
 
-**See Also:** [`parsestringarray()`][parsestringarray], [`parserealarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]
+**See also:** [`parsestringarray()`][parsestringarray], [`parserealarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/parserealarray.markdown
+++ b/reference/functions/parserealarray.markdown
@@ -41,4 +41,4 @@ Output:
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
 
-**See Also:** [`parsestringarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]
+**See also:** [`parsestringarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/parsestringarray.markdown
+++ b/reference/functions/parsestringarray.markdown
@@ -41,4 +41,4 @@ Output:
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
 
-**See Also:** [`parserealarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]
+**See also:** [`parserealarray()`][parsestringarray], [`parseintarray()`][parserealarray], [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`readrealarray()`][readrealarray]

--- a/reference/functions/readintarray.markdown
+++ b/reference/functions/readintarray.markdown
@@ -48,4 +48,4 @@ Output:
 
 [%CFEngine_include_snippet(readintarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** [`readstringarray()`][readstringarray], [`readrealarray()`][readrealarray], [`parseintarray()`][parseintarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 
+**See also:** [`readstringarray()`][readstringarray], [`readrealarray()`][readrealarray], [`parseintarray()`][parseintarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 

--- a/reference/functions/readintlist.markdown
+++ b/reference/functions/readintlist.markdown
@@ -40,4 +40,4 @@ Output:
 [%CFEngine_include_snippet(readintlist.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 
-**See Also:** [`readstringlist()`][readstringlist], [`readreallist()`][readreallist]
+**See also:** [`readstringlist()`][readstringlist], [`readreallist()`][readreallist]

--- a/reference/functions/readrealarray.markdown
+++ b/reference/functions/readrealarray.markdown
@@ -124,4 +124,4 @@ Output:
 
 [%CFEngine_include_snippet(readrealarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 
+**See also:** [`readstringarray()`][readstringarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 

--- a/reference/functions/readreallist.markdown
+++ b/reference/functions/readreallist.markdown
@@ -40,4 +40,4 @@ Output:
 [%CFEngine_include_snippet(readreallist.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 
-**See Also:** [`readstringlist()`][readstringlist], [`readintlist()`][readintlist]
+**See also:** [`readstringlist()`][readstringlist], [`readintlist()`][readintlist]

--- a/reference/functions/readstringarray.markdown
+++ b/reference/functions/readstringarray.markdown
@@ -124,4 +124,4 @@ Output:
 
 [%CFEngine_include_snippet(readrealarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** [`readrealarray()`][readrealarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 
+**See also:** [`readrealarray()`][readrealarray], [`readintarray()`][readintarray], [`parserealarray()`][parserealarray], [`parserealarray()`][parserealarray], [`parsestringarray()`][parsestringarray] 

--- a/reference/functions/readstringlist.markdown
+++ b/reference/functions/readstringlist.markdown
@@ -40,4 +40,4 @@ Output:
 [%CFEngine_include_snippet(readstringlist.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 
-**See Also:** [`readintlist()`][readintlist], [`readreallist()`][readreallist]
+**See also:** [`readintlist()`][readintlist], [`readreallist()`][readreallist]

--- a/reference/functions/regcmp.markdown
+++ b/reference/functions/regcmp.markdown
@@ -27,4 +27,4 @@ using either standard regular expression syntax or using the additional
 features of PCRE (where `(?ms)` changes the way that ., `^` and `$` behave), e.g.
 
 
-**See Also:** `regline()`, `strcmp()`
+**See also:** `regline()`, `strcmp()`

--- a/reference/functions/regline.markdown
+++ b/reference/functions/regline.markdown
@@ -60,4 +60,4 @@ bundle edit_line upgrade_cfexecd
 }
 ```
 
-**See Also:** `regcmp()`, `strcmp()`
+**See also:** `regcmp()`, `strcmp()`

--- a/reference/functions/splayclass.markdown
+++ b/reference/functions/splayclass.markdown
@@ -54,4 +54,4 @@ by the `splayclass` is a time when you have told CFEngine *not* to run).
     }
 ```
 
-**See Also:** `hash_to_int()`
+**See also:** `hash_to_int()`

--- a/reference/functions/strcmp.markdown
+++ b/reference/functions/strcmp.markdown
@@ -20,4 +20,4 @@ Output:
 
 [%CFEngine_include_snippet(strcmp.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See Also:** `regcmp()`, `regline()`
+**See also:** `regcmp()`, `regline()`

--- a/reference/language-concepts/classes.markdown
+++ b/reference/language-concepts/classes.markdown
@@ -59,7 +59,7 @@ the `/var/cfengine/state/env_data` file is secure.
 The `classesmatching()` function searches using a regular expression for classes
 matching a given name and or tag.
 
-**See also**: The ```--show-vars``` option for `cf-promises` and the
+**See also:** The ```--show-vars``` option for `cf-promises` and the
 ```--show-evaluated-vars``` option for `cf-agent`.
 
 ## Tags

--- a/reference/language-concepts/promises.markdown
+++ b/reference/language-concepts/promises.markdown
@@ -99,7 +99,7 @@ Promise locks can be useful for controlling frequency.
 `access`, `classes`, `defaults`, `meta`, `roles` and `vars` type promises do not
 participate in locking.
 
-**See Also:** [ifelapsed in body agent control][cf-agent#ifelapsed], [ifelapsed action body attribute][Promise Types and Attributes#ifelapsed]
+**See also:** [ifelapsed in body agent control][cf-agent#ifelapsed], [ifelapsed action body attribute][Promise Types and Attributes#ifelapsed]
 
 ### Promise Attributes
 

--- a/reference/masterfiles-policy-framework/controls-cf_runagent.markdown
+++ b/reference/masterfiles-policy-framework/controls-cf_runagent.markdown
@@ -8,7 +8,7 @@ tags: [reference, controls, MPF]
 This is where `body runagent control` is defined. `body runagent control` is where
 various settings related to `cf-runagent` can be tuned.
 
-**See Also:** [Run agent on multiple hosts sharing a class][Manual Execution#Remote agent run for many hosts sharing a class]
+**See also:** [Run agent on multiple hosts sharing a class][Manual Execution#Remote agent run for many hosts sharing a class]
 
 [%CFEngine_library_include(controls/cf_runagent)%]
 

--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -214,7 +214,7 @@ body agent control
 }
 ```
 
-**See Also:** [promise locking][Promises#Promise Locking], [ifelapsed in body agent control][cf-agent#ifelapsed]
+**See also:** [promise locking][Promises#Promise Locking], [ifelapsed in body agent control][cf-agent#ifelapsed]
 
 #### expireafter
 
@@ -244,7 +244,7 @@ body action example
 }
 ```
 
-**See Also:** [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
+**See also:** [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
 
 #### log_string
 
@@ -479,7 +479,7 @@ body action background
 }
 ```
 
-**See Also**: [`max_children` in body agent control][cf-agent#max_children]
+**See also:** [`max_children` in body agent control][cf-agent#max_children]
 
 #### report_level
 

--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -707,7 +707,7 @@ access:
 }
 ```
 
-**See also**: [--remote-bundles option for cf-runagent][cf-runagent], [cfruncommand in body server control][cf-serverd#cfruncommand]
+**See also:** [--remote-bundles option for cf-runagent][cf-runagent], [cfruncommand in body server control][cf-serverd#cfruncommand]
 
 **History:**
 

--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -322,7 +322,7 @@ case of failure.
      }
 ```
 
-**See Also:** [`body action expireafter`][Promise Types and Attributes#expireafter],  [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
+**See also:** [`body action expireafter`][Promise Types and Attributes#expireafter],  [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
 
 #### chdir
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1041,7 +1041,7 @@ absolute path. Windows only supports hard links.
      }
 ```
 
-**See Also**: [link_type][files#link_type].
+**See also:** [link_type][files#link_type].
 
 #### link_type
 
@@ -1282,7 +1282,7 @@ timeout, in seconds.
      }
 ```
 
-**See Also:** [agent `default_timeout`][cf-agent#default_timeout], [`cf-runagent` timeout][cf-runagent#timeout]
+**See also:** [agent `default_timeout`][cf-agent#default_timeout], [`cf-runagent` timeout][cf-runagent#timeout]
 
 **Notes:**
 

--- a/reference/promise-types/files/edit_line.markdown
+++ b/reference/promise-types/files/edit_line.markdown
@@ -444,7 +444,7 @@ the file no matter what the value of `select_end_match_eof` is set to.
      }
 ```
 
-**See Also:** [`select_end_match_eof` in body agent control][cf-agent#select_end_match_eof]
+**See also:** [`select_end_match_eof` in body agent control][cf-agent#select_end_match_eof]
 
 **History:**
 

--- a/reference/promise-types/files/edit_line/delete_lines.markdown
+++ b/reference/promise-types/files/edit_line/delete_lines.markdown
@@ -224,4 +224,4 @@ only negates the match of the initially promised lines.
 
 This body applies to all promise types within `edit_line` bundles.
 
-**See Also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `insert_lines`][field_edits#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]
+**See also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `insert_lines`][field_edits#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]

--- a/reference/promise-types/files/edit_line/field_edits.markdown
+++ b/reference/promise-types/files/edit_line/field_edits.markdown
@@ -310,4 +310,4 @@ the lists of users in these fields are separated by a comma (',').
 
 This body applies to all promise types within `edit_line` bundles.
 
-**See Also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `insert_lines`][insert_lines#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]
+**See also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `insert_lines`][insert_lines#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]

--- a/reference/promise-types/files/edit_line/insert_lines.markdown
+++ b/reference/promise-types/files/edit_line/insert_lines.markdown
@@ -455,7 +455,7 @@ This attribute is mutually exclusive of `select_line_number`.
 
 This body applies to all promise types within `edit_line` bundles.
 
-**See Also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]
+**See also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `replace_patterns`][replace_patterns#select_region]
 
 ### whitespace_policy
 

--- a/reference/promise-types/files/edit_line/replace_patterns.markdown
+++ b/reference/promise-types/files/edit_line/replace_patterns.markdown
@@ -106,5 +106,5 @@ Replace only the first occurrence. Note: this is non-convergent.
 
 This body applies to all promise types within `edit_line` bundles.
 
-**See Also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `insert_lines`][insert_lines#select_region]
+**See also:** [```select_region``` with `edit_line` operations][edit_line#select_region], [```select_region``` in `delete_lines`][delete_lines#select_region], [```select_region``` in `field_edits`][field_edits#select_region], [```select_region``` in `insert_lines`][insert_lines#select_region]
 

--- a/reference/promise-types/files/edit_xml/delete_attribute.markdown
+++ b/reference/promise-types/files/edit_xml/delete_attribute.markdown
@@ -25,4 +25,4 @@ Note that typically, only a single attribute, within a single specified
 node, is deleted in each `delete_attribute` promise. You may of course
 have multiple promises that each delete an attribute.
 
-**See Also:** [Common `edit_xml` attributes][edit_xml#common attributes]
+**See also:** [Common `edit_xml` attributes][edit_xml#common attributes]

--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -256,7 +256,7 @@ body package_module apt_get
 repairs a package using the given `package_module`, when the lock has expired or
 when the agent is run without locks.
 
-**See Also:** `Package Modules`
+**See also:** `Package Modules`
 
 #### query_updates_ifelapsed
 
@@ -290,7 +290,7 @@ expired or when the agent is run without locks.
 [`list-updates-local`][Package Modules#list-updates-local] is called in all
 other conditions.
 
-**See Also:** `Package Modules`
+**See also:** `Package Modules`
 
 #### interpreter
 
@@ -315,7 +315,7 @@ body package_module apt_get
 }
 ```
 
-**See Also:** `Package Modules`
+**See also:** `Package Modules`
 
 **History:** Introduced in 3.13.0, 3.12.2
 
@@ -343,7 +343,7 @@ body package_module yum_all_repos
 }
 ```
 
-**See Also:** `Package Modules`
+**See also:** `Package Modules`
 
 **History:** Introduced in 3.13.0, 3.12.2
 

--- a/reference/promise-types/services.markdown
+++ b/reference/promise-types/services.markdown
@@ -267,7 +267,7 @@ bundle agent my_custom_service_method_DEB( service_identifier, desired_service_s
 }
 ```
 
-**See Also:** [generic standard_services][Services Bodies and Bundles#standard_services]
+**See also:** [generic standard_services][Services Bodies and Bundles#standard_services]
 
 **History:**
 

--- a/reference/special-variables/sys.markdown
+++ b/reference/special-variables/sys.markdown
@@ -1218,7 +1218,7 @@ The name of the directory where CFEngine saves the daemon pid files.
 The basename of the first policy file read by the agent. For example
 ```promises.cf``` or ```update.cf```.
 
-**See Also:** [`sys.policy_entry_dirname`][sys.policy_entry_dirname] [`sys.policy_entry_filename`][sys.policy_entry_dirname]
+**See also:** [`sys.policy_entry_dirname`][sys.policy_entry_dirname] [`sys.policy_entry_filename`][sys.policy_entry_dirname]
 
 **History:**
 
@@ -1229,7 +1229,7 @@ The basename of the first policy file read by the agent. For example
 The full path to the directory containing the first policy file read by the agent. For example
 ```/var/cfengine/inputs``` or ```~/.cfagent/inputs```.
 
-**See Also:** [`sys.policy_entry_basename`][sys#sys.policy_entry_basename] [`sys.policy_entry_filename`][sys.policy_entry_filename]
+**See also:** [`sys.policy_entry_basename`][sys#sys.policy_entry_basename] [`sys.policy_entry_filename`][sys.policy_entry_filename]
 
 
 **History:**
@@ -1241,7 +1241,7 @@ The full path to the directory containing the first policy file read by the agen
 The full path to the first policy file read by the agent. For example
 ```/var/cfengine/inputs/promises.cf``` or ```~/.cfagent/inputs/promises.cf```.
 
-**See Also:** [`sys.policy_entry_basename`][sys#sys.policy_entry_basename] [`sys.policy_entry_dirname`][sys#sys.policy_entry_dirname]
+**See also:** [`sys.policy_entry_basename`][sys#sys.policy_entry_basename] [`sys.policy_entry_dirname`][sys#sys.policy_entry_dirname]
 
 
 **History:**

--- a/reference/special-variables/this.markdown
+++ b/reference/special-variables/this.markdown
@@ -152,7 +152,7 @@ body service_method non_standard_services
 This is typically used in the adaptations for custom services bundles in
 the service methods.
 
-**See Also:**
+**See also:**
 
 * `Services Bundles and Bodies` in the `Masterfiles Policy Framework standard
   library`


### PR DESCRIPTION
Used replacer.py:

https://github.com/olehermanse/dotfiles/blob/d3a155320b4ec5c297f9364ebcfbc39dc7dbaa01/bin/replacer.py

3 commands:

```
find . -name '*.markdown' -exec replacer.py '**See Also:**' '**See also:**' '{}' \;
find . -name '*.markdown' -exec replacer.py '**See Also**:' '**See also:**' '{}' \;
find . -name '*.markdown' -exec replacer.py '**See also**:' '**See also:**' '{}' \;
```