### PR TITLE
ENT-5866: Added documentation for edit.empty_before_use special variable (3.18)

### DIFF
--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -1768,6 +1768,10 @@ recipe allows an ordered procedure to be convergent.
 
 **Default value:** false
 
+**Notes:**
+
+* Within `edit_line` bundles the variable `$(edit.empty_before_use)` holds this value, allowing for decisions to be bade based on it.
+
 **Example:**
 
 ```cf3
@@ -1776,6 +1780,7 @@ recipe allows an ordered procedure to be convergent.
      empty_file_before_editing => "true";
      }
 ```
+
 
 #### inherit
 

--- a/reference/promise-types/files/edit_line.markdown
+++ b/reference/promise-types/files/edit_line.markdown
@@ -118,6 +118,10 @@ There are several things to notice:
     a table, to append, order and delete items from lists inside fields.
 -   The special variable `$(edit.filename)` contains the name of the
     file being edited within an edit bundle.
+-   The special variable `$(edit.empty_before_use)` holds the current value of
+    `empty_file_before_editing` which can be set by `edit_defaults bodies`. This
+    is used to know if the prior state of the file will have any effect on the
+    promise.
 -   On Windows, a text file may be stored stored either with CRLF line
     endings (Windows style), or LF line endings (Unix style). CFEngine
     will respect the existing line ending type and make modifications

--- a/reference/special-variables/edit.markdown
+++ b/reference/special-variables/edit.markdown
@@ -37,3 +37,18 @@ available.
 This variable points to the filename of the file currently making an
 edit promise. If the file has been arrived at through a search, this
 could be different from the files promiser.
+
+### edit.empty_before_use
+
+This variable holds the value of `empty_file_before_editing` from
+`edit_defaults` bodies. It's useful for altering behavior within an `edit_line`
+bundle depending if the files prior content will or won't have any effect.
+
+**See also:**
+
+* [empty_file_before_editing][files#empty_file_before_editing] in [edit_defaults bodies][files#edit_defaults].
+
+**History:**
+
+* 3.21.0, 3.18.3 added
+


### PR DESCRIPTION
Ticket: ENT-5866
Changelog: None
(cherry picked from commit ea9c87a916b722b7d1d0f8d4379866661dac2618)