### PR TITLE
CFE-3472: ensure_running_1.c: Fixed components -> component

### DIFF
--- a/examples/example-snippets/ensure_running_1.cf
+++ b/examples/example-snippets/ensure_running_1.cf
@@ -2,11 +2,11 @@ bundle agent CFEngine_processes
 {
   vars:
 
-    "components" slist => { "cf-execd", "cf-monitord", "cf-serverd", "cf-hub" };
+    "component" slist => { "cf-execd", "cf-monitord", "cf-serverd", "cf-hub" };
 
   processes:
 
-    "$(components)"
+    "$(component)"
       comment => "Make sure server parts of CFEngine are running",
       restart_class => canonify("$(component)_not_running");
 


### PR DESCRIPTION
This example disagrees with itself, referencing both
"component" and "components". The other examples call the
slist "component" so I went for that.