### PR TITLE
CFE-4162: Added note that parsejson() does not parse primitives (3.21)

### DIFF
--- a/reference/functions/parsejson.markdown
+++ b/reference/functions/parsejson.markdown
@@ -33,6 +33,10 @@ vars:
      data =>  '{ "key": "value" }';
 ```
 
+**Notes:**
+
+* This functions does not parse _primitives_.
+
 **History:**
 
 * Introduced in CFEngine 3.6.0


### PR DESCRIPTION
Ticket: CFE-4162
Changelog: None