### PR TITLE
CFE-4098: Added cross references related to data_expand()

### DIFF
--- a/reference/functions/classfiltercsv.markdown
+++ b/reference/functions/classfiltercsv.markdown
@@ -48,7 +48,7 @@ minus `1`.
    *.sh       text eol=lf
    ```
 
-**See also:** [readcsv()][readcsv], [classmatch()][classmatch]
+**See also:** [`data_expand()`][data_expand], [`readcsv()`][readcsv], [`classmatch()`][classmatch]
 
 **History:**
 

--- a/reference/functions/data_expand.markdown
+++ b/reference/functions/data_expand.markdown
@@ -41,4 +41,4 @@ Output:
 
 **History:** Was introduced in version 3.7.0 (2015). The [collecting functions][Functions#collecting functions] behavior was added in 3.9.
 
-**See also:** `readcsv()`, `readjson()`, `readyaml()`, `mergedata()`, [about collecting functions][Functions#collecting functions], and `data` documentation.
+**See also:** [`readcsv()`][readcsv], [`readjson()`][readjson], [`readyaml()`][readyaml], [`mergedata()`][mergedata], [`readenvfile()`][readenvfile], [`classfiltercsv()`][classfiltercsv], [about collecting functions][Functions#collecting functions], and `data` documentation.

--- a/reference/functions/mergedata.markdown
+++ b/reference/functions/mergedata.markdown
@@ -55,4 +55,4 @@ traditional list and array data types in CFEngine.
 * Introduced in CFEngine 3.6.0 (2014).
 * The [collecting function][Functions#collecting functions] behavior was added in 3.9.
 
-**See also:** `getindices()`, `getvalues()`, `readjson()`, `parsejson()`, `readyaml()`, `parseyaml()`, [about collecting functions][Functions#collecting functions], and `data` documentation.
+**See also:** [`data_expand()`][data_expand], `getindices()`, `getvalues()`, `readjson()`, `parsejson()`, `readyaml()`, `parseyaml()`, [about collecting functions][Functions#collecting functions], and `data` documentation.

--- a/reference/functions/readcsv.markdown
+++ b/reference/functions/readcsv.markdown
@@ -41,6 +41,6 @@ Output:
 sequence. Thus a text file created on Unix with standard Unix tools
 like vi will not, by default, have those line endings.
 
-**See also:** `readdata()`, `data_readstringarrayidx()`,`data_readstringarray()`, `parsejson()`, `storejson()`, `mergedata()`, and `data` documentation.
+**See also:** [`data_expand()`][data_expand], `readdata()`, `data_readstringarrayidx()`,`data_readstringarray()`, `parsejson()`, `storejson()`, `mergedata()`, and `data` documentation.
 
 **History:** Was introduced in 3.7.0.

--- a/reference/functions/readdata.markdown
+++ b/reference/functions/readdata.markdown
@@ -35,6 +35,6 @@ Output:
 
 [%CFEngine_include_snippet(readdata.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** `readcsv()`, `readyaml()`, `readjson()`, `readenvfile()`, `validdata()`, `data` documentation.
+**See also:** [`data_expand()`][data_expand], `readcsv()`, `readyaml()`, `readjson()`, `readenvfile()`, `validdata()`, `data` documentation.
 
 **History:** Was introduced in 3.7.0.

--- a/reference/functions/readenvfile.markdown
+++ b/reference/functions/readenvfile.markdown
@@ -41,7 +41,7 @@ Output:
 **Notes:**
 This function is used internally to load `/etc/os-release` into `sys.os_release`.
 
-**See also:** `readdata()`, `parsejson()`, `parseyaml()`, `storejson()`, `mergedata()`, and `data` documentation.
+**See also:** [`data_expand()`][data_expand], `readdata()`, `parsejson()`, `parseyaml()`, `storejson()`, `mergedata()`, and `data` documentation.
 
 **History:**
 

--- a/reference/functions/readjson.markdown
+++ b/reference/functions/readjson.markdown
@@ -23,7 +23,7 @@ vars:
      data =>  readjson("/tmp/data.json", 4000);
 ```
 
-**See also:** `readdata()`, `parsejson()`, `storejson()`, `parseyaml()`, `readyaml()`, `mergedata()`, `validjson()`, and `data` documentation.
+**See also:** [`data_expand()`][data_expand], `readdata()`, `parsejson()`, `storejson()`, `parseyaml()`, `readyaml()`, `mergedata()`, `validjson()`, and `data` documentation.
 
 **History:**
 

--- a/reference/functions/readyaml.markdown
+++ b/reference/functions/readyaml.markdown
@@ -23,4 +23,4 @@ vars:
      data =>  readyaml("/tmp/data.yaml", 4000);
 ```
 
-**See also:** `readdata()`, `parsejson()`, `parseyaml()`, `storejson()`, `mergedata()`, and `data` documentation.
+**See also:** [`data_expand()`][data_expand], `readdata()`, `parsejson()`, `parseyaml()`, `storejson()`, `mergedata()`, and `data` documentation.


### PR DESCRIPTION
Most functions that return data (notably, functions that read content from a
file, e.g. readjson() ) do not de-reference CFEngine variables within that data.

This change simply cross references functions that return data where someone
might have expected CFEngine variables to have been dereferenced with
data_expand() to bring more awareness.

Ticket: CFE-4098
Changelog: None