### PR TITLE
remove generator from pages

### DIFF
--- a/generator/_scripts/_run_jekyll.sh
+++ b/generator/_scripts/_run_jekyll.sh
@@ -14,6 +14,7 @@ mv $WRKDIR/documentation/generator/new_references.md $WRKDIR/documentation/gener
 
 mkdir $WRKDIR/documentation/generator/pages
 cp -r $WRKDIR/documentation/* $WRKDIR/documentation/generator/pages
+rm -rf $WRKDIR/documentation/generator/pages/generator
 cd $WRKDIR/documentation/generator
 
 # rvm commands are insane scripts which pollut output


### PR DESCRIPTION
Sometimes it caused unexpanded (unstyled) *.html files to be copied,
instead of proper ones, on line 14 of generator/_scripts/_publish.sh.

Ticket: ENT-8967