### PR TITLE
CFE-3673: Switched to correct examples from core for parse*array functions (master)

### DIFF
--- a/reference/functions/parseintarray.markdown
+++ b/reference/functions/parseintarray.markdown
@@ -32,11 +32,11 @@ split into fields. Using the empty string (`""`) indicates no comments.
 
 **Example:**
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+[%CFEngine_include_snippet(parseintarray.cf, #\+begin_src cfengine3, .*end_src)%]
 
 Output:
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+[%CFEngine_include_snippet(parseintarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011**
 

--- a/reference/functions/parserealarray.markdown
+++ b/reference/functions/parserealarray.markdown
@@ -33,11 +33,11 @@ split into fields. Using the empty string (`""`) indicates no comments.
 
 **Example:**
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+[%CFEngine_include_snippet(parserealarray.cf, #\+begin_src cfengine3, .*end_src)%]
 
 Output:
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+[%CFEngine_include_snippet(parserealarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
 

--- a/reference/functions/parsestringarray.markdown
+++ b/reference/functions/parsestringarray.markdown
@@ -33,11 +33,11 @@ split into fields. Using the empty string (`""`) indicates no comments.
 
 **Example:**
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src cfengine3, .*end_src)%]
+[%CFEngine_include_snippet(parsestringarray.cf, #\+begin_src cfengine3, .*end_src)%]
 
 Output:
 
-[%CFEngine_include_snippet(parseintrealstringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
+[%CFEngine_include_snippet(parsestringarray.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
 **History:** Was introduced in version 3.1.5a1, Nova 2.1.0 (2011)
 


### PR DESCRIPTION
merge together: https://github.com/cfengine/core/pull/4668

Ticket: CFE-3673
Changelog: None