### PR TITLE
CFE-3952: Switched to 192.168.56.0/24 from 192.168.33.0/24

### DIFF
--- a/examples/example-snippets/promise-patterns/example_ssh_keys.markdown
+++ b/examples/example-snippets/promise-patterns/example_ssh_keys.markdown
@@ -64,16 +64,16 @@ root@host001:~# cf-agent -Kf update.cf; cf-agent -KI
     info: Created directory '/home/bob/.ssh/.'
     info: Owner of '/home/bob/.ssh' was 0, setting to 1002
     info: Object '/home/bob/.ssh' had permission 0755, changed it to 0700
-    info: Copying from '192.168.33.2:/srv/ssh_authorized_keys/bob'
+    info: Copying from '192.168.56.2:/srv/ssh_authorized_keys/bob'
     info: Owner of '/home/bob/.ssh/authorized_keys' was 0, setting to 1002
     info: Created directory '/home/frank/.ssh/.'
     info: Owner of '/home/frank/.ssh' was 0, setting to 1003
     info: Object '/home/frank/.ssh' had permission 0755, changed it to 0700
-    info: Copying from '192.168.33.2:/srv/ssh_authorized_keys/frank'
+    info: Copying from '192.168.56.2:/srv/ssh_authorized_keys/frank'
     info: Owner of '/home/frank/.ssh/authorized_keys' was 0, setting to 1003
     info: Created directory '/home/kelly/.ssh/.'
     info: Owner of '/home/kelly/.ssh' was 0, setting to 1004
     info: Object '/home/kelly/.ssh' had permission 0755, changed it to 0700
-    info: Copying from '192.168.33.2:/srv/ssh_authorized_keys/kelly'
+    info: Copying from '192.168.56.2:/srv/ssh_authorized_keys/kelly'
     info: Owner of '/home/kelly/.ssh/authorized_keys' was 0, setting to 1004
 ```

--- a/guide/faq/enterprise-report-collection.markdown
+++ b/guide/faq/enterprise-report-collection.markdown
@@ -156,21 +156,21 @@ help to expose so called *patching* issues. If the same amount of data is
 collected twice a **rebase** may resolve it.
 
 ```console
-[root@hub ~]# cf-hub -q delta -H 192.168.33.2 -v
+[root@hub ~]# cf-hub -q delta -H 192.168.56.2 -v
  verbose: ----------------------------------------------------------------
  verbose:  Initialization preamble 
  verbose: ----------------------------------------------------------------
  # <snipped for brevity>
- verbose: Connecting to host 192.168.33.2, port 5308 as address 192.168.33.2
+ verbose: Connecting to host 192.168.56.2, port 5308 as address 192.168.56.2
  verbose: Waiting to connect...
  verbose: Setting socket timeout to 10 seconds.
- verbose: Connected to host 192.168.33.2 address 192.168.33.2 port 5308 (socket descriptor 4)
+ verbose: Connected to host 192.168.56.2 address 192.168.56.2 port 5308 (socket descriptor 4)
  verbose: TLS version negotiated:  TLSv1.2; Cipher: AES256-GCM-SHA384,TLSv1/SSLv3
  verbose: TLS session established, checking trust...
  verbose: Received public key compares equal to the one we have stored
  verbose: Server is TRUSTED, received key 'SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1' MATCHES stored one.
- verbose: Key digest for address '192.168.33.2' is SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1
- verbose: Will request from host 192.168.33.2 (digest = SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1) data later than timestamp 1481901790
+ verbose: Key digest for address '192.168.56.2' is SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1
+ verbose: Will request from host 192.168.56.2 (digest = SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1) data later than timestamp 1481901790
  verbose: Successfully opened extension plugin 'cfengine-report-collect.so' from '/var/cfengine/lib/cfengine-report-collect.so'
  verbose: Successfully loaded extension plugin 'cfengine-report-collect.so'
  verbose: Sending query at Fri Dec 16 15:24:23 2016
@@ -182,7 +182,7 @@ collected twice a **rebase** may resolve it.
  verbose: Processing report: MOH (items: 22)
  verbose: Processing report: EXS (items: 1)
  verbose: Received 5 kb of report data with 115 individual items
