### PR TITLE
ENT-6182: Added docs referencing cf-runagent socket activation (3.18)

### DIFF
--- a/reference/components/cf-execd.markdown
+++ b/reference/components/cf-execd.markdown
@@ -371,3 +371,28 @@ The CFEngine default policy sets `splaytime` to 1.
 
 **See also:** The [`splayclass()`][splayclass] function for a task-specific
 means for setting splay times.
+
+## Sockets
+
+`cf-execd` creates `STATEDIR/cf-execd.sockets/runagent.socket` (`/var/cfengine/state/cf-execd.sockets/runagent.socket`).
+
+The `body executor control` attribute `runagent_socket_allow_users` controls the list of users that should be allowed to access (**RW**) the socket via ACLs.
+
+**Notes:**
+
+* Unlike execution triggered with the `cf-runagent` binary, there is currently no capability to define additional options like defining additional classes, or the remote bundlesequence.
+
+**Example:**
+
+Write the name or IP into the socket to request unscheduled execution on that host:
+
+```console
+echo 'host001' > /var/cfengine/state/cf-execd.sockets/cf-runagent.socket
+```
+
+**See also:** [`cf-runagent`][cf-runagent], [`runagent_socket_allow_users`][cf-execd#runagent_socket_allow_users]
+
+**History:**
+
+* 3.18.0 Added socket for triggering `cf-runagent` by hostname or IP.
+

--- a/reference/components/cf-runagent.markdown
+++ b/reference/components/cf-runagent.markdown
@@ -290,3 +290,23 @@ body runagent control
 ```
 
 **See also:** [body `copy_from` timeout][files#timeout], [agent `default_timeout`][cf-agent#default_timeout]
+
+## Sockets
+
+`cf-runagent` can be triggered by writing a hostname or IP into a socket provided by `cf-execd`.
+
+**Notes:**
+
+* Unlike execution triggered with the `cf-runagent` binary, there is currently no capability to define additional options like defining additional classes, or the remote bundlesequence.
+
+**Example:**
+
+```console
+echo 'host001' > /var/cfengine/state/cf-execd.sockets/cf-runagent.socket
+```
+
+**See also:** [`cf-execd`][cf-execd], [`runagent_socket_allow_users`][cf-execd#runagent_socket_allow_users]
+
+**History:**
+
+* 3.18.0 Added socket for triggering `cf-runagent` by hostname or IP.


### PR DESCRIPTION
Ticket: ENT-6182
Changelog: None
(cherry picked from commit 8e9630df01c722a363555807e920c993618a8cce)