### PR TITLE
ENT-8792: Added cross-reference between reports bundle_return_value_index and methods useresult attributes (3.15)

### DIFF
--- a/reference/promise-types/methods.markdown
+++ b/reference/promise-types/methods.markdown
@@ -195,4 +195,6 @@ Return values are limited to scalars.
     }
 ```
 
+**See also:** [reports bundle_return_value_index attribute][reports#bundle_return_value_index]
+
 **History:** Was introduced in 3.4.0 (2012)

--- a/reference/promise-types/reports.markdown
+++ b/reference/promise-types/reports.markdown
@@ -202,6 +202,8 @@ bundle agent child
 }
 ```
 
+**See also:** [methods useresult attribute][methods#useresult]
+
 **History:** Introduced in 3.4.0.
 
 ### lastseen


### PR DESCRIPTION
This change simply makes it easier to hop back and forth between related things
in the documentation.