### PR TITLE
ENT-9202: Changed order of docs page titles to highlight more specific part first

### DIFF
--- a/generator/_includes/head.html
+++ b/generator/_includes/head.html
@@ -4,7 +4,7 @@
         <meta charset=utf-8 />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-        <title>CFEngine{% if site.CFE_manuals_version %} {{ site.CFE_manuals_version }} {% endif %} Documentation{% if page.title %} - {{ page.title }}{% endif %}</title>
+        <title>{% if page.title %}{{ page.title }} - {% endif %}CFEngine{% if site.CFE_manuals_version %} {{ site.CFE_manuals_version }} {% endif %} Docs</title>
         <link rel="icon" type="image/svg+xml" href="./media/images/favicon.svg">
         <!-- page.url ~ https://docs.cfengine.com/latest/pages/examples/tutorials/manage-packages.html -->
         <!-- WANT https://docs.cfengine.com/latest/pages/examples-tutorials-manage-packages.html -->


### PR DESCRIPTION
See ticket:
https://tracker.mender.io/browse/ENT-9202
