### PR TITLE
CFE-3794: Removed indication that associative arrays are being deprecated (3.18)

### DIFF
--- a/reference/language-concepts/variables.markdown
+++ b/reference/language-concepts/variables.markdown
@@ -189,6 +189,6 @@ from array variables for iteration purposes.
 
 **Example:**
 
-[%CFEngine_include_example(array.cf)%]
+[%CFEngine_include_example(arrays.cf)%]
 
 **See also:** `getindices()`, `getvalues()`


### PR DESCRIPTION
Ticket: CFE-3794
Changelog: None
(cherry picked from commit 96843faa376dc59146e89c7f897b57ffd7075567)