### PR TITLE
Changed commands' attribute inform default value to true

### DIFF
--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -423,7 +423,7 @@ be useful in all cases.
 
 **Type:** [`boolean`][boolean]
 
-**Default value:** false
+**Default value:** true
 
 **Example:**
 


### PR DESCRIPTION
Running the bellow bundle indicates that the default
value is not false but true, as output is reported.
```
bundle agent main
{
  commands:
    "/bin/touch /tmp/module_cache";  # expect output

    "/bin/cat /tmp/module_cache"  # expect no output
      inform => "false";
}
```
Command: `sudo cf-agent -KI inform.cf`
Output:
```
    info: Executing 'no timeout' ... '/bin/touch /tmp/module_cache'
    info: Completed execution of '/bin/touch /tmp/module_cache'
```

Ticket: None
Changelog: None
