### PR TITLE
ENT-8547: Removed section about "internal" variables and classes from policy style guide

### DIFF
--- a/guide/writing-and-serving-policy/policy-style.markdown
+++ b/guide/writing-and-serving-policy/policy-style.markdown
@@ -408,12 +408,6 @@ bundle agent main
 }
 ```
 
-### Internal variables & classes
-
-Variables and classes that have no centralized reporting value are considered
-"internal". By convention internal variables and classes should be prefixed with
-an underscore "_".
-
 ## Deprecating Bundles
 As your policy library changes over time you may want to deprecate various
 bundles in favor of newer implimentations. To indicate that a bundle is


### PR DESCRIPTION
This section was misleading. The reference to underscore prefixed variables
related to a default related to Enterprise Reporting that has not been true
since 3.6.0.

Ticket: ENT-8547
Changelog: None