### PR TITLE
CFE-3957: Fixed link target for template_method

### DIFF
--- a/examples/tutorials/manage-ntp.markdown
+++ b/examples/tutorials/manage-ntp.markdown
@@ -447,7 +447,7 @@ The classes attribute here uses the [`results()`][lib/common.cf#results] classes
       template_method       => "inline_mustache",
 ```
 
-CFEngine supports multiple templating engines, the `template_method` attribute specifies how the promised file content will be resolved. The value `inline_mustache` indicates that we will use the mustache templating engine and specify the template in-line, instead of in an external file.
+CFEngine supports multiple templating engines, the [template_method][files#template_method] attribute specifies how the promised file content will be resolved. The value `inline_mustache` indicates that we will use the mustache templating engine and specify the template in-line, instead of in an external file.
 
 ##### edit_template_string
 

--- a/reference/functions/bundlestate.markdown
+++ b/reference/functions/bundlestate.markdown
@@ -32,7 +32,7 @@ Output:
 
 [%CFEngine_include_snippet(bundlestate.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** `getindices()`, `classesmatching()`, `variablesmatching()`, `mergedata()`, `template_method`, `mustache`, `inline_mustache`, `datastate()`
+**See also:** `getindices()`, `classesmatching()`, `variablesmatching()`, `mergedata()`, [template_method][files#template_method], `mustache`, `inline_mustache`, `datastate()`
 
 **History:**
 

--- a/reference/functions/datastate.markdown
+++ b/reference/functions/datastate.markdown
@@ -20,7 +20,7 @@ map with the variable name as the key.  The value is converted to a
 data container (JSON format) if necessary.  The example should make it
 clearer.
 
-Mustache templates (see `template_method`), if not given a
+Mustache templates (see [template_method][files#template_method]), if not given a
 `template_data`, will use the output of `datastate()` as their input.
 
 [%CFEngine_function_attributes()%]
@@ -33,7 +33,7 @@ Output:
 
 [%CFEngine_include_snippet(datastate.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** `getindices()`, `classesmatching()`, `variablesmatching()`, `mergedata()`, `template_method`, `mustache`, `inline_mustache`, `bundlestate()`
+**See also:** `getindices()`, `classesmatching()`, `variablesmatching()`, `mergedata()`, [template_method][files#template_method], `mustache`, `inline_mustache`, `bundlestate()`
 
 **Notes:**
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1948,7 +1948,7 @@ bundle agent example
 
 **History:** Was introduced in 3.3.0, Nova 2.2.0 (2012).  Mustache templates were introduced in 3.6.0.
 
-**See also:** `template_method`, `template_data`, `readjson()`, `parsejson()`,
+**See also:** [template_method][files#template_method], `template_data`, `readjson()`, `parsejson()`,
 `readyaml()`, `parseyaml()`, `mergedata()`,
 `data`, [Customize Message of the Day][Customize Message of the Day]
 
@@ -1969,7 +1969,7 @@ bundle agent example
 
 **History:** Was introduced in 3.12.0
 
-**See also:** `template_method`, `template_data`, `readjson()`, `parsejson()`,
+**See also:** [template_method][files#template_method], `template_data`, `readjson()`, `parsejson()`,
 `readyaml()`, `parseyaml()`, `mergedata()`,
 `data`, [Customize Message of the Day][Customize Message of the Day]
 
@@ -2994,7 +2994,7 @@ If this attribute is omitted, the result of the `datastate()` function
 call is used instead. See `edit_template` for how you can use the data
 state in Mustache.
 
-**See also:** `edit_template`, `template_method`, `datastate()`
+**See also:** `edit_template`, [template_method][files#template_method], `datastate()`
 
 ### template_method
 
@@ -3008,7 +3008,7 @@ implementation, but you can use `mustache` or `inline_mustache` as well.
 #### template_method cfengine
 
 The default native-CFEngine template format (selected when
-`template_method` is `cfengine` or unspecified) uses inline tags to
+[template_method][files#template_method] is `cfengine` or unspecified) uses inline tags to
 mark regions and classes. Each line represents an `insert_lines`
 promise, unless the promises are grouped into a block using:
 
@@ -3095,7 +3095,7 @@ Example ```cfengine``` template for apache vhost directives:
 
 #### template_method inline_mustache
 
-When `template_method` is `inline_mustache` the mustache input is not a file
+When [template_method][files#template_method] is `inline_mustache` the mustache input is not a file
 but a string and you must set `edit_template_string`.  The same rules apply
 for `inline_mustache` and `mustache`.  For mustache explanation see
 `template_method mustache`
@@ -3113,7 +3113,7 @@ for `inline_mustache` and `mustache`.  For mustache explanation see
 
 #### template_method mustache
 
-When `template_method` is `mustache` data must be provided to render the
+When [template_method][files#template_method] is `mustache` data must be provided to render the
 template with. Data can be provided by functions that return data ( i.e.
 `mergedata()`, `mapdata()`, `readdata()`, `findprocesses()`, etc ...), lists or
 data variables by reference `@(data)`, or by specifying data as inline json


### PR DESCRIPTION
The automatic link target was resolving to a tutorial instead of the promise
attribute on the files type promise page. This change makes the link target
explicit based on the page title.

Ticket: CFE-3957
Changelog: None