### PR TITLE
Changed title of MPF section in Augments docs

### DIFF
--- a/reference/language-concepts/augments.markdown
+++ b/reference/language-concepts/augments.markdown
@@ -12,10 +12,10 @@ JSON data files, so you should view and edit them with a JSON-aware editor if
 possible. This is a convenient way to override defaults defined in the default policy,
 the Masterfiles Policy Framework (MPF), without modifying the shipped policy files.
 
-## Modifying the behavior of the MPF without editing it ##
+## Using the MPF without maintaining your own patches to it ##
 
 As an example, you can add your own policy file to inputs and bundle name to the
-bundle sequence, without editing `promises.cf` by editing the Augments file
+bundle sequence, without editing `promises.cf`, by adding the Augments file below
 (`/var/cfengine/masterfiles/def.json`):
 
 ```json


### PR DESCRIPTION
I thought this title gives a more high level, goal oriented view
on it. Also, we use modify / edit many times in the text, so
a header with different wording might be nice.