### PR TITLE
Remove an extra 'Parameters' section in Update CMDB API docs (3.18)

### DIFF
--- a/reference/enterprise-api-ref/cmdb-api.markdown
+++ b/reference/enterprise-api-ref/cmdb-api.markdown
@@ -308,16 +308,6 @@ HTTP 201 Created
 * **name** *(string)*
   Configuration name. Classes or variables name.
 
-**Parameters:**
-* **hostkey** *(string)*
-  Unique host identifier.
-
-* **type** *(string)*
-  Configuration type. Allowed value: `variables`, `classes`
-
-* **name** *(string)*
-  Configuration name. Classes or variables name.
-
 **Request body parameters:**
 
 * **value** *(string|array)*


### PR DESCRIPTION
Noticed when reading the docs and using the API.

(cherry picked from commit e017ae59452c1d59051dcff0e2be75dd175eed70)