### PR TITLE
ENT-9722: Updated package install commands for enterprise to use yum and apt

### DIFF
--- a/getting-started/installation/general-installation.markdown
+++ b/getting-started/installation/general-installation.markdown
@@ -24,15 +24,15 @@ Note: See [Installing Community][Installing Community] for the community version
 1. On the designated Policy Server, install the `cfengine-nova-hub` package:
 
     ```
-    [RedHat/CentOS/SUSE] $ rpm -i <server hub package>.rpm
-    [Debian/Ubuntu]      $ dpkg -i <server hub package>.deb
+    [RedHat/CentOS/SUSE] # yum -y install /path/to/<server hub package>.rpm
+    [Debian/Ubuntu]      # apt -y install /path/to/<server hub package>.deb
     ```
 
 2. On each Host, install the `cfengine-nova` package:
 
     ```
-    [RedHat/CentOS/SUSE] $ rpm -i <agent package>.rpm
-    [Debian/Ubuntu]      $ dpkg -i <agent package>.deb
+    [RedHat/CentOS/SUSE] # yum -y install /path/to/<agent package>.rpm
+    [Debian/Ubuntu]      # apt -y install /path/to/<agent package>.deb
     ```
 
 Note: Install actions logged to `/var/logs/cfengine-install.log`.

--- a/getting-started/installation/general-installation/installation-enterprise.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise.markdown
@@ -203,15 +203,15 @@ Server (hub) and the other is for each Host (client).
 1. On the designated Policy Server, install the `cfengine-nova-hub` package:
 
     ```console
-    [RedHat/CentOS/SUSE] # rpm -i <hub package>.rpm
-    [Debian/Ubuntu]      # dpkg -i <hub package>.deb
+    [RedHat/CentOS/SUSE] # yum -y install /path/to/<hub package>.rpm
+    [Debian/Ubuntu]      # apt -y install /path/to/<hub package>.deb
     ```
 
 2. On each Host, install the `cfengine-nova` package:
 
     ```console
-    [RedHat/CentOS/SUSE] # rpm -i <agent package>.rpm
-    [Debian/Ubuntu]      # dpkg -i <agent package>.deb
+    [RedHat/CentOS/SUSE] # yum -y install /path/to/<agent package>.rpm
+    [Debian/Ubuntu]      # apt -y install /path/to/<agent package>.deb
     [Solaris]            # pkgadd -d <agent package>.pkg all
     [AIX]                # installp -a -d <agent package>.bff cfengine.cfengine-nova
     [HP-UX]              # swinstall -s <full path to agent package>.depot cfengine-nova


### PR DESCRIPTION
Especially now that the hub package has an external dependency on python it's
much nicer to use yum and apt which will try to auto-solve the dependencies
unlike rpm and dpkg.