### PR TITLE
CFE-3793: Added docs and example for const.at (3.18)

### DIFF
--- a/reference/special-variables/const.markdown
+++ b/reference/special-variables/const.markdown
@@ -8,6 +8,21 @@ tags: [reference, variables, const, const]
 CFEngine defines a number of variables for embedding unprintable values
 or values with special meanings in strings.
 
+[%CFEngine_include_example(const.cf)%]
+
+### const.at
+
+```cf3
+    reports:
+
+       "The value of $(const.at) is @";
+
+```
+
+**History:**
+
+* Added in CFEngine 3.19.0, 3.18.1
+
 ### const.dollar
 
 


### PR DESCRIPTION
The example covers all const variables in addition to the new const.at variable.

Ticket: CFE-3793
Changelog: None
(cherry picked from commit beff15b07423eb1c1d7872756debf2f63cea30c8)