### PR TITLE
CFE-4095: Added cross references for function irange() (3.18)

### DIFF
--- a/reference/functions/accumulated.markdown
+++ b/reference/functions/accumulated.markdown
@@ -78,3 +78,10 @@ Seconds of runtime
 
 In the example we look for processes that have accumulated between 2 and
 20 minutes of total run time.
+
+**See also:**
+
+* Related functions
+    * [`ago()`][ago]
+    * [`now()`][now]
+    * [`irange()`][irange]

--- a/reference/functions/ago.markdown
+++ b/reference/functions/ago.markdown
@@ -51,3 +51,9 @@ Output:
 
 [%CFEngine_include_snippet(ago.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
+**See also:**
+
+* Related functions
+    * [`now()`][now]
+    * [`accumulated()`][accumulated]
+    * [`irange()`][irange]

--- a/reference/functions/irange.markdown
+++ b/reference/functions/irange.markdown
@@ -23,3 +23,26 @@ also use the functions `ago()`, `now()`, `accumulated()`, etc.
 
     irange(ago(0,0,0,1,30,0), "0");
 ```
+
+**See also:**
+
+* Functions commonly used with [`irange()`][irange]
+  * [`ago()`][ago]
+  * [`now()`][now]
+  * [`accumulated()`][accumulated]
+* Attributes of type irange
+    * [`atime` in body `file_select`][files#atime]
+    * [`copy_size` in body `copy_from`][files#copy_size]
+    * [`ctime` in body `file_select`][files#ctime]
+    * [`mtime` in body `file_select`][files#mtime]
+    * [`match_range` in body `process_count`][processes#match_range]
+    * [`pgid` in body `process_count`][processes#pgid]
+    * [`pid` in body `process_count`][processes#pid]
+    * [`ppid` in body `process_count`][processes#ppid]
+    * [`priority` in body `process_count`][processes#priority]
+    * [`rsize` in body `process_count`][processes#rsize]
+    * [`search_size` in body `file_select`][files#search_size]
+    * [`stime_range` in body `process_count`][processes#stime_range]
+    * [`threads` in body `process_count`][processes#threads]
+    * [`ttime_range` in body `process_count`][processes#ttime_range]
+    * [`vsize` in body `process_count`][processes#vsize]

--- a/reference/functions/now.markdown
+++ b/reference/functions/now.markdown
@@ -79,3 +79,9 @@ select processes based on relative execution time.
 
 [%CFEngine_include_example(processes_define_class_based_on_process_runtime.cf)%]
 
+**See also:**
+
+* Related functions
+    * [`ago()`][ago]
+    * [`accumulated()`][accumulated]
+    * [`irange()`][irange]

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -956,6 +956,8 @@ comma separated numbers.
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### findertype
 
 **Description:** The `findertype` menu option policy describes the default finder type on MacOSX.
@@ -2169,6 +2171,8 @@ time.
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### mtime
 
 **Description:** Range of modification times (mtime) for acceptable files
@@ -2190,6 +2194,8 @@ not other attributes, such as permissions.
      file_result => "!mtime";
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 #### atime
 
@@ -2220,6 +2226,8 @@ A range of times during which a file was accessed can be specified in a
      file_result => "!atime";
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 #### exec_regex
 

--- a/reference/promise-types/processes.markdown
+++ b/reference/promise-types/processes.markdown
@@ -217,6 +217,8 @@ the end of line.
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### pgid
 
 **Description:** Range of integers matching the parent group id of a
@@ -235,6 +237,8 @@ process
      process_result => "pgid";
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 #### ppid
 
@@ -255,6 +259,8 @@ process
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### priority
 
 **Description:** Range of integers matching the priority field (PRI/NI) of
@@ -272,6 +278,8 @@ a process
      priority => irange("-5","0");
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 #### process_owner
 
@@ -338,6 +346,8 @@ process, in kilobytes
 
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### status
 
 **Description:** Regular expression matching the status field of a process
@@ -379,6 +389,8 @@ hour off. This is for now a bug to be fixed.
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### ttime_range
 
 **Description:** Range of integers matching the total elapsed time of a
@@ -398,6 +410,8 @@ This is total accumulated time for a process.
      ttime_range => irange(0,accumulated(0,1,0,0,0,0));
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 #### tty
 
@@ -437,6 +451,8 @@ process
      }
 ```
 
+**See also:** [Function: irange()][irange]
+
 #### vsize
 
 **Description:** Range of integers matching the virtual memory size of a
@@ -458,6 +474,8 @@ Size (Windows 2008), or VM Size (Windows XP).
      vsize => irange("4000","9000");
      }
 ```
+
+**See also:** [Function: irange()][irange]
 
 ### process_stop
 


### PR DESCRIPTION
Ticket: CFE-4095
Changelog: None
(cherry picked from commit d9a942d0cdba7aaf40b52ebedd00812583ec330c)