### PR TITLE
ENT-9586: Added note that LDAP group sync does not add or remove Mission Portal roles (3.18)

### DIFF
--- a/enterprise-cfengine-guide/settings.markdown
+++ b/enterprise-cfengine-guide/settings.markdown
@@ -202,18 +202,19 @@ Mission portal can authenticate against an external directory.
 
 ### LDAP groups syncing ###
 
-- Ldap group syncing can be turned on by clicking the corresponding checkbox
-    
-    - User group attribute must be provided to obtain groups from an LDAP user entity. 
-    The default value for Active Directory is `memberOf`. 
+- LDAP group syncing can be turned on by clicking the corresponding checkbox
+
+    - User group attribute must be provided to obtain groups from an LDAP user entity.
+    The default value for Active Directory is `memberOf`.
     The group name will be taken from `cn` attribute
     - List of groups to sync, names must match in LDAP/MP. Each role should be added on a new line.
     - Click `Perform sync on every login` checkbox to synchronize user roles on every login, otherwise
     roles will be assigned to a user only on sign-up (first login).
-    
 
-**See also:** [LDAP authentication REST API][LDAP authentication API]
+**Note:** Roles *must* be created in Mission Portal. Enabling LDAP group sync
+will not result in addition or removal of Mission Portal roles.
 
+**See also:** [LDAP authentication REST API][LDAP authentication API], [Role Management][Settings#Role Management]
 
 ## Export/Import ##
 

--- a/enterprise-cfengine-guide/settings.markdown
+++ b/enterprise-cfengine-guide/settings.markdown
@@ -123,7 +123,7 @@ User three will only be able to see hosts that have reported the `ubuntu` class.
 
 * ```admin``` - The admin role can see everything and do anything.
 * ```cf_remoteagent``` - This role allows execution of `cf-runagent`.
-  
+
 ### Default Role
 
 To set the default role, click Settings -> User management -> Roles. You can then select which role will be the default role for new users.
@@ -186,7 +186,7 @@ Configure outbound mail settings:
 
 Mission portal can authenticate against an external directory.
 
-**Special Notes:** 
+**Special Notes:**
 
 - LDAP API Url refers to the API cfengine uses internally for authentication.
   Most likely you will not alter the default value.
@@ -228,10 +228,10 @@ Mission Portal's configuration can be exported and imported.
 
 ![Role based access control](role_based_access_control_settings.png)
 
-Roles in Mission portal can be restricted to perform only configured actions. 
+Roles in Mission portal can be restricted to perform only configured actions.
 Configure role-based access controls from settings.
 
-**Special Notes:** 
+**Special Notes:**
 
 - Admin role has all permissions by default.
 
@@ -239,7 +239,7 @@ Configure role-based access controls from settings.
 
 - Permissions granted by roles are additive, users with multiple roles are permitted to perform actions granted by each role.
 
-**Restore admin role permissions:** 
+**Restore admin role permissions:**
 
 To restore the CFEngine admin role permissions run the following sql as root on your hub
 


### PR DESCRIPTION
This change simply tries to make it clear that roles matching the LDAP groups
you wish to synchronize must be created in Mission Portal for LDAP group syncing
to have effect.

Ticket: ENT-9586
Changelog: None
(cherry picked from commit 010f20d40e99901be7f1ece82f7894d055341436)