### PR TITLE
CFE-3775: Added link from packagesmatching* functions to related MPF tunables (3.18)

### DIFF
--- a/reference/functions/packagesmatching.markdown
+++ b/reference/functions/packagesmatching.markdown
@@ -62,4 +62,4 @@ some desired packages, and finally reports if they are installed.
 
 **History:** Introduced in CFEngine 3.6
 
-**See also:** `packageupdatesmatching()`.
+**See also:** `packageupdatesmatching()`, [Package information cache tunables in the MPF][Masterfiles Policy Framework#Configure periodic package inventory refresh interval]

--- a/reference/functions/packageupdatesmatching.markdown
+++ b/reference/functions/packageupdatesmatching.markdown
@@ -58,4 +58,4 @@ this:
 
 **History:** Introduced in CFEngine 3.6
 
-**See also:** `packagesmatching()`.
+**See also:** `packagesmatching()`, [Package information cache tunables in the MPF][Masterfiles Policy Framework#Configure periodic package inventory refresh interval]


### PR DESCRIPTION
Ticket: CFE-3775
Changelog: None