### PR TITLE
ENT-8883: Resized the images in the Policy Deployment page

### DIFF
--- a/web-ui/hub_administration/policy-deployment.markdown
+++ b/web-ui/hub_administration/policy-deployment.markdown
@@ -57,9 +57,9 @@ In the Mission Portal VCS integration panel. To access it, click on "Settings"
 in the top-left menu of the Mission Portal screen, and then select "Version
 control repository".
 
-![Settings menu](settings-menu.png)
+<img src="settings-menu.png" alt="Settings menu" width="320px">
 
-![VCS settings screen](settings-vcs.png)
+<img src="settings-vcs.png" alt="VCS settings screen" width="640px">
 
 ### Configuring upstream VCS manually
 


### PR DESCRIPTION
Resized the images in the [Policy Deployment page.](https://docs.cfengine.com/docs/master/web-ui-hub_administration-policy-deployment.html)

Ticket: ENT-8883
Changelog: Resized the images in the Policy Deployment page