### PR TITLE
Various cleanups in FAQ

### DIFF
--- a/examples/tutorials/write-cfengine-policy.markdown
+++ b/examples/tutorials/write-cfengine-policy.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Write cfengine policy
+title: Write CFEngine policy
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/resources/faq/bootstrap-failed.markdown
+++ b/resources/faq/bootstrap-failed.markdown
@@ -5,6 +5,8 @@ published: true
 tags: [faq]
 ---
 
+Frequently asked questions around bootstrapping, the process of starting CFEngine for the first time, and connecting the agents to the correct policy server.
+
 ## Why did bootstrap fail?
 
 When I bootstrap a host, I get errors:

--- a/resources/faq/enterprise-report-collection.markdown
+++ b/resources/faq/enterprise-report-collection.markdown
@@ -6,6 +6,8 @@ sorting: 90
 tags: [ FAQ, Enterprise, reporting, health, cf-hub ]
 ---
 
+Frequently asked questions on Enterprise report collection.
+
 ## What are reports?
 
 Reports are the records that the components ( `cf-agent`, `cf-monitord`,

--- a/resources/faq/enterprise.markdown
+++ b/resources/faq/enterprise.markdown
@@ -8,43 +8,43 @@ tags: [getting started, installation, faq]
 
 Frequently asked questions on the Enterprise reporting database
 
-# Can I use an existing PostgreSQL installation?
+## Can I use an existing PostgreSQL installation?
 
 No. Although CFEngine keeps its assumptions about Postgres to a bare minimum,
 CFEngine should use a dedicated PostgreSQL database instance to ensure there is
 no conflict with an existing installation.
 
-# Do I need experience with PostgreSQL?
+## Do I need experience with PostgreSQL?
 
 PostgreSQL is highly configurable and you should have some in-house expertise to
 properly configure your database installation. The defaults are well tuned for
 common cases but you may find optimizations depending on your hardware and OS.
 
-# What is the system user for the CFEngine dedicated PostgreSQL database?
+## What is the system user for the CFEngine dedicated PostgreSQL database?
 
 The database runs under the `cfpostgres` user.
 
-# What are the requirements for installing CFEngine Enterprise?
+## What are the requirements for installing CFEngine Enterprise?
 
-## General Information
+### General Information
 
 * [Pre-Installation Checklist][Pre-Installation Checklist]
 * [Supported Platforms and Versions][Supported Platforms and Versions]
 
-## Users and Permissions
+### Users and Permissions
 
 * CFEngine Enterprise makes an attempt to create the local users `cfapache` and
   `cfpostgres`, as well as group `cfapache` during install.
 
-# How does Enterprise Scale?
+## How does Enterprise Scale?
 
 See best practices on [scalability][Best Practices#Scalability]
 
-# Is it normal to have many cf-hub processes running?
+## Is it normal to have many cf-hub processes running?
 
 * Yes, it is expected to have ~ 50 `cf-hub` processes running on a hub.
 
-# What steps should I take after installing CFEngine Enterprise?
+## What steps should I take after installing CFEngine Enterprise?
 
 There are general steps to be taken outlined in
 [Post-Installation Configuration][General Installation#Post-Installation Configuration].

--- a/resources/faq/enterprise.markdown
+++ b/resources/faq/enterprise.markdown
@@ -6,7 +6,7 @@ sorting: 90
 tags: [getting started, installation, faq]
 ---
 
-Frequently asked questions on the Enterprise reporting database
+Frequently asked questions on the Enterprise reporting database.
 
 ## Can I use an existing PostgreSQL installation?
 

--- a/resources/faq/enterprise.markdown
+++ b/resources/faq/enterprise.markdown
@@ -6,6 +6,8 @@ sorting: 90
 tags: [getting started, installation, faq]
 ---
 
+Frequently asked questions on the Enterprise reporting database
+
 # Can I use an existing PostgreSQL installation?
 
 No. Although CFEngine keeps its assumptions about Postgres to a bare minimum,

--- a/resources/faq/fhs.markdown
+++ b/resources/faq/fhs.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Why does cfengine install into /var/cfengine instead of following the FHS?
+title: Why does CFEngine install into /var/cfengine instead of following the FHS?
 published: true
 sorting: 90
 tags: [FAQ, FHS ]

--- a/resources/faq/fix-undefined-body-error.markdown
+++ b/resources/faq/fix-undefined-body-error.markdown
@@ -19,7 +19,7 @@ inputs. Bodies and bundles must either be defined within the same policy file or
 included from [body common control inputs][Components#inputs]
 or [body file control inputs][file control#inputs].
 
-# Example: Add stdlib via body common control
+## Example: Add stdlib via body common control
 
 ```cf3
 body common control
@@ -29,7 +29,7 @@ body common control
 }
 ```
 
-# Example: Add stdlib via body file control
+## Example: Add stdlib via body file control
 
 Body file control allows you to build modular policy. Body file control inputs
 are typically relative to the policy file itself.
@@ -49,7 +49,7 @@ body file control
 }
 ```
 
-# Tip: Locate bodies or bundles with cf-locate
+## Tip: Locate bodies or bundles with cf-locate
 
 `cf-locate` is a small utility that makes searching for and referencing body or
 bundle definitions quick and easy. Simply download the utility from

--- a/resources/faq/manual-execution.markdown
+++ b/resources/faq/manual-execution.markdown
@@ -6,6 +6,8 @@ sorting: 90
 tags: [getting started, installation, faq]
 ---
 
+Frequently asked questions on manual execution.
+
 # How do I run a standalone policy file?
 
 The `--file` or `-f` option to `cf-agent` specifys the policy file. The `-K` or

--- a/resources/faq/manual-execution.markdown
+++ b/resources/faq/manual-execution.markdown
@@ -8,7 +8,7 @@ tags: [getting started, installation, faq]
 
 Frequently asked questions on manual execution.
 
-# How do I run a standalone policy file?
+## How do I run a standalone policy file?
 
 The `--file` or `-f` option to `cf-agent` specifys the policy file. The `-K` or
 `--no-lock` flag and the `-I` or `--inform` options are commonly used in
@@ -24,7 +24,7 @@ A standalone policy file **may** choose not to specify a `bundlesequence`. In
 that case, the `bundlesequence` defaults to `main` so you'll need a bundle
 called `main`, or will need to specify the bundlesequence.
 
-# How do I run a specific bundle?
+## How do I run a specific bundle?
 
 A specific bundle can be activated by passing the `-b` or `--bundlesequence`
 options to `cf-agent`. This may be used to activate a specific bundle within a
@@ -42,7 +42,7 @@ with commas (no spaces between).
 [root@hub ~]# cf-agent --bundlesequence bundle1,bundle2
 ```
 
-# How do I define a class for a single run?
+## How do I define a class for a single run?
 
 You can use the `--define` or `-D` options of `cf-agent`.
 
@@ -57,7 +57,7 @@ between).
 [root@hub ~]# cf-agent --define my_class,my_other_class
 ```
 
-# Run via cf-execd
+## Run via cf-execd
 
 Sometimes it's convenient to run `cf-execd` with `--once`. It will execute
 `exec_command` as defined in `body executor control`. In the
@@ -76,7 +76,7 @@ arbitrary commands, but it can be useful for triggering out of turn policy runs.
 # cf-runagent --hail 203.0.113.5 --inform
 ```
 
-## Remote agent run for many hosts sharing a class
+### Remote agent run for many hosts sharing a class
 
 The `--hail` and `-H` options take a comma separated list of hosts that will be contacted.
 

--- a/resources/faq/output-email.markdown
+++ b/resources/faq/output-email.markdown
@@ -6,7 +6,7 @@ sorting: 90
 tags: [getting started, installation, faq]
 ---
 
-# How do I set the email where agent reports are sent?
+## How do I set the email where agent reports are sent?
 
 The agent report email functionality is configured in `body executor control`
 https://github.com/cfengine/masterfiles/blob/{{site.cfengine.branch}}/controls/cf_execd.cf.
@@ -15,7 +15,7 @@ https://github.com/cfengine/masterfiles/blob/{{site.cfengine.branch}}/def.cf.
 
 **See also:** [`def.mailto`][Masterfiles Policy Framework#mailto].
 
-# How do I disable agent email output?
+## How do I disable agent email output?
 
 You can simply remove or comment out the settings.
 

--- a/resources/faq/show-classes-and-vars.markdown
+++ b/resources/faq/show-classes-and-vars.markdown
@@ -29,7 +29,7 @@ cf-promises --show-classes
 
 [%CFEngine_include_snippet(cf-promises_--show-classes.txt, [\w], ^$)%]
 
-# Show first order variables with cf-promises
+## Show first order variables with cf-promises
 
 ```console
 cf-promises --show-vars

--- a/resources/faq/uninstall-reinstall.markdown
+++ b/resources/faq/uninstall-reinstall.markdown
@@ -6,7 +6,7 @@ sorting: 40
 tags: [uninstall, reinstall]
 ---
 
-# What is left behind after uninstalling?
+## What is left behind after uninstalling?
 
 Uninstalling a CFEngine package does not remove any user data. Most data
 including the host identity (`$(sys.workdir)/ppkeys/localhost.{pub,priv}`),
@@ -15,7 +15,7 @@ state, policy, and logs remain.
 To completely remove CFEngine delete `$(sys.workdir)` typically `/var/cfengine`
 or `C:\Program Files\Cfengine` after uninstalling the package.
 
-# Should I delete anything if I am re-installing?
+## Should I delete anything if I am re-installing?
 
 You may want to wipe `$(sys.statedir)` and `$(sys.workdir)/outputs` for a fresh start to log data and history.
 

--- a/resources/faq/users.markdown
+++ b/resources/faq/users.markdown
@@ -6,7 +6,9 @@ sorting: 90
 tags: [getting started, installation, enterprise, faq]
 ---
 
-# How do I ensure that a local user is locked?
+Frequently asked questions about managing users from policy.
+
+## How do I ensure that a local user is locked?
 
 To ensure that a local user exists but is locked (for example a service
 account) simply specify `policy => "locked"`.

--- a/resources/faq/what-did-cfengine-change.markdown
+++ b/resources/faq/what-did-cfengine-change.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: What did cfengine do?
+title: What did CFEngine do?
 published: true
 tags: [getting started, faq, logging, reporting ]
 ---


### PR DESCRIPTION
- ENT-8434: Added some short summary sentences to FAQ pages
- Corrected capitalization of CFEngine in a few places
- Fixed some bad h1 headers in FAQ
