### PR TITLE
Remove generator from pages - 3.15

### DIFF
--- a/generator/_scripts/_run_jekyll.sh
+++ b/generator/_scripts/_run_jekyll.sh
@@ -14,6 +14,7 @@ mv $WRKDIR/documentation/generator/new_references.md $WRKDIR/documentation/gener
 
 mkdir $WRKDIR/documentation/generator/pages
 cp -r $WRKDIR/documentation/* $WRKDIR/documentation/generator/pages
+rm -rf $WRKDIR/documentation/generator/pages/generator
 cd $WRKDIR/documentation/generator
 # rvm commands are insane scripts which pollut output
 # so instead of set -x we just echo each command ourselves


### PR DESCRIPTION
Sometimes it caused unexpanded (unstyled) *.html files to be copied,
instead of proper ones, on line 14 of generator/_scripts/_publish.sh.

Ticket: ENT-8967
(cherry picked from commit aa7635f0c458367be414bf8c8bab4fda46d7948e)