### PR TITLE
CFE-3551/3.12: Fixed syntax in example inline yaml

### DIFF
--- a/reference/promise-types/vars.markdown
+++ b/reference/promise-types/vars.markdown
@@ -297,7 +297,7 @@ Output:
 
      # JSON or YAML can be inlined since CFEngine 3.7
      "inline1" data => '{"key":"value"}'; # JSON
-     "inline2" data => '---\n- key2: value2'; # YAML requires "---\n" header
+     "inline2" data => '---$(const.n)- key2: value2'; # YAML requires "---$(const.n)" header
 
 ```
 


### PR DESCRIPTION
CFEngine doesn't interpret \n in strings as a newline, if a newline is needed,
$(const.n) should be used.

Ticket: CFE-3551
Changelog: None
(cherry picked from commit ae175d98e72b10c93aac1c826e865badce015063)