### PR TITLE
ENT-7355 fix upgrading link in guide

### DIFF
--- a/guide.markdown
+++ b/guide.markdown
@@ -66,7 +66,7 @@ experts if you need more help. Contact us!
 * [Installation and Configuration][]
 	* [Pre-Installation Checklist]
 	* [General Installation]
-	* [Upgrading to {{site.cfengine.branch}}]
+	* [Upgrading]
 	* [Secure Bootstrap]
 * [Writing and Serving Policy][]
 	* [Language Concepts][]


### PR DESCRIPTION
The page is called just "upgrading" now, without version.