### PR TITLE
ENT-4768: Added details about measurements (3.15)

### DIFF
--- a/reference/promise-types/measurements.markdown
+++ b/reference/promise-types/measurements.markdown
@@ -169,7 +169,7 @@ A synonym for 'scalar'.
 * `log`
 
 The measured value is logged as an infinite time-series in
-`$(sys.workdir)/state`.
+`$(sys.workdir)/state/<handle>_measure.log`.
 
 * `weekly`
 
@@ -188,6 +188,13 @@ is retained.
       units => "kB",
       match_value => free_memory;
 ```
+
+**Notes:**
+
+* Measurements with history type `weekly` _are collected_ by CFEngine Enterprise reporting.
+* Measurements with history type `static` are _not collected_ by CFEngine Enterprise reporting.
+* Measurements with history type `scalar` are _not collected_ by CFEngine Enterprise reporting.
+* Measurements with history type `log` are _not collected_ by CFEngine Enterprise reporting.
 
 ### units
 


### PR DESCRIPTION
Specifically:
- Where measurements with history_type log are recorded.
- What history_type values are and aren't collected by Enterprise Reporting

Ticket: ENT-4768
Changelog: None
(cherry picked from commit 6b36fcb89ec7216af14e3f39db4f810d377ca2fa)