- verbose: Connection to 192.168.33.2 is closed
+ verbose: Connection to 192.168.56.2 is closed
 ```
 
 ### Perform manual rebase collection for a single host
@@ -191,20 +191,20 @@ A `rebase` causes the hub to throw away all reports since the last collection
 and collect only the output from the most recent run.
 
 ```console
-[root@hub ~]# cf-hub -q rebase -H 192.168.33.2 -v
+[root@hub ~]# cf-hub -q rebase -H 192.168.56.2 -v
  verbose: ----------------------------------------------------------------
  verbose:  Initialization preamble 
  verbose: ----------------------------------------------------------------
  # <snipped for brevity>
- verbose: Connecting to host 192.168.33.2, port 5308 as address 192.168.33.2
+ verbose: Connecting to host 192.168.56.2, port 5308 as address 192.168.56.2
  verbose: Waiting to connect...
  verbose: Setting socket timeout to 10 seconds.
- verbose: Connected to host 192.168.33.2 address 192.168.33.2 port 5308 (socket descriptor 4)
+ verbose: Connected to host 192.168.56.2 address 192.168.56.2 port 5308 (socket descriptor 4)
  verbose: TLS version negotiated:  TLSv1.2; Cipher: AES256-GCM-SHA384,TLSv1/SSLv3
  verbose: TLS session established, checking trust...
  verbose: Received public key compares equal to the one we have stored
  verbose: Server is TRUSTED, received key 'SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1' MATCHES stored one.
- verbose: Key digest for address '192.168.33.2' is SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1
+ verbose: Key digest for address '192.168.56.2' is SHA=e77d408e9802e2c549417d5e3379c43050d2ad5928a198855dbb7e9c8af9a6f1
  verbose: Successfully opened extension plugin 'cfengine-report-collect.so' from '/var/cfengine/lib/cfengine-report-collect.so'
  verbose: Successfully loaded extension plugin 'cfengine-report-collect.so'
  verbose: Sending query at Fri Dec 16 15:35:10 2016
@@ -219,7 +219,7 @@ and collect only the output from the most recent run.
  verbose: Processing report: ELD (items: 205)
  verbose: 	ts #0 > 1481902510
  verbose: Received 125 kb of report data with 786 individual items
- verbose: Connection to 192.168.33.2 is closed
+ verbose: Connection to 192.168.56.2 is closed
 ```
 
 **Note:** The Enterprise hub automatically schedules rebase queries if it has

--- a/guide/faq/unable-to-log-in-mission-portal.markdown
+++ b/guide/faq/unable-to-log-in-mission-portal.markdown
@@ -16,7 +16,7 @@ Verify the name used to access mission portal resolves correctly:
   Portal listed in the second column.
 
 ```
-192.168.33.1 hub.cfengine.com hub
+192.168.56.1 hub.cfengine.com hub
 ```
 
 * `hostname -f` returns the fqdn used to access Mission Portal.

--- a/guide/introduction/networking.markdown
+++ b/guide/introduction/networking.markdown
@@ -257,7 +257,7 @@ mode.
 `/var/cfenigne/bin/cf-agent -Kdf update.cf`
 
 ```
-verbose: Connected to host 192.168.33.2 address 192.168.33.2 port 5308
+verbose: Connected to host 192.168.56.2 address 192.168.56.2 port 5308
   debug: TLSVerifyCallback: no ssl->peer_cert
   debug: TLSVerifyCallback: no conn_info->key
   debug: This must be the initial TLS handshake, accepting
