### PR TITLE
Fixed vagrant ip for better compatibility

### DIFF
--- a/guide/getting-started-with-cfengine-build/installation.markdown
+++ b/guide/getting-started-with-cfengine-build/installation.markdown
@@ -128,7 +128,7 @@ For example, in Digital Ocean, the username is `root`, and the IP might be `128.
 
 ![](digital-ocean.png)
 
-**Note:** In the rest of this tutorial, replace the IP address we use in the examples, `192.168.56.2` with that IP.
+**Note:** In the rest of this tutorial, replace the IP address we use in the examples, `192.0.2.2` with that IP.
 
 **Using Vagrant and Virtualbox:**
 
@@ -143,13 +143,13 @@ Come back to this tutorial after you have completed the installation and setup o
 Test that ssh works:
 
 ```
-$ ssh root@192.168.56.2
+$ ssh root@192.0.2.2
 ```
 
 Save the host in `cf-remote` so you can copy-paste our later commands:
 
 ```
-$ cf-remote save -H root@192.168.56.2 --role hub --name hub
+$ cf-remote save -H root@192.0.2.2 --role hub --name hub
 ```
 
 The host is now in a `cf-remote` group called `hub`, so we don't have to type the username and IP, for example:
@@ -161,7 +161,7 @@ $ cf-remote info -H hub
 Shows this output:
 
 ```
-root@192.168.56.2
+root@192.0.2.2
 OS            : ubuntu (debian)
 Architecture  : x86_64
 CFEngine      : Not installed
@@ -181,7 +181,7 @@ $ cf-remote install --hub hub --bootstrap hub
 
 Open the CFEngine Web UI in a web browser by clicking this link, or typing the appropriate IP in the address bar:
 
-https://192.168.56.2/
+https://192.0.2.2/
 
 You might get warnings about an insecure connection or invalid certificate.
 At this point, your hub has a self signed certificate, which means there is no certificate authority that can verify which server you are talking to.

--- a/guide/getting-started-with-cfengine-build/installation/vagrant.markdown
+++ b/guide/getting-started-with-cfengine-build/installation/vagrant.markdown
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
     # Ubuntu 20.04 VM, for CFEngine Enterprise Hub:
     config.vm.define "hub", autostart: false do |hub|
         hub.vm.box = "ubuntu/focal64"
-        hub.vm.network "private_network", ip: "192.168.56.2"
+        hub.vm.network "private_network", ip: "192.0.2.2"
         hub.ssh.insert_key = true
         hub.vm.provider "virtualbox" do |v|
             v.memory = 2048
@@ -90,7 +90,7 @@ end
 The `Vagrantfile` above does some important things:
 
 * Defines a Ubuntu 20.04 Virtual machine called `hub`
-* Sets its IP address to be `192.168.56.2`
+* Sets its IP address to be `192.0.2.2`
 * Sets how much memory and CPU cores we want the VM to have
 * Copies the `id_rsa.pub` public key into the host when it starts, so we can use `ssh`
 

--- a/guide/getting-started-with-cfengine-build/modules-from-cfengine-build.markdown
+++ b/guide/getting-started-with-cfengine-build/modules-from-cfengine-build.markdown
@@ -119,7 +119,7 @@ $ cf-remote deploy
 We did this in the first part of the series, while installing CFEngine, but if you haven't you can do it like this:
 
 ```
-$ cf-remote save -H root@192.168.56.2 --role hub --name hub
+$ cf-remote save -H root@192.0.2.2 --role hub --name hub
 ```
 
 (Replace SSH username and IP with what works on your hub).
@@ -129,7 +129,7 @@ $ cf-remote save -H root@192.168.56.2 --role hub --name hub
 Open your web browser and enter the IP address of your hub in the address bar to go the Mission Portal web UI.
 For example:
 
-https://192.168.56.2/
+https://192.0.2.2/
 
 (Log in with username `admin` and password `admin`, or whatever you changed it to when you first logged into your hub).
 

--- a/guide/getting-started-with-cfengine-build/reporting-and-web-ui.markdown
+++ b/guide/getting-started-with-cfengine-build/reporting-and-web-ui.markdown
@@ -11,7 +11,7 @@ This is by no means an exhaustive list of everything Mission Portal offers, but 
 If you haven't already, open your web browser and put the IP address (or hostname) of your CFEngine Hub in the address bar.
 For example:
 
-https://192.168.56.2/
+https://192.0.2.2/
 
 (Log in with the username and password for your hub, the default is `admin` as both and you will be prompted to change it on the first login).
 

--- a/guide/getting-started-with-cfengine-build/writing-policy.markdown
+++ b/guide/getting-started-with-cfengine-build/writing-policy.markdown
@@ -76,7 +76,7 @@ You can log in with SSH to check this, or use `cf-remote`:
 
 ```
 $ cf-remote sudo -H hub "cat /tmp/hello"
-root@192.168.56.2: 'cat /tmp/hello' -> 'Hello, world!'
+root@192.0.2.2: 'cat /tmp/hello' -> 'Hello, world!'
 ```
 
 ## Running the agent


### PR DESCRIPTION
Bringing up the vagrant environment with the provided config results in messages
like this:

==> hub: You assigned a static IP ending in ".1" to this machine.
==> hub: This is very often used by the router and can cause the
==> hub: network to not work properly. If the network doesn't work
==> hub: properly, try changing this IP.

Indeed, while the vagrant env got the proper ssh keys inserted I was unable to
log in directly with ssh (but could use vagrant ssh from within the project).

I recall that I had similar issues when originally making the vagrant project
years ago. Indeed, switching to .2 resolved the issue.