### PR TITLE
ENT-8883: Resized the image in the custom LDAP page

### DIFF
--- a/web-ui/hub_administration/custom-ldap-port.markdown
+++ b/web-ui/hub_administration/custom-ldap-port.markdown
@@ -8,7 +8,7 @@ tags: [cfengine enterprise, hub administration, ldap]
 Mission Portals User settings and preferences provides a radio button
 encryption. This controls the encryption and the port to connect to.
 
-![Ldap Settings](custom-ldap-port-settings.png)
+<img src="custom-ldap-port-settings.png" alt="Ldap Settings" width="640px">
 
 If you want to configure LDAP authentication to use a custom port you can do so
 via the Status and Setting REST API.


### PR DESCRIPTION
Resized the images in custom [LDAP page](https://docs.cfengine.com/docs/master/web-ui-hub_administration-custom-ldap-port.html)

Ticket: ENT-8883
Changelog: Resized the images in custom LDAP page