@@ -277,23 +277,23 @@ with debug mode.
 `/var/cfenigne/bin/cf-serverd -Fd`
 
 ```
-verbose: New connection (from 192.168.33.3, sd 7), spawning new thread...
+verbose: New connection (from 192.168.56.3, sd 7), spawning new thread...
 verbose: CollectCallHasPending: false
   debug: Waiting at incoming select...
-   info: 192.168.33.3> Accepting connection
-verbose: 192.168.33.3> Setting socket timeout to 600 seconds.
-verbose: 192.168.33.3> Peeked nothing important in TCP stream, considering the protocol as TLS
-  debug: 192.168.33.3> Peeked data: ....2......ak.
-  debug: 192.168.33.3> TLSVerifyCallback: no ssl->peer_cert
-  debug: 192.168.33.3> TLSVerifyCallback: no conn_info->key
-  debug: 192.168.33.3> This must be the initial TLS handshake, accepting
-verbose: 192.168.33.3> TLS version negotiated:  TLSv1.2; Cipher: AES256-GCM-SHA384,TLSv1/SSLv3
-verbose: 192.168.33.3> TLS session established, checking trust...
-  debug: 192.168.33.3> TLSRecvLines(): CFE_v2 cf-agent 3.7.1.
-  debug: 192.168.33.3> TLSRecvLines(): IDENTITY USERNAME=root.
-verbose: 192.168.33.3> Setting IDENTITY: USERNAME=root
-verbose: 192.168.33.3> Received public key compares equal to the one we have stored
-verbose: 192.168.33.3> SHA=4f25279831eeaf579d2e3451345854a93fdefc856ad741bd59515b859fb84dea: Client is TRUSTED, public key MATCHES stored one.
+   info: 192.168.56.3> Accepting connection
+verbose: 192.168.56.3> Setting socket timeout to 600 seconds.
+verbose: 192.168.56.3> Peeked nothing important in TCP stream, considering the protocol as TLS
+  debug: 192.168.56.3> Peeked data: ....2......ak.
+  debug: 192.168.56.3> TLSVerifyCallback: no ssl->peer_cert
+  debug: 192.168.56.3> TLSVerifyCallback: no conn_info->key
+  debug: 192.168.56.3> This must be the initial TLS handshake, accepting
+verbose: 192.168.56.3> TLS version negotiated:  TLSv1.2; Cipher: AES256-GCM-SHA384,TLSv1/SSLv3
+verbose: 192.168.56.3> TLS session established, checking trust...
+  debug: 192.168.56.3> TLSRecvLines(): CFE_v2 cf-agent 3.7.1.
+  debug: 192.168.56.3> TLSRecvLines(): IDENTITY USERNAME=root.
+verbose: 192.168.56.3> Setting IDENTITY: USERNAME=root
+verbose: 192.168.56.3> Received public key compares equal to the one we have stored
+verbose: 192.168.56.3> SHA=4f25279831eeaf579d2e3451345854a93fdefc856ad741bd59515b859fb84dea: Client is TRUSTED, public key MATCHES stored one.
 ```
 
 ## Troubleshooting

--- a/reference/enterprise-api-ref/host.markdown
+++ b/reference/enterprise-api-ref/host.markdown
@@ -40,14 +40,14 @@ Host API allows to access host specific information.
     {
       "id": "SHA=27b88b8a92f1b10b1839ac5b26d022c98d48629bd761c4324d1f1fb0f04f17ba",
       "hostname": "host001",
-      "ip": "192.168.33.151",
+      "ip": "192.168.56.151",
       "lastreport": "1437141907",
       "firstseen": "1437138906"
     },
     {
       "id": "SHA=4a18877bbb7b79f4dde4b03d3ba05bcd66346124cbcd9373590416a90177fcaa",
       "hostname": "hub",
-      "ip": "192.168.33.65",
+      "ip": "192.168.56.65",
       "lastreport": "1437141907",
       "firstseen": "1437138666"
     }
@@ -90,7 +90,7 @@ Host API allows to access host specific information.
     {
       "id": "SHA=27b88b8a92f1b10b1839ac5b26d022c98d48629bd",
       "hostname": "host001",
-      "ip": "192.168.33.151",
+      "ip": "192.168.56.151",
       "lastreport": "1437144007",
       "firstseen": "1437138906"
     }

--- a/reference/enterprise-api-ref/sql-schema.markdown
+++ b/reference/enterprise-api-ref/sql-schema.markdown
@@ -341,19 +341,19 @@ FROM   hosts;
 -[ RECORD 1 ]--------|-----------------------
 hostkey              | SHA=a4dd...
 hostname             | host001
-ipaddress            | 192.168.33.151
+ipaddress            | 192.168.56.151
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:40:20+00
 -[ RECORD 2 ]--------|-----------------------
 hostkey              | SHA=3b94...
 hostname             | hub
-ipaddress            | 192.168.33.65
+ipaddress            | 192.168.56.65
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:34:20+00
 -[ RECORD 3 ]--------|-----------------------
 hostkey              | SHA=2aab...
 hostname             | host002
