### PR TITLE
ENT-7426: Added documentation about where cf-monitord stores data (3.15)

### DIFF
--- a/reference/components/cf-monitord.markdown
+++ b/reference/components/cf-monitord.markdown
@@ -116,6 +116,19 @@ into agent variables in the `$(mon.`name`)` context.
 
 Note: There is no way for force a refresh of the monitored data.
 
+## Data storage ##
+
+`cf-monitord` records data in `$(sys.statedir)` (typically `/var/cfengine/state`).
+
+* `cf_observations.lmdb`
+* `nova_measures.lmdb`
+* `ts_key`
+* `env_data`
+* `cf_incoming.<service id>`
+* `cf_outgoing.<service id>`
+* `cf_state.lmdb`
+* `history.lmdb`
+
 ## Control Promises
 
 Settings describing the details of the fixed behavioral promises


### PR DESCRIPTION
Ticket: ENT-7426
Changelog: None
(cherry picked from commit 928625fb4a013ef43d66284fd4685e91f4e32639)