### PR TITLE
ENT-8542: Fixed links to page detailing editors with CFEngine support

### DIFF
--- a/guide/additional-resources.markdown
+++ b/guide/additional-resources.markdown
@@ -38,11 +38,7 @@ configuration management best practices from the CFEngine team.
 
 ## Tools ##
 
-* Download CFEngine [code editors](https://cfengine.com/cfengine-code-editors).
-
-* Download syntax highlighters for
-  [vim](https://github.com/neilhwatson/vim_cf3) or
-  [emacs](https://github.com/cfengine/core/blob/master/contrib/cfengine.el).
+* [Editors with syntax support][Editors]
 
 ### Sign Up
 

--- a/guide/writing-and-serving-policy/policy-style.markdown
+++ b/guide/writing-and-serving-policy/policy-style.markdown
@@ -432,7 +432,7 @@ bundle agent old
 ```
 ## Tooling
 
-Currently, there is no canonical policy linting or reformatting tool. There are a few different tools that can be useful apart from an [editor with syntax support](https://cfengine.com/cfengine-code-editors/) for achieving regular formatting.
+Currently, there is no canonical policy linting or reformatting tool. There are a few different tools that can be useful apart from an [editor with syntax support][Editors] for achieving regular formatting.
 
 ### cf-promises
 


### PR DESCRIPTION
Ticket: ENT-8542
Changelog: None