### PR TITLE
Fixed `Download all documentation` link

### DIFF
--- a/generator/_includes/footer.html
+++ b/generator/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="container">
         <ul>
             <li><a target="_blank" href="https://cfengine.com"><img  alt="CFEngine homepage"src="./media/images/cfengine-logo-white.svg" /></a></li>
-            <li><a href="cfengine-documentation-{{site.cfengine.branch}}.tar.gz">Download all documentation</a></li>
+            <li><a href="cfengine-documentation-{{site.branch}}.tar.gz">Download all documentation</a></li>
             <li><a href="legal.html">Legal and Licenses</a></li>
             <li><a target="_blank" href="https://cfengine.com/contact/">Contact us</a></li>
             <li>Last update on {{site.time | date_to_long_string}}</li>


### PR DESCRIPTION
Use branch version instead of the current master CFEnigne version