-ipaddress            | 192.168.33.152
+ipaddress            | 192.168.56.152
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:40:20+00
 ```
@@ -586,21 +586,21 @@ FROM   lastseenhosts;
 hostkey           | SHA=3b94d...
 lastseendirection | OUTGOING
 remotehostkey     | SHA=2aab8...
-remotehostip      | 192.168.33.152
+remotehostip      | 192.168.56.152
 lastseentimestamp | 2015-03-13 12:20:45+00
 lastseeninterval  | 299
 -[ RECORD 2 ]-----|------------------------
 hostkey           | SHA=3b94d...
 lastseendirection | INCOMING
 remotehostkey     | SHA=a4dd5...
-remotehostip      | 192.168.33.151
+remotehostip      | 192.168.56.151
 lastseentimestamp | 2015-03-13 12:22:06+00
 lastseeninterval  | 298
 -[ RECORD 3 ]-----|------------------------
 hostkey           | SHA=2aab8...
 lastseendirection | INCOMING
 remotehostkey     | SHA=3b94d...
-remotehostip      | 192.168.33.65
+remotehostip      | 192.168.56.65
 lastseentimestamp | 2015-03-13 12:20:45+00
 lastseeninterval  | 299
 ```
@@ -650,21 +650,21 @@ FROM   LastSeenHostsLogs;
 hostkey           | SHA=3b94d...
 lastseendirection | OUTGOING
 remotehostkey     | SHA=2aab8...
-remotehostip      | 192.168.33.152
+remotehostip      | 192.168.56.152
 lastseentimestamp | 2015-03-13 12:20:45+00
 lastseeninterval  | 299
 -[ RECORD 2 ]-----|------------------------
 hostkey           | SHA=3b94d...
 lastseendirection | INCOMING
 remotehostkey     | SHA=a4dd5...
-remotehostip      | 192.168.33.151
+remotehostip      | 192.168.56.151
 lastseentimestamp | 2015-03-13 12:22:06+00
 lastseeninterval  | 298
 -[ RECORD 3 ]-----|------------------------
 hostkey           | SHA=2aab8...
 lastseendirection | INCOMING
 remotehostkey     | SHA=3b94d...
-remotehostip      | 192.168.33.65
+remotehostip      | 192.168.56.65
 lastseentimestamp | 2015-03-13 12:20:45+00
 lastseeninterval  | 299
 ```
@@ -1764,19 +1764,19 @@ FROM   hosts;
 -[ RECORD 1 ]--------|-----------------------
 hostkey              | SHA=a4dd...
 hostname             | host001
-ipaddress            | 192.168.33.151
+ipaddress            | 192.168.56.151
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:40:20+00
 -[ RECORD 2 ]--------|-----------------------
 hostkey              | SHA=3b94...
 hostname             | hub
-ipaddress            | 192.168.33.65
+ipaddress            | 192.168.56.65
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:34:20+00
 -[ RECORD 3 ]--------|-----------------------
 hostkey              | SHA=2aab...
 hostname             | host002
-ipaddress            | 192.168.33.152
+ipaddress            | 192.168.56.152
 lastreporttimestamp  | 2015-03-10 14:20:20+00
 firstreporttimestamp | 2015-03-10 13:40:20+00
 ```

--- a/reference/language-concepts/classes.markdown
+++ b/reference/language-concepts/classes.markdown
@@ -44,7 +44,7 @@ Example:
 Class name                                                   Meta tags
 10_0_2_15                                                    inventory,attribute_name=none,source=agent,hardclass
 127_0_0_1                                                    inventory,attribute_name=none,source=agent,hardclass
-192_168_33_2                                                 inventory,attribute_name=none,source=agent,hardclass
+192.168.56_2                                                 inventory,attribute_name=none,source=agent,hardclass
 1_cpu                                                        source=agent,derived-from=sys.cpus,hardclass
 64_bit                                                       source=agent,hardclass
 Afternoon                                                    time_based,source=agent,hardclass


### PR DESCRIPTION
Merge together:
* https://github.com/cfengine/misc/pull/147
* https://github.com/cfengine/documentation/pull/2662

By default Virtualbox only allows host-only networking on 192.168.56.0/24.
This change is done to make instructions and example output comport with the
same change in our Vagrant Quickstart environment.

Ticket: CFE-3952
Changelog: Switched Vagrant Quickstart Environment subnet from 192.168.33.0/24 to 192.168.56.0/24 in order to better align with Virtualbox defaults