### PR TITLE
ENT-7735: Added section for CFEngine documentation license to legal page (3.15)

### DIFF
--- a/legal.markdown
+++ b/legal.markdown
@@ -16,6 +16,10 @@ including, but not limited to, implied warranties of merchantability, fitness
 for a particular purpose, title and non-infringement with regard to the
 Licensed Software.
 
+## CFEngine Documentation License
+
+The documentation is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/deed.en_US).
+
 ## 3rd Party Licenses and Libraries
 
 CFEngine includes the following 3rd party libraries and components:


### PR DESCRIPTION
Ticket: ENT-7735
Changelog: None
(cherry picked from commit 2d54c9aaae45b6f4cac3095c1ea2c6b528386248)