### PR TITLE
ENT-8547: Moved deprecated report_data_select attributes to History (3.18)

### DIFF
--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -448,7 +448,17 @@ Here are the built-in `report_data_select` bodies `default_data_select_host()` a
 
 **See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
 
-**History:** Introduced in Enterprise 3.5.0
+**History:**
+
+* Introduced in Enterprise 3.5.0
+
+* `metatags_exclude`, `metatags_include`, `promise_handle_exclude`, and
+  `promise_handle_include` body attributes added in 3.6.0.
+
+* `classes_exclude`, `classes_include`, `promise_notkept_log_exclude`,
+  `promise_notkept_log_include`, `promise_repaired_log_exclude`,
+  `promise_repaired_log_include`, `variables_exclude`, and `variables_include`
+  body attributes removed in 3.6.0
 
 #### metatags_exclude
 
@@ -551,63 +561,6 @@ subset.
 **See also:** `monitoring_include`, `promise_handle_exclude`, `metatags_exclude`
 
 **History:** Introduced in Enterprise 3.5.0
-
-
-#### classes_include
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by meta-tags instead.
-
-**See also:** `metatags_include`, `metatags_exclude`
-
-#### classes_exclude
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by meta-tags instead.
-
-**See also:** `metatags_include`, `metatags_exclude`
-
-#### variables_include
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by meta-tags instead.
-
-**See also:** `metatags_include`, `metatags_exclude`
-
-#### variables_exclude
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by meta-tags instead.
-
-**See also:** `metatags_include`, `metatags_exclude`
-
-#### promise_notkept_log_include
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by handle instead.
-
-**See also:** `promise_handle_exclude`
-
-#### promise_notkept_log_exclude
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by handle instead.
-
-**See also:** `promise_handle_exclude`
-
-#### promise_repaired_log_include
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by handle instead.
-
-**See also:** `promise_handle_exclude`
-
-#### promise_repaired_log_exclude
-
-**Deprecated:** This attribute is deprecated as of CFEngine 3.6.0. It performs no
-action and is kept for backwards compatibility. Filter data by handle instead.
-
-**See also:** `promise_handle_exclude`
 
 ### resource_type
 


### PR DESCRIPTION
This change simply removes attribute sections for report_data_select attribtues
that were removed back in 3.6.0. Now, instead of each of them having their own
section, they are all listed as removed in the main history for report_data_select.

Ticket: ENT-8547
Changelog: None
(cherry picked from commit 7bf8eb43eb89d0dee70f8de0d6da5141c1defab1)