### PR TITLE
ENT-6853: Published special topics Security (3.18)

### DIFF
--- a/guide/special-topics/security.markdown
+++ b/guide/special-topics/security.markdown
@@ -1,16 +1,24 @@
 ---
 layout: default
 title: Security
-published: false
+published: True
 sorting: 80
 tags: [overviews, special topics, guide]
 ---
-# Architecture Principles
+
+{% comment %}
+Diego Zamboni, discusses why CFEngine is a critical component of maintaining IT system security. Many vulnerabilities are directly caused by faulty configurations, so security is closely linked to how well configuration management works.
+
+Learn how security has been built into CFEngine architecture and how CFEngine keeps your organization secure by continuously running checks of settings, files, databases, services and registries, and correcting them when required.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7gb7ic0T708" frameborder="0" allowfullscreen></iframe>
+{% endcomment %}
+## Architecture Principles
 
 CFEngine is agent based software. It resides on and runs processes on each
 individual computer under its management. That means you do not need to grant
 any security credentials for login to CFEngine. Instead, for normal operation,
-CFEngine runs in privileged `root' or `Administrator' mode to get access to
+CFEngine runs in privileged `root` or `Administrator` mode to get access to
 system resources and makes these available safely to authorized enquiries.
 
 A CFEngine installation is thus required on every machine you want to manage:
@@ -45,7 +53,7 @@ communication (e.g. network connectivity) and that each host is responsible for
 maintaining its own state. This affects the security and scalability of the
 solution.
 
-## Single point of coordination
+### Single point of coordination
 
 The default CFEngine Nova architecture uses a single hub or policy server to
 publish changes of policy and to aggregate knowledge about the environment, but
@@ -54,8 +62,8 @@ organization independently. The CFEngine technology is not centralized by
 nature. Most users choose to centralize updating of policy and report
 aggregation for convenience however.
 
-Figure: A policy server or `hub' is implemented in CFEngine Nova
-as a simple solution that will scale for most sites `out of the box'.
+Figure: A policy server or `hub` is implemented in CFEngine Nova
+as a simple solution that will scale for most sites out of the box.
 
 
 If you operate CFEngine Nova in its default mode, the hub acts as a server from
@@ -69,7 +77,7 @@ outside of normal production environment. This can be done using the specialized
 editor embedded in CFEngine Nova, or it can be done using any text editor of
 your choice.
 
-## Policy information flow
+### Policy information flow
 
 Edits are made in conjunction with a version control repository1, which should
 be used to document the reasons for changes to policy2. When a change has been
@@ -82,7 +90,7 @@ Figure: Policy coordinated from a central root location
 is implemented in a distributed manner at every leaf node.
 
 
-## Robustness to failure
+### Robustness to failure
 
 If an agent receives a policy proposal that is badly formed or in some way
 non-executable, it switches to a failover strategy to recover. It will continue
@@ -95,7 +103,7 @@ source, and restart its own services. Should the new version be corrupt, the
 twin will still be the old working version, hence the software will be able to
 recover as soon as a new valid version is available.
 
-## Distributed execution and federation
+### Distributed execution and federation
 
 Each agent runs independently of others, unless it promises to acquire services
 from other hosts. Thus all processing capacity and decision-making computation
@@ -110,12 +118,12 @@ where attention to local requirements is paramount for whatever reason.
 Federation is typically a recommended strategy when the cost of avoiding local
 specialization outweighs the price of having local policy-makers. Universities
 and large companies (e.g. formed through acquisition) are typical candidates for
-federated management. Federation is facilitated by an essentially `service
-oriented architecture'3, i.e. a weak coupling.
+federated management. Federation is facilitated by a service
+oriented architecture, i.e. a weak coupling.
 
-# Security Principles
+## Security Principles
 
-## What is security?
+### What is security?
 
 
 The concept of security, while various in its interpretation and intented use,
@@ -125,7 +133,7 @@ defined by a model, an attitude, and a policy. It involves a set of compromises
 called atrust modelthat determines where you draw the line in the sand between
 trusted and risky.
 
-## The principles of CFEngine security
+### The principles of CFEngine security
 
 CFEngine adheres to the following design principles:
 
@@ -145,7 +153,7 @@ CFEngine adheres to the following design principles:
 * CFEngine shall always provide safe defaults, that grant no access to other
   hosts.
 
-## Communications
+### Communications
 
 CFEngine uses a simple, private protocol that is based on (but not identical to)
 that used by OpenSSH (the free version of the Secure Shel). It is based on
@@ -155,15 +163,14 @@ Infrastructure.
  * Authentication by Public Key is mandatory.
  * Encryption of data transfer is optional.
 
-# Communication Security
-
-## TCP wrappers
+## Communication Security
+### TCP wrappers
 
 The right to connect to the server is the first line of defence. CFEngine has
-built into it the equivalent of the `TCP wrappers' software to deny
+built into it the equivalent of the `TCP wrappers` software to deny
 non-authorized hosts the ability to connect to the server at all.
 
-## The connection sequence
+### The connection sequence
 
 A client attempts to connect to port 5308 Server examines IP address of
 connection and applies rules from
@@ -199,7 +206,7 @@ connection and applies rules from
   * All other deny rules are ignored
   * No deny rule means you're admitted
 
-## Encryption algorithms
+### Encryption algorithms
 
 CFEngine Community Edition uses RSA 2048 public key encryption for
 authentication. These are generated by the ‘cf-key’ command. It generates a 128
@@ -211,17 +218,17 @@ and then AES 256 with a 256 bit random key for data transmission. The latter is
 validated for FIPS 140-2 government use in the United States of America.
 Challenge response is verified by a SHA256 hash.
 
-## Remote communication
+### Remote communication
 
 The concept of voluntary cooperation used by CFEngine places restrictions on how
-files can be copied between hosts. CFEngine allows only `pull' (download) but
-not `push' (upload). Users cannot force an agent to perform an operation against
+files can be copied between hosts. CFEngine allows only _pull_ (download) but
+not _push_ (upload). Users cannot force an agent to perform an operation against
 local policy.
 
 To allow remote copying between two systems each of the system must explicitly
 grant access before the operation can take place.
 
-## Authentication
+### Authentication
 
 Authentication is about making sure users are who they say you are.
 Traditionally, there are two approaches: the trusted third party (arbiter of the
@@ -247,7 +254,7 @@ instead of ‘ssh key-gen’ program. Key acceptance is accomplished in CFEngine
 using trust-key method. Once the keys have been exchange the trust settings are
 irrelevant.
 
-## Security FAQ
+### Security FAQ
 
 Doesn't opening a port on a machine on the inside of the firewall make it
 vulnerable to both Denial of Service and buffer overflow attacks?
@@ -291,14 +298,14 @@ firewall security model of trusted/untrusted regions. The firewall does not
 mitigate the responsibility of security every host in a network regardless of
 which side of the firewall it is connected.
 
-# CFEngine and Firewalls
+### CFEngine and Firewalls
 
 Some users want to use CFEngine's remote copying mechanism through a firewall,
 in particular to update the CFEngine policy on hosts inside a DMZ (so-called
 de-militarized zone). In making a risk assessment, it is important to see the
 firewall security model together with the CFEngine security model. CFEngine's
 security record is better than most firewalls, but Firewalls are nearly always
-trusted because they are `security products'.
+trusted because they are "_security products_".
 
 Any piece of software that traverses a firewall can, in principle, weaken the
 security of the barrier. On the other hand, a strong piece or software might
@@ -328,7 +335,7 @@ inside of the firewall, information has to traverse the firewall.
 * Policy Mirror in the DMZ
 * Pulling through a wormhole
 
-### CFEngine trust model
+#### CFEngine trust model
 
 CFEngine's trust model is fundamentally at odds with the external firewall
 concept. CFEngine says: “I am my own boss. I don't trust anyone to push me
@@ -362,7 +369,7 @@ latter to offer at this point:
   ludicrous to suggest that an arbitrary employee's machine is more secure than
   an inaccessible host in the DMZ.
 
-### Policy Mirror in the DMZ
+#### Policy Mirror in the DMZ
 
 By creating a policy mirror in the DMZ, these issues can be worked around. This
 is the recommended way to copy files, so that normal CFEngine pull methods can
@@ -379,7 +386,7 @@ on the mirror, except that now you have to trust the security of another piece
 of software too. Since this is not a CFEngine port, no guarantees can be made
 about what access attackers will get to the mirror host.
 
-### Pulling through a wormhole
+#### Pulling through a wormhole
 
 Suppose you are allowed to open a hole in your firewall to a single policy host
 on the inside. To distribute files to hosts that are outside the firewall it is
@@ -413,7 +420,7 @@ Once a new copy of the policy is downloaded by CFEngine to the policy mirror,
 other clients in the DMZ can download that copy from the mirror. The security of
 other hosts in the DMZ is dependent on the security of the policy mirror.
 
-## Tamperproof data and distributed monitoring
+### Tamperproof data and distributed monitoring
 
 Message digests are supposed to be unbreakable, tamperproof technologies, but of
 course everything can be broken by a sufficiently determined attacker. Suppose
@@ -484,7 +491,7 @@ cannot see the contents of your files from this.Â A possibly greater problem is
 that this configuration will unleash an avalanche of messages if a change is
 detected. This makes messages visible at least.
 
-# Footnotes
+## Footnotes
 
 [1] CFEngine supports integration with Subversion through its Mission Portal,
 but any versioning system can of course be used.


### PR DESCRIPTION
I made some tweaks which should help pass the build, and I added a comment with
the text from the old cfengine.com/learn section on security. The comment
includes the link to the youtube video presentation where Diego discusses
security. Since the video is private, I figured that this was the best place to
leave a bread crumb.

Ticket: ENT-6853
Changelog: None
(cherry picked from commit d8cdd96b729d742a1cc3b5753482f715403625ff)