### PR TITLE
ENT-8542: Fixed links to page detailing editors with CFEngine support (3.15)

### DIFF
--- a/guide/additional-resources.markdown
+++ b/guide/additional-resources.markdown
@@ -38,11 +38,7 @@ configuration management best practices from the CFEngine team.
 
 ## Tools ##
 
-* Download CFEngine [code editors](https://cfengine.com/cfengine-code-editors).
-
-* Download syntax highlighters for
-  [vim](https://github.com/neilhwatson/vim_cf3) or
-  [emacs](https://github.com/cfengine/core/blob/master/contrib/cfengine.el).
+* [Editors with syntax support][Editors]
 
 ### Sign Up
 

--- a/guide/writing-and-serving-policy/policy-style.markdown
+++ b/guide/writing-and-serving-policy/policy-style.markdown
@@ -438,5 +438,4 @@ FILE1.cf FILE2.c FILE3.h` to reindent files, if you don't want to set
 up Emacs.  It will rewrite them with the new indentation, using Emacs
 in batch mode.
 
-Some [editors](https://cfengine.com/cfengine-code-editors/) also have
-support for automatic re-indentation.
+Some [editors][Editors] also have support for automatic re-indentation.


### PR DESCRIPTION
Ticket: ENT-8542
Changelog: None
(cherry picked from commit 6de0df83a9838118616d7dcdf1915b9c1965cb50)