### PR TITLE
ENT-7059: Added Bootstrap icon license reference (master)

### DIFF
--- a/legal.markdown
+++ b/legal.markdown
@@ -62,6 +62,7 @@ CFEngine includes the following 3rd party libraries and components:
 * [redis](http://redis.io) under the [three clause BSD license](http://redis.io/topics/license)
 * [rsync](http://rsync.samba.org) under the [GPLv3](http://rsync.samba.org/GPL.html)
 * [Twitter Bootstrap Framework](http://getbootstrap.com) under [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [Bootstrap Icons](https://icons.getbootstrap.com) under the [MIT license](https://github.com/twbs/icons/blob/main/LICENSE.md)
 * [underscore.js](http://underscorejs.org) under the MIT license
 
 <!--- * [Piwik.js](http://piwik.org) under the [Simplified BSD license](http://piwik.org/free-software/bsd/) -->


### PR DESCRIPTION
To have more clean and sharp-looking icons within the mission portal, we would like to include Bootstrap's icon set in the MP UI design. 

Ticket: ENT-7059
Changelog: Added Bootstrap icon license reference