### PR TITLE
ENT-9964: Made all titles use sentence case instead of title case

### DIFF
--- a/api.markdown
+++ b/api.markdown
@@ -16,4 +16,4 @@ API uses SQL. With the simplicity of REST and the flexibility of
 SQL, users can craft custom reports about systems of arbitrary scale, mining
 a wealth of data residing on globally distributed CFEngine Database Servers.
 
-See also the [Enterprise API Examples][Enterprise API Examples] and the [Enterprise API Reference][Enterprise API Reference].
+See also the [Enterprise API examples][Enterprise API examples] and the [Enterprise API reference][Enterprise API reference].

--- a/api/enterprise-api-examples.markdown
+++ b/api/enterprise-api-examples.markdown
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Enterprise API Examples
+title: Enterprise API examples
 published: true
 sorting: 6
 tags: [examples, enterprise, REST, API, reporting]
 ---
 
-* [Check installation status][Checking Status]
-* [Manage users, roles][Managing Users and Roles]
-* [Managing Settings][Managing Settings]
-* [Browse host information][Browsing Host Information]
-* [Issue flexible SQL queries][SQL Query Examples] against data collected from hosts by the CFEngine Server
-* [Schedule reports][SQL Query Examples#Subscribed Query Example: Creating A Subscribed Query] for email and later download
+* [Check installation status][Checking status]
+* [Manage users, roles][Managing users and roles]
+* [Managing settings][Managing settings]
+* [Browse host information][Browsing host information]
+* [Issue flexible SQL queries][SQL query examples] against data collected from hosts by the CFEngine Server
+* [Schedule reports][SQL query examples#Subscribed Query Example: Creating A Subscribed Query] for email and later download
 * [Tracking changes performed by CFEngine][Tracking changes]
 
-**See also:** [Enterprise API Reference][Enterprise API Reference]
+**See also:** [Enterprise API reference][Enterprise API reference]

--- a/api/enterprise-api-examples/browsing-host-information.markdown
+++ b/api/enterprise-api-examples/browsing-host-information.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Browsing Host Information
+title: Browsing host information
 published: true
 sorting: 50
 tags: [examples, enterprise, rest, api, reporting, hosts]
 ---
 
 A resource [/api/host][Host REST API#List hosts] is added as an alternative interface for browsing host
-information. For full flexibility we recommend using [SQL][SQL Schema]
+information. For full flexibility we recommend using [SQL][SQL schema]
 reports via [/api/query][Query REST API#Execute SQL query] for this. however, currently vital signs (data
 gathered from `cf-monitord`) is not part of the SQL reports data model.
 

--- a/api/enterprise-api-examples/checking-status.markdown
+++ b/api/enterprise-api-examples/checking-status.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title:  Checking Status
+title:  Checking status
 published: true
 sorting: 20
 tags: [examples, enterprise, rest, api, reporting, status]
 ---
 
-You can get basic info about the API by issuing [/api][Status and Settings REST API#Get server status]. This status
+You can get basic info about the API by issuing [/api][Status and settings REST API#Get server status]. This status
 information may also be useful if you contact support, as it gives some basic
 diagnostics.
 

--- a/api/enterprise-api-examples/managing-settings.markdown
+++ b/api/enterprise-api-examples/managing-settings.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Managing Settings
+title:  Managing settings
 published: true
 sorting: 30
 tags: [examples, enterprise, rest, api, reporting, settings, ldap]

--- a/api/enterprise-api-examples/managing-users-and-roles.markdown
+++ b/api/enterprise-api-examples/managing-users-and-roles.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Managing Users and Roles
+title:  Managing users and roles
 published: true
 sorting: 40
 tags: [examples, enterprise, rest, api, reporting, users, roles]

--- a/api/enterprise-api-examples/sql-queries.markdown
+++ b/api/enterprise-api-examples/sql-queries.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  SQL Query Examples
+title:  SQL query examples
 published: true
 tags: [examples, enterprise, rest, api, reporting, sql, queries]
 ---

--- a/api/enterprise-api-ref.markdown
+++ b/api/enterprise-api-ref.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Enterprise API Reference
+title:  Enterprise API reference
 published: true
 sorting: 70
 tags: [reference, enterprise, REST, API, reporting, sql]
@@ -11,17 +11,17 @@ number of URI resources that support one or more GET, PUT, POST, or
 DELETE operations. While reporting is done using SQL, this query is
 always wrapped in a JSON request.
 
-**See also:** [Enterprise API Examples][Enterprise API Examples]
+**See also:** [Enterprise API examples][Enterprise API examples]
 
 ## Requests
 
 **GET** requests are one of **listing** or **getting**. **Listing** resources
 means that a number of results will be returned, but each entry may contain
-limited information. An example of a **listing** query is [/api/user][Users and Access-Control REST API#List users] to list
+limited information. An example of a **listing** query is [/api/user][Users and access-control REST API#List users] to list
 users. Notice that URI components are always non-plural. An exception to this
-is [/api/settings][Status and Settings REST API#Get settings], which returns the singleton resource for settings.
+is [/api/settings][Status and settings REST API#Get settings], which returns the singleton resource for settings.
 **Getting** a resource specifies an individual resource to return, e.g.
-[/api/user/homer][Users and Access-Control REST API#Get user data].
+[/api/user/homer][Users and access-control REST API#Get user data].
 
 **PUT** request typically create a new resource, e.g. a user.
 
@@ -86,9 +86,9 @@ All timestamps are reported in *Unix Time*, i.e. seconds since 1970.
 The API supports both internal and external authentication. The internal users
 table will always be consulted first, followed by an external source specified
 in the settings. External sources are *OpenLDAP* or *Active Directory* servers
-configurable through [/api/settings][Status and Settings REST API#Update settings].
+configurable through [/api/settings][Status and settings REST API#Update settings].
 
 
 ## Authorization
 
-Some resources require that the request user is a member of the *admin* role. Roles are managed with [/api/role][Users and Access-Control REST API#List RBAC roles]. Role Based Access Control (RBAC) is configurable through the settings. Users typically have permission to access their own resources, e.g. their own scheduled reports.
+Some resources require that the request user is a member of the *admin* role. Roles are managed with [/api/role][Users and access-control REST API#List RBAC roles]. Role Based Access Control (RBAC) is configurable through the settings. Users typically have permission to access their own resources, e.g. their own scheduled reports.

--- a/api/enterprise-api-ref/changes.markdown
+++ b/api/enterprise-api-ref/changes.markdown
@@ -162,7 +162,7 @@ List changes performed by CFEngine to the infrastructure. List can be narrowed d
 * **data.hostkey**
     Unique host identifier.
 * **data.hostname**
-    Host name locally detected on the host, configurable as `hostIdentifier` option in [Settings API][Status and Settings REST API#Get settings] and Mission Portal settings UI.
+    Host name locally detected on the host, configurable as `hostIdentifier` option in [Settings API][Status and settings REST API#Get settings] and Mission Portal settings UI.
 * **data.logmessages**
     List of 5 last messages generated during promise execution. Log messages can be used for tracking specific changes made by CFEngine while repairing or failing promise execution.
 * **data.policyfile**
@@ -174,7 +174,7 @@ List changes performed by CFEngine to the infrastructure. List can be narrowed d
 * **data.promiser**
     Object affected by a promise.
 * **data.promisetype**
-    [Type][Promise Types] of the promise.
+    [Type][Promise types] of the promise.
 * **data.stackpath**
     Call stack of the promise.
 

--- a/api/enterprise-api-ref/export-import-api.markdown
+++ b/api/enterprise-api-ref/export-import-api.markdown
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Import & Export API
+title: Import & export API
 published: true
 tags: [reference, enterprise, API, import, export]
 ---
 
-Import & Export API provides users the ability to transfer Mission Portal data between hubs.
+Import & export API provides users the ability to transfer Mission Portal data between hubs.
 
 **See also:** [Export/Import Settings UI][Settings#Export/Import]
 
@@ -91,7 +91,7 @@ HTTP 200 Ok
 
 * **item_id** *(array)*
     Item id to be exported.
-    List of item ids you can obtain through [List of items to export][Import & Export API#Get available items to export]
+    List of item ids you can obtain through [List of items to export][Import & export API#Get available items to export]
         call described below.
 
 * **encryptionKey** *(string)*

--- a/api/enterprise-api-ref/export-import-compliance-report-api.markdown
+++ b/api/enterprise-api-ref/export-import-compliance-report-api.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Import & Export Compliance Report API
+title: Import & export compliance report API
 published: true
 tags: [reference, enterprise, API, import, export, compliance report]
 ---

--- a/api/enterprise-api-ref/federated-reporting-api.markdown
+++ b/api/enterprise-api-ref/federated-reporting-api.markdown
@@ -10,7 +10,7 @@ This API is used for configuring hubs so that a single hub can be used to report
 # Remote hubs
 
 Federated reporting must be enabled before it is possible to use the remote hubs API, please
-see the `Enable hub for Federated Reporting` section below.
+see the `Enable hub for Federated reporting` section below.
 
 ## Remote hubs list
 
@@ -157,7 +157,7 @@ HTTP 202 ACCEPTED
 HTTP 202 ACCEPTED
 ```
 
-# Enable hub for Federated Reporting
+# Enable hub for Federated reporting
 
 ## Enable hub as a Superhub
 
@@ -206,7 +206,7 @@ HTTP 202 ACCEPTED
 # Federation config
 
 Federated reporting must be enabled before generating or removing federation configuration, please
-see `Enable hub for Federated Reporting` section above. Otherwise an error will be thrown and
+see `Enable hub for Federated reporting` section above. Otherwise an error will be thrown and
 config file will not be created/deleted.
 
 ## Generate federation config

--- a/api/enterprise-api-ref/file-changes.markdown
+++ b/api/enterprise-api-ref/file-changes.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: File Changes API
+title: File changes API
 published: true
 tags: [reference, enterprise, API, reporting, file changes]
 ---

--- a/api/enterprise-api-ref/host.markdown
+++ b/api/enterprise-api-ref/host.markdown
@@ -60,7 +60,7 @@ Host API allows to access host specific information.
 * **id**
     Unique host identifier.
 * **hostname**
-    Host name. Can be reconfigured globally to represent variable set in the policy using **hostIdentifier** [setting][Status and Settings REST API#Update settings].
+    Host name. Can be reconfigured globally to represent variable set in the policy using **hostIdentifier** [setting][Status and settings REST API#Update settings].
 * **ip**
     IP address of the host. If host have multiple network interfaces, IP belongs to the interface that is used to communicate with policy server.
 * **lastreport**
@@ -103,7 +103,7 @@ Host API allows to access host specific information.
 * **id**
     Unique host identifier.
 * **hostname**
-    Host name. Can be reconfigured globally to represent variable set in the policy using **hostIdentifier** [setting][Status and Settings REST API#Update settings].
+    Host name. Can be reconfigured globally to represent variable set in the policy using **hostIdentifier** [setting][Status and settings REST API#Update settings].
 * **ip**
     IP address of the host. If host have multiple network interfaces, IP belongs to the interface that is used to communicate with policy server.
 * **lastreport**
@@ -139,7 +139,7 @@ The hostkey is then removed from:
 
 Note: There is a record of the host retained that includes the time when the host was deleted and this record also prevents further collection from this host identity.
 
-**See also:** [Example removing host data][Browsing Host Information#example: removing host data]
+**See also:** [Example removing host data][Browsing host information#example: removing host data]
 
 ## Hosts list grouped by hard classes
 

--- a/api/enterprise-api-ref/inventory.markdown
+++ b/api/enterprise-api-ref/inventory.markdown
@@ -188,7 +188,7 @@ curl -k --user <username>:<password> \
 Shows list of all inventory attributes available in the system.
 
 See more details:
-* [Custom Inventory][Custom Inventory]
+* [Custom inventory][Custom inventory]
 
 **CURL request example**
 ```

--- a/api/enterprise-api-ref/query.markdown
+++ b/api/enterprise-api-ref/query.markdown
@@ -7,7 +7,7 @@ tags: [reference, enterprise, REST, API, SQL, reporting, URI]
 
 In case of a need for full flexibility, Query API allow users to execute SQL queries on CFEngine Database.
 
-Database schema available can be found [here][SQL Schema].
+Database schema available can be found [here][SQL schema].
 
 ## Execute SQL query
 

--- a/api/enterprise-api-ref/sql-schema.markdown
+++ b/api/enterprise-api-ref/sql-schema.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: SQL Schema
+title: SQL schema
 published: true
 tags: [reference, enterprise, REST, API, reporting, sql, schema]
 ---
@@ -132,7 +132,7 @@ CFEngine contexts present on hosts at their last reported cf-agent execution.
     Unique host identifier. All tables can be joined by `HostKey` to connect data concerning same hosts.
 
 * **ContextName** *(text)*
-    CFEngine [context][Classes and Decisions] set by cf-agent.
+    CFEngine [context][Classes and decisions] set by cf-agent.
 
 * **MetaTags** *(text[])*
     List of [meta tags][Tags for variables, classes, and bundles] set for the context.
@@ -192,7 +192,7 @@ CFEngine contexts set on hosts by CFEngine over period of time.
     * `UNTRACKED` - CFEngine provides a mechanism for filtering unwanted data from being reported. `UNTRACKED` marker states that information about this context is being filtered and will not report any future information about it.
 
 * **ContextName** *(text)*
-    CFEngine [context][Classes and Decisions] set by cf-agent.
+    CFEngine [context][Classes and decisions] set by cf-agent.
 
 * **MetaTags** *(text[])*
     List of [meta tags][Tags for variables, classes, and bundles] set for the context.
@@ -309,7 +309,7 @@ Hosts table contains basic information about hosts managed by CFEngine.
 
 * **HostName** *(text)*
     Host name locally detected on the host, configurable as `hostIdentifier`
-    option in [Settings API][Status and Settings REST API#Get settings] and
+    option in [Settings API][Status and settings REST API#Get settings] and
     Mission Portal settings UI.
 
 * **IPAddress** *(text)*
@@ -779,7 +779,7 @@ Promises executed on hosts during their last reported cf-agent run.
     [Bundle][Bundles] name where the promise is executed.
 
 * **PromiseType** *(text)*
-    [Type][Promise Types] of the promise.
+    [Type][Promise types] of the promise.
 
 * **Promiser** *(text)*
     Object affected by a promise.
@@ -914,7 +914,7 @@ Promise status / outcome changes over period of time.
     [Bundle][Bundles] name where the promise is executed.
 
 * **PromiseType** *(text)*
-    [Type][Promise Types] of the promise.
+    [Type][Promise types] of the promise.
 
 * **Promiser** *(text)*
     Object affected by a promise.
@@ -1049,7 +1049,7 @@ History of promises executed on hosts.
     [Bundle][Bundles] name where the promise is executed.
 
 * **PromiseType** *(text)*
-    [Type][Promise Types] of the promise.
+    [Type][Promise types] of the promise.
 
 * **Promiser** *(text)*
     Object affected by a promise.
@@ -1732,7 +1732,7 @@ In this table data are cached what gives a better query performance
 
 * **HostName** *(text)*
     Host name locally detected on the host, configurable as `hostIdentifier`
-    option in [Settings API][Status and Settings REST API#Get settings] and
+    option in [Settings API][Status and settings REST API#Get settings] and
     Mission Portal settings UI.
 
 * **IPAddress** *(text)*

--- a/api/enterprise-api-ref/status-settings.markdown
+++ b/api/enterprise-api-ref/status-settings.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Status and Settings REST API
+title: Status and settings REST API
 published: true
 tags: [reference, enterprise, REST, API, reporting, status, URI, ldap, settings]
 ---
@@ -66,7 +66,7 @@ REST API for managing settings, checking hub status.
 * **license.licenseType**
     License description.
 
-**Example usage:** `Checking Status`
+**Example usage:** `Checking status`
 
 ## Get settings
 

--- a/api/enterprise-api-ref/users-rbac.markdown
+++ b/api/enterprise-api-ref/users-rbac.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Users and Access-Control REST API
+title: Users and access-control REST API
 published: true
 tags: [reference, enterprise, REST, API, reporting, URI, users, rbac]
 ---

--- a/cheatsheet.markdown
+++ b/cheatsheet.markdown
@@ -373,7 +373,7 @@ SELECT
         +++ b/README.md
         @@ -377,8 +377,12 @@ As a general note, avoiding abbreviations provides better readability.
 
-         * follow the [Policy Style Guide](guide/writing-and-serving-policy/policy-style.markdown)
+         * follow the [Policy style guide](guide/writing-and-serving-policy/policy-style.markdown)
            in examples and code snippets
         -* always run it through Pygments plus the appropriate lexer (only cf3
         -  supported for now)
@@ -394,7 +394,7 @@ index 92555a2..b49c0bb 100644
 +++ b/README.md
 @@ -377,8 +377,12 @@ As a general note, avoiding abbreviations provides better readability.
 
- * follow the [Policy Style Guide](guide/writing-and-serving-policy/policy-style.markdown)
+ * follow the [Policy style guide](guide/writing-and-serving-policy/policy-style.markdown)
    in examples and code snippets
 -* always run it through Pygments plus the appropriate lexer (only cf3
 -  supported for now)

--- a/enterprise-cfengine-guide/install-get-started.markdown
+++ b/enterprise-cfengine-guide/install-get-started.markdown
@@ -16,7 +16,7 @@ https://docs.google.com/document/d/1CeRR8cuMtrrr0X27gzVzP2ndiU0HuHvo7dJT2vIWfp0/
 
 ## Installation ##
 
-The [General Installation][General Installation] instructions provide the detailed steps for installing CFEngine, which are generally the same steps to follow for CFEngine Enterprise, with the exception of license keys (if applicable), and also some aspects of post-installation and configuration.
+The [General installation][General installation] instructions provide the detailed steps for installing CFEngine, which are generally the same steps to follow for CFEngine Enterprise, with the exception of license keys (if applicable), and also some aspects of post-installation and configuration.
 
 ### Installing Enterprise Licenses ###
 
@@ -36,7 +36,7 @@ The default FROM email for all emails sent from the Mission Portal is ```admin@o
 
 Consider enabling the built-in version control of your policies as
 described in
-[Version Control and Configuration Policy][Best Practices#Version Control and Configuration Policy]
+[Version control and Configuration Policy][Best practices#Version control and Configuration Policy]
 
 Whether you do or not, please put your policies in some kind of
 backed-up VCS. Losing work because of "fat fingering" `rm` commands is

--- a/examples.markdown
+++ b/examples.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Examples and Tutorials
+title: Examples and tutorials
 published: true
 sorting: 60
 tags: [Examples]
@@ -8,22 +8,22 @@ tags: [Examples]
 
 ## Links to Examples ##
 
-* [Example Snippets][Example Snippets]: This section is divided into topical areas and includes many examples of policy and promises. Each of the snippets can be easily copied or downloaded to a policy server and used as is.
+* [Example snippets][Example snippets]: This section is divided into topical areas and includes many examples of policy and promises. Each of the snippets can be easily copied or downloaded to a policy server and used as is.
 
 Note: CFEngine also includes a small set of examples by default, which can be
 found in `/var/cfengine/share/doc/examples`.
 
-* [Enterprise API Examples][Enterprise API Examples]
+* [Enterprise API examples][Enterprise API examples]
 * [Tutorials][Tutorials]
 
 See Also:
 
-* [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples]
-  * ["Hello World" Policy Example][Examples and Tutorials#"Hello World" Policy Example]
-  * [Activate a Bundle Manually][Examples and Tutorials#Activate a Bundle Manually]
-  * [Make the Example Stand Alone][Examples and Tutorials#Make the Example Stand Alone]
-  * [Make the Example an Executable Script][Examples and Tutorials#Make the Example an Executable Script]
-  * [Integrating the Example into your Main Policy][Examples and Tutorials#Integrating the Example into your Main Policy]
+* [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples]
+  * ["Hello World" Policy Example][Examples and tutorials#"Hello World" Policy Example]
+  * [Activate a Bundle Manually][Examples and tutorials#Activate a Bundle Manually]
+  * [Make the Example Stand Alone][Examples and tutorials#Make the Example Stand Alone]
+  * [Make the Example an Executable Script][Examples and tutorials#Make the Example an Executable Script]
+  * [Integrating the Example into your Main Policy][Examples and tutorials#Integrating the Example into your Main Policy]
 
 
 ## Tutorial for Running Examples ##
@@ -36,7 +36,7 @@ In this tutorial, you will perform the following:
 * Make the example an executable script
 * Add the example to the main policy file (`promises.cf`)
 
-**Note** if your CFEngine administrator has enabled continuous deployment of the policy from a Version Control System, your changes may be overwritten!
+**Note** if your CFEngine administrator has enabled continuous deployment of the policy from a Version control System, your changes may be overwritten!
 
 ### "Hello World" Policy Example ###
 
@@ -70,8 +70,8 @@ Following these steps, you will login to your policy server via the SSH protocol
 In the policy file above, we have defined an **agent bundle** named `hello_world`. Agent
 bundles are only evaluated by **cf-agent**, the [agent component][cf-agent] of CFEngine.
 
-This bundle [promises][Promise Types] to [report][reports] on any [class of
-hosts][Classes and Decisions].
+This bundle [promises][Promise types] to [report][reports] on any [class of
+hosts][Classes and decisions].
 
 
 
@@ -83,7 +83,7 @@ Activate the bundle manually by executing the following command at prompt:
 /var/cfengine/bin/cf-agent --no-lock --file ./hello_world.cf --bundlesequence hello_world
 ```
 
-This command instructs CFEngine to ignore [locks][Controlling Frequency], load
+This command instructs CFEngine to ignore [locks][Controlling frequency], load
 the `hello_world.cf` policy, and activate the `hello_world` bundle. See the output below:
 
 ```console

--- a/examples/example-snippets.markdown
+++ b/examples/example-snippets.markdown
@@ -1,23 +1,23 @@
 ---
 layout: default
-title: Example Snippets
+title: Example snippets
 sorting: 1
 published: true
 tags: [examples, policy, example snippets]
 ---
 
-* [General Examples][General Examples]
-* [Administration Examples][Administration Examples]
-* [Measuring Examples][Measuring Examples]
-* [Software Administration Examples][Software Administration Examples]
-* [Commands, Scripts, and Execution Examples][Commands, Scripts, and Execution Examples]
-* [File and Directory Examples][File and Directory Examples]
-* [File Template Examples][File Template Examples]
-* [Database Examples][Database Examples]
-* [Network Examples][Network Examples]
-* [System Security Examples][System Security Examples]
-* [System Information Examples][System Information Examples]
-* [System Administration Examples][System Administration Examples]
-* [System File Examples][System File Examples]
-* [Windows Registry Examples][Windows Registry Examples]
-* [User Management][User Management Examples]
+* [General examples][General examples]
+* [Administration examples][Administration examples]
+* [Measuring examples][Measuring examples]
+* [Software administration examples][Software administration examples]
+* [Commands, scripts, and execution examples][Commands, scripts, and execution examples]
+* [File and directory examples][File and directory examples]
+* [File template examples][File template examples]
+* [Database examples][Database examples]
+* [Network examples][Network examples]
+* [System security examples][System security examples]
+* [System information examples][System information examples]
+* [System administration examples][System administration examples]
+* [System file examples][System file examples]
+* [Windows registry examples][Windows registry examples]
+* [User Management][User management examples]

--- a/examples/example-snippets/active_directory.markdown
+++ b/examples/example-snippets/active_directory.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Interacting with Directory Services
+title: Interacting with directory services
 published: true
 sorting: 7
 tags: [Examples, Active Directory, LDAP, ldaparray(), ldaplist() ]

--- a/examples/example-snippets/basic-file-directory.markdown
+++ b/examples/example-snippets/basic-file-directory.markdown
@@ -1,36 +1,36 @@
 ---
 layout: default
-title: File and Directory Examples
+title: File and directory examples
 published: true
 sorting: 6
 tags: [Examples,Files,Directories]
 ---
 
-* [Create files and directories][File and Directory Examples#Create files and directories]
-* [Copy single files][File and Directory Examples#Copy single files]
-* [Copy directory trees][File and Directory Examples#Copy directory trees]
-* [Disabling and rotating files][File and Directory Examples#Disabling and rotating files]
-* [Add lines to a file][File and Directory Examples#Add lines to a file]
-* [Check file or directory permissions][File and Directory Examples#Check file or directory permissions]
-* [Commenting lines in a file][File and Directory Examples#Commenting lines in a file]
-* [Copy files][File and Directory Examples#Copy files]
-* [Copy and flatten directory][File and Directory Examples#Copy and flatten directory]
-* [Copy then edit a file convergently][File and Directory Examples#Copy then edit a file convergently]
-* [Deleting lines from a file][File and Directory Examples#Deleting lines from a file]
-* [Deleting lines exception][File and Directory Examples#Deleting lines exception]
-* [Delete files recursively][File and Directory Examples#Delete files recursively]
-* [Editing files][File and Directory Examples#Editing files]
-* [Editing tabular files][File and Directory Examples#Editing tabular files]
-* [Inserting lines in a file][File and Directory Examples#Inserting lines in a file]
-* [Back references in filenames][File and Directory Examples#Back references in filenames]
-* [Add variable definitions to a file][File and Directory Examples#Add variable definitions to a file]
-* [Linking files][File and Directory Examples#Linking files]
-* [Listing files-pattern in a directory][File and Directory Examples#Listing files-pattern in a directory]
-* [Locate and transform files][File and Directory Examples#Locate and transform files]
-* [BSD flags][File and Directory Examples#BSD flags]
-* [Search and replace text][File and Directory Examples#Search and replace text]
-* [Selecting a region in a file][File and Directory Examples#Selecting a region in a file]
-* [Warn if matching line in file][File and Directory Examples#Warn if matching line in file]
+* [Create files and directories][File and directory examples#Create files and directories]
+* [Copy single files][File and directory examples#Copy single files]
+* [Copy directory trees][File and directory examples#Copy directory trees]
+* [Disabling and rotating files][File and directory examples#Disabling and rotating files]
+* [Add lines to a file][File and directory examples#Add lines to a file]
+* [Check file or directory permissions][File and directory examples#Check file or directory permissions]
+* [Commenting lines in a file][File and directory examples#Commenting lines in a file]
+* [Copy files][File and directory examples#Copy files]
+* [Copy and flatten directory][File and directory examples#Copy and flatten directory]
+* [Copy then edit a file convergently][File and directory examples#Copy then edit a file convergently]
+* [Deleting lines from a file][File and directory examples#Deleting lines from a file]
+* [Deleting lines exception][File and directory examples#Deleting lines exception]
+* [Delete files recursively][File and directory examples#Delete files recursively]
+* [Editing files][File and directory examples#Editing files]
+* [Editing tabular files][File and directory examples#Editing tabular files]
+* [Inserting lines in a file][File and directory examples#Inserting lines in a file]
+* [Back references in filenames][File and directory examples#Back references in filenames]
+* [Add variable definitions to a file][File and directory examples#Add variable definitions to a file]
+* [Linking files][File and directory examples#Linking files]
+* [Listing files-pattern in a directory][File and directory examples#Listing files-pattern in a directory]
+* [Locate and transform files][File and directory examples#Locate and transform files]
+* [BSD flags][File and directory examples#BSD flags]
+* [Search and replace text][File and directory examples#Search and replace text]
+* [Selecting a region in a file][File and directory examples#Selecting a region in a file]
+* [Warn if matching line in file][File and directory examples#Warn if matching line in file]
 
 ## Create files and directories ##
 

--- a/examples/example-snippets/cfengine-administration.markdown
+++ b/examples/example-snippets/cfengine-administration.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Administration Examples
+title: Administration examples
 published: true
 sorting: 2
 tags: [Examples, CFEngine Administration]
 ---
 
-* [Ordering promises][Administration Examples#Ordering promises]
-* [Aborting execution][Administration Examples#Aborting execution]
+* [Ordering promises][Administration examples#Ordering promises]
+* [Aborting execution][Administration examples#Aborting execution]
 
 ## Ordering promises
 

--- a/examples/example-snippets/commands-scripts-execution.markdown
+++ b/examples/example-snippets/commands-scripts-execution.markdown
@@ -1,18 +1,18 @@
 ---
 layout: default
-title: Commands, Scripts, and Execution Examples
+title: Commands, scripts, and execution examples
 published: true
 sorting: 5
 tags: [Examples,Commands,Scripts]
 ---
 
-* [Command or script execution][Commands, Scripts, and Execution Examples#Command or script execution]
-* [Change directory for command][Commands, Scripts, and Execution Examples#Change directory for command]
-* [Commands example][Commands, Scripts, and Execution Examples#Commands example]
-* [Execresult example][Commands, Scripts, and Execution Examples#Execresult example]
-* [Methods][Commands, Scripts, and Execution Examples#Methods]
-* [Method validation][Commands, Scripts, and Execution Examples#Method validation]
-* [Trigger classes][Commands, Scripts, and Execution Examples#Trigger classes]
+* [Command or script execution][Commands, scripts, and execution examples#Command or script execution]
+* [Change directory for command][Commands, scripts, and execution examples#Change directory for command]
+* [Commands example][Commands, scripts, and execution examples#Commands example]
+* [Execresult example][Commands, scripts, and execution examples#Execresult example]
+* [Methods][Commands, scripts, and execution examples#Methods]
+* [Method validation][Commands, scripts, and execution examples#Method validation]
+* [Trigger classes][Commands, scripts, and execution examples#Trigger classes]
 
 ## Command or script execution ##
 

--- a/examples/example-snippets/database.markdown
+++ b/examples/example-snippets/database.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Database Examples
+title: Database examples
 published: true
 sorting: 8
 tags: [Examples,Databases]
 ---
 
-* [Database creation][Database Examples#Database creation]
+* [Database creation][Database examples#Database creation]
 
 ## Database creation
 

--- a/examples/example-snippets/file-template.markdown
+++ b/examples/example-snippets/file-template.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: File Template Examples
+title: File template examples
 published: true
 sorting: 7
 tags: [Examples]
 ---
 
-* [Templating][File Template Examples#Templating]
+* [Templating][File template examples#Templating]
 
 ## Templating
 

--- a/examples/example-snippets/file_permissions.markdown
+++ b/examples/example-snippets/file_permissions.markdown
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: File Permissions
+title: File permissions
 published: true
 sorting: 15
-tags: [Examples,File Permissions,Extended ACLs]
+tags: [Examples,File permissions,Extended ACLs]
 ---
 
 ## ACL file example

--- a/examples/example-snippets/general.markdown
+++ b/examples/example-snippets/general.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: General Examples
+title: General examples
 published: true
 sorting: 1
 tags: [Examples]
 ---
 
-* [Basic Example][General Examples#Basic Example]
-* [Hello world][General Examples#Hello world]
-* [Array example][General Examples#Array example]
+* [Basic Example][General examples#Basic Example]
+* [Hello world][General examples#Hello world]
+* [Array example][General examples#Array example]
 
 ## Basic Example ##
 

--- a/examples/example-snippets/network.markdown
+++ b/examples/example-snippets/network.markdown
@@ -1,18 +1,18 @@
 ---
 layout: default
-title: Network Examples
+title: Network examples
 published: true
 sorting: 9
 tags: [Examples]
 ---
 
-* [Find MAC address][Network Examples#Find MAC address]
-* [Client-server example][Network Examples#Client-server example]
-* [Read from a TCP socket][Network Examples#Read from a TCP socket]
-* [Set up a PXE boot server][Network Examples#Set up a PXE boot server]
-* [Resolver management][Network Examples#Resolver management]
-* [Mount NFS filesystem][Network Examples#Mount NFS filesystem]
-* [Unmount NFS filesystem][Network Examples#Unmount NFS filesystem]
+* [Find MAC address][Network examples#Find MAC address]
+* [Client-server example][Network examples#Client-server example]
+* [Read from a TCP socket][Network examples#Read from a TCP socket]
+* [Set up a PXE boot server][Network examples#Set up a PXE boot server]
+* [Resolver management][Network examples#Resolver management]
+* [Mount NFS filesystem][Network examples#Mount NFS filesystem]
+* [Unmount NFS filesystem][Network examples#Unmount NFS filesystem]
 * Find the MAC address
 * Mount NFS filesystem
 

--- a/examples/example-snippets/promise-patterns.markdown
+++ b/examples/example-snippets/promise-patterns.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Common Promise Patterns
+title:  Common promise patterns
 sorting: 2
 published: true
 tags: [examples, policy]
@@ -14,14 +14,14 @@ write policy for your system.
 * [Check filesystem space][Check filesystem space]
 * [Copy single files][Copy single files]
 * [Create files and directories][Create files and directories]
-* [Customize Message of the Day][Customize Message of the Day]
+* [Customize message of the day][Customize message of the day]
 * [Distribute ssh keys][Distribute ssh keys]
 * [Ensure a process is not running][Ensure a process is not running]
 * [Ensure a service is enabled and running][Ensure a service is enabled and running]
 * [Find the MAC address][Find the MAC address]
 * [Install packages][Install packages]
 * [Mount NFS filesystem][Mount NFS filesystem]
-* [Restart a Process][Restart a Process]
+* [Restart a process][Restart a process]
 * [Set up sudo][Set up sudo]
 * [Set up time management through NTP][Set up time management through NTP]
 * [Set up name resolution with DNS][Set up name resolution with DNS]

--- a/examples/example-snippets/promise-patterns/example_edit_motd.markdown
+++ b/examples/example-snippets/promise-patterns/example_edit_motd.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Customize Message of the Day
+title: Customize message of the day
 published: true
 tags: [Examples, Policy, motd, file editing, files]
 reviewed: 2015-12-18

--- a/examples/example-snippets/promise-patterns/example_process_restart.markdown
+++ b/examples/example-snippets/promise-patterns/example_process_restart.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Restart a Process
+title: Restart a process
 published: true
 tags: [Examples, Policy, process, restart]
 reviewed: 2013-06-08

--- a/examples/example-snippets/software-adminstration.markdown
+++ b/examples/example-snippets/software-adminstration.markdown
@@ -1,19 +1,19 @@
 ---
 layout: default
-title: Software Administration Examples
+title: Software administration examples
 published: true
 sorting: 4
 tags: [Examples,Software Administration]
 ---
 
-* [Software and patch installation][Software Administration Examples#Software and patch installation]
-* [Postfix mail configuration][Software Administration Examples#Postfix mail configuration]
-* [Set up a web server][Software Administration Examples#Set up a web server]
-* [Add software packages to the system][Software Administration Examples#Add software packages to the system]
-* [Application baseline][Software Administration Examples#Application baseline]
-* [Service management (windows)][Software Administration Examples#Service management (windows)]
-* [Software distribution][Software Administration Examples#Software distribution]
-* [Web server modules][Software Administration Examples#Web server modules]
+* [Software and patch installation][Software administration examples#Software and patch installation]
+* [Postfix mail configuration][Software administration examples#Postfix mail configuration]
+* [Set up a web server][Software administration examples#Set up a web server]
+* [Add software packages to the system][Software administration examples#Add software packages to the system]
+* [Application baseline][Software administration examples#Application baseline]
+* [Service management (windows)][Software administration examples#Service management (windows)]
+* [Software distribution][Software administration examples#Software distribution]
+* [Web server modules][Software administration examples#Web server modules]
 * Ensure a service is enabled and running
 * Managing Software
 * Install packages

--- a/examples/example-snippets/system-administration.markdown
+++ b/examples/example-snippets/system-administration.markdown
@@ -1,30 +1,30 @@
 ---
 layout: default
-title: System Administration Examples
+title: System administration examples
 published: true
 sorting: 12
 tags: [Examples,System Administration]
 ---
 
-* [Centralized Management][System Administration Examples#Centralized Management]
-	* [All hosts the same][System Administration Examples#All hosts the same]
-	* [Variation in hosts][System Administration Examples#Variation in hosts]
-	* [Updating from a central hub][System Administration Examples#Updating from a central hub]
-* [Laptop support configuration][System Administration Examples#Laptop support configuration]
-* [Process management][System Administration Examples#Process management]
-* [Kill process][System Administration Examples#Kill process]
-* [Restart process][System Administration Examples#Restart process]
-* [Mount a filesystem][System Administration Examples#Mount a filesystem]
-* [Manage a system process][System Administration Examples#Manage a system process]
-	* [Ensure running][System Administration Examples#Ensure running]
-	* [Ensure not running][System Administration Examples#Ensure not running]
-	* [Prune processes][System Administration Examples#Prune processes]
-* [Set up HPC clusters][System Administration Examples#Set up HPC clusters]
-* [Set up name resolution][System Administration Examples#Set up name resolution]
-* [Set up sudo][System Administration Examples#Set up sudo]
-* [Environments (virtual)][System Administration Examples#Environments (virtual)]
-* [Environment variables][System Administration Examples#Environment variables]
-* [Tidying garbage files][System Administration Examples#Tidying garbage files]
+* [Centralized Management][System administration examples#Centralized Management]
+	* [All hosts the same][System administration examples#All hosts the same]
+	* [Variation in hosts][System administration examples#Variation in hosts]
+	* [Updating from a central hub][System administration examples#Updating from a central hub]
+* [Laptop support configuration][System administration examples#Laptop support configuration]
+* [Process management][System administration examples#Process management]
+* [Kill process][System administration examples#Kill process]
+* [Restart process][System administration examples#Restart process]
+* [Mount a filesystem][System administration examples#Mount a filesystem]
+* [Manage a system process][System administration examples#Manage a system process]
+	* [Ensure running][System administration examples#Ensure running]
+	* [Ensure not running][System administration examples#Ensure not running]
+	* [Prune processes][System administration examples#Prune processes]
+* [Set up HPC clusters][System administration examples#Set up HPC clusters]
+* [Set up name resolution][System administration examples#Set up name resolution]
+* [Set up sudo][System administration examples#Set up sudo]
+* [Environments (virtual)][System administration examples#Environments (virtual)]
+* [Environment variables][System administration examples#Environment variables]
+* [Tidying garbage files][System administration examples#Tidying garbage files]
 
 ## Centralized Management
 

--- a/examples/example-snippets/system-file.markdown
+++ b/examples/example-snippets/system-file.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: System File Examples
+title: System file examples
 published: true
 sorting: 13
 tags: [Examples,System Administration,System Files]

--- a/examples/example-snippets/system-information.markdown
+++ b/examples/example-snippets/system-information.markdown
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: System Information Examples
+title: System information examples
 published: true
 sorting: 11
 tags: [Examples,System Information]
 ---
 
-* [Change detection][System Information Examples#Change detection]
-* [Hashing for change detection (tripwire)][System Information Examples#Hashing for change detection (tripwire)]
-* [Check filesystem space][System Information Examples#Check filesystem space]
-* [Class match example][System Information Examples#Class match example]
-* [Global classes][System Information Examples#Global classes]
-* [Logging][System Information Examples#Logging]
+* [Change detection][System information examples#Change detection]
+* [Hashing for change detection (tripwire)][System information examples#Hashing for change detection (tripwire)]
+* [Check filesystem space][System information examples#Check filesystem space]
+* [Class match example][System information examples#Class match example]
+* [Global classes][System information examples#Global classes]
+* [Logging][System information examples#Logging]
 * Check filesystem space
 
 ## Change detection

--- a/examples/example-snippets/system-security.markdown
+++ b/examples/example-snippets/system-security.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: System Security Examples
+title: System security examples
 published: true
 sorting: 10
 tags: [Examples,System Security]
 ---
 
-* [Distribute root passwords][System Security Examples#Distribute root passwords]
-* [Distribute ssh keys][System Security Examples#Distribute ssh keys]
+* [Distribute root passwords][System security examples#Distribute root passwords]
+* [Distribute ssh keys][System security examples#Distribute ssh keys]
 * Distribute ssh keys
 
 ## Distribute root passwords

--- a/examples/example-snippets/timing-counting-measuring.markdown
+++ b/examples/example-snippets/timing-counting-measuring.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Measuring Examples
+title: Measuring examples
 published: true
 sorting: 3
 tags: [Examples, Timing, Counting, Measuring]
 ---
 
-* [Measurements][Measuring Examples#Measurements]
+* [Measurements][Measuring examples#Measurements]
 
 ## Measurements
 

--- a/examples/example-snippets/user-management.markdown
+++ b/examples/example-snippets/user-management.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: User Management Examples
+title: User management examples
 published: true
 sorting: 15
 tags: [Examples,User Management]

--- a/examples/example-snippets/windows-registry.markdown
+++ b/examples/example-snippets/windows-registry.markdown
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Windows Registry Examples
+title: Windows registry examples
 published: true
 sorting: 14
 tags: [Examples,Windows Registry]
 ---
 
-* [Windows registry][Windows Registry Examples#Windows registry]
-* [unit_registry_cache.cf][Windows Registry Examples#unit_registry_cache.cf]
-* [unit_registry.cf][Windows Registry Examples#unit_registry.cf]
+* [Windows registry][Windows registry examples#Windows registry]
+* [unit_registry_cache.cf][Windows registry examples#unit_registry_cache.cf]
+* [unit_registry.cf][Windows registry examples#unit_registry.cf]
 
 ## Windows registry
 

--- a/examples/tutorials/custom_inventory.markdown
+++ b/examples/tutorials/custom_inventory.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Custom Inventory
+title: Custom inventory
 sorting: 15
 published: true
 tags: [Examples, Tutorials, Inventory, Enterprise]
@@ -15,11 +15,11 @@ For a more detailed overview on how the inventory system works please reference
 
 This tutorial provides instructions for the following:
 
-* [Choose an attribute][Custom Inventory#Choose an Attribute to Inventory]
+* [Choose an attribute][Custom inventory#Choose an Attribute to Inventory]
 
-* [Create and deploy inventory policy][Custom Inventory#Create and Deploy Inventory Policy]
+* [Create and deploy inventory policy][Custom inventory#Create and Deploy Inventory Policy]
 
-* [Run Reports][Custom Inventory#Reporting]
+* [Run Reports][Custom inventory#Reporting]
 
 **Note:** This tutorial uses the [CFEngine Enterprise Vagrant Environment][Using Vagrant] and files located in the vagrant project directory are automatically available to all hosts.
 

--- a/examples/tutorials/dashboard-alerts.markdown
+++ b/examples/tutorials/dashboard-alerts.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Dashboard Alerts
+title: Dashboard alerts
 sorting: 15
 published: true
 tags: [Examples, Tutorials, Dashboard, Alerts, Enterprise]

--- a/examples/tutorials/file_comparison.markdown
+++ b/examples/tutorials/file_comparison.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: File Comparison
+title: File comparison
 published: true
 sorting: 100
 tags: [examples, tutorials, file]
 ---
 
-1. Add the [policy contents][File Comparison#Full Policy] (also can be downloaded from <a href="file_compare_test.cf">file_compare_test.cf</a>) to a new file, such as /var/cfengine/masterfiles/file_test.cf.
+1. Add the [policy contents][File comparison#Full Policy] (also can be downloaded from <a href="file_compare_test.cf">file_compare_test.cf</a>) to a new file, such as /var/cfengine/masterfiles/file_test.cf.
 2. Run the following commands as root on the command line:
 
 	```console

--- a/examples/tutorials/files-tutorial.markdown
+++ b/examples/tutorials/files-tutorial.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Create, Modify, and Delete Files
+title: Create, modify, and delete Files
 sorting: 10
 published: true
 tags: [Examples, Tutorials]
@@ -8,8 +8,8 @@ tags: [Examples, Tutorials]
 
 ## Prerequisites ##
 
-* Read the tutorial [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples]
-* Ensure you have read and understand the section on [how to make an example stand alone][Examples and Tutorials#Make the Example Stand Alone]
+* Read the tutorial [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples]
+* Ensure you have read and understand the section on [how to make an example stand alone][Examples and tutorials#Make the Example Stand Alone]
 * Ensure you have read the note at the end of that section regarding modification of the body common control to the following:
 
 ```cf3

--- a/examples/tutorials/high-availability.markdown
+++ b/examples/tutorials/high-availability.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: High Availability
+title: High availability
 published: true
 tags: [cfengine enterprise, high availability]
 ---
@@ -9,7 +9,7 @@ tags: [cfengine enterprise, high availability]
 
 Although CFEngine is a distributed system, with decisions made by autonomous agents running on each
 node, the hub can be viewed as a single point of failure. In order to be able to play both roles
-that hub is responsible for - policy serving and report collection - High Availability feature was
+that hub is responsible for - policy serving and report collection - High availability feature was
 introduced in 3.6.2.  Essentially it is based on well known and broadly used cluster resource
 management tools - [corosync](https://corosync.github.io/corosync/) and
 [pacemaker](https://clusterlabs.org/pacemaker/) as well as PostgreSQL streaming replication feature.
@@ -17,14 +17,14 @@ management tools - [corosync](https://corosync.github.io/corosync/) and
 
 ## Design
 
-CFEngine High Availability is based on redundancy of all components, most importantly the PostgreSQL
+CFEngine High availability is based on redundancy of all components, most importantly the PostgreSQL
 database. Active-passive PostgreSQL database configuration is the essential part of High
 Availability feature. While PostgreSQL supports different replication methods and active-passive
 configuration schemes, it doesn't provide out-of-the-box database failover-failback mechanism. To
 support that the well established cluster resources management solution based on the Linux-HA
 project was selected.
 
-Overview of CFEngine High Availability is shown in the diagram below.
+Overview of CFEngine High availability is shown in the diagram below.
 
 ![HASetup](ha_3.6.png)
 
@@ -55,7 +55,7 @@ documentation](https://wiki.postgresql.org/wiki/Streaming_Replication).
 
 ## CFEngine
 
-In a High Availability setup all the clients are aware of existence of more than one hub. Current
+In a High availability setup all the clients are aware of existence of more than one hub. Current
 active hub is selected as a policy server and policy fetching and report collection is done by the
 active hub. One of the differences comparing to single-hub installation is that instead of having
 one policy server, clients have a list of hubs where they should fetch policy and initiate report
@@ -67,12 +67,12 @@ already established trust with the passive hub as well.
 
 ### Mission Portal
 
-Mission Portal since 3.6.2 has a new indicator whitch shows the status of the High Availability
+Mission Portal since 3.6.2 has a new indicator whitch shows the status of the High availability
 configuration.
 
 <img src="ha_health_OK.png" alt="HAHealth" width="480px">
 
-High Availability status is constantly monitored so that once some malfunction is discovered the
+High availability status is constantly monitored so that once some malfunction is discovered the
 user is notified about the degraded state of the system. Besides simple visualization of High
 Availability, the user is able to get detailed information regarding the reason for a degraded
 state, as well as when data was last reported from each hub. This gives quite comprehensive
@@ -84,16 +84,16 @@ knowledge and overview of the whole setup.
 ### Inventory
 
 There are also new Mission Portal inventory variables indicating the IP address of the active hub
-instance and status of the High Availability installation on each of the hubs. Looking at inventory
-reports is especially helpful to diagnose any problems when High Availability is reported as
+instance and status of the High availability installation on each of the hubs. Looking at inventory
+reports is especially helpful to diagnose any problems when High availability is reported as
 *degraded*.
 
 <img src="ha_inventory.png" alt="HAInventory" width="700px">
 
 
-### CFEngine High Availability installation
+### CFEngine High availability installation
 
-Existing CFEngine Enterprise installations can upgrade their single-node hub to a High Availability
+Existing CFEngine Enterprise installations can upgrade their single-node hub to a High availability
 system in versions 3.6.2 and newer. Detailed instructions how to upgrade from single hub to High
-Availability or how to install CFEngine High Availability from scratch can be found in the
-[Installation Guide][Installation Guide].
+Availability or how to install CFEngine High availability from scratch can be found in the
+[Installation guide][Installation guide].

--- a/examples/tutorials/high-availability/installation-guide.markdown
+++ b/examples/tutorials/high-availability/installation-guide.markdown
@@ -1,20 +1,20 @@
 ---
 layout: default
 published: true
-title: Installation Guide
+title: Installation guide
 tags: [cfengine enterprise, high availability]
 ---
 
 ## Overview ##
 
-This tutorial is describing the installation steps of the **CFEngine High Availability** feature. It
+This tutorial is describing the installation steps of the **CFEngine High availability** feature. It
 is suitable for both upgrading existing CFEngine installations to HA and for installing HA from
-scratch. Before starting installation we strongly recommend reading the [CFEngine High Availability
-overview][High Availability].
+scratch. Before starting installation we strongly recommend reading the [CFEngine High availability
+overview][High availability].
 
 ## Installation procedure ##
 
-As with most High Availability systems, setting it up requires carefully following a series of steps
+As with most High availability systems, setting it up requires carefully following a series of steps
 with dependencies on network components. The setup can therefore be error-prone, so if you are a
 CFEngine Enterprise customer we recommend that you contact support for assistance if you do not feel
 100% comfortable of doing this on your own.

--- a/examples/tutorials/installing-cfengine-enterprise-agent.markdown
+++ b/examples/tutorials/installing-cfengine-enterprise-agent.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Installing CFEngine Enterprise Agent
+title: Installing CFEngine Enterprise agent
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/examples/tutorials/integrating-alerts-with-ticketing-systems.markdown
+++ b/examples/tutorials/integrating-alerts-with-ticketing-systems.markdown
@@ -70,4 +70,4 @@ In this tutorial, we have shown how easy it is to integrate with a ticketing sys
 
 Using this Custom action, you can choose to open JIRA tickets when some or all of your alerts are triggered. But this is just the beginning; using Custom actions, you can integrate with virtually *any* external system for notifying about- or handling triggered alerts.
 
-Read more in the [Custom action documentation][Custom actions for Alerts].
+Read more in the [Custom action documentation][Custom actions for alerts].

--- a/examples/tutorials/json-yaml-support-in-cfengine.markdown
+++ b/examples/tutorials/json-yaml-support-in-cfengine.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: JSON and YAML Support in CFEngine
+title: JSON and YAML support in CFEngine
 published: true
 sorting: 2
 tags: [json, yaml]

--- a/examples/tutorials/manage-ntp.markdown
+++ b/examples/tutorials/manage-ntp.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Manage Network Time Protocol
+title: Manage network time protocol
 published: true
 sorting: 3
 tags: [getting started, tutorial]
@@ -430,7 +430,7 @@ This attribute sets the permissions and ownership of the file. [`mog()`][stdlib-
 handle                => "ntp_files_conf",
 ```
 
-A handle uniquely identifies a promise within a policy set. The [policy style guide][Policy Style Guide#promise handles] recommends a naming scheme for the handles e.g. `bundle_name_promise_type_class_restriction_promiser`. Handles are optional, but can be very useful when reviewing logs and can also be used to influence promise ordering with `depends_on`.
+A handle uniquely identifies a promise within a policy set. The [policy style guide][Policy style guide#promise handles] recommends a naming scheme for the handles e.g. `bundle_name_promise_type_class_restriction_promiser`. Handles are optional, but can be very useful when reviewing logs and can also be used to influence promise ordering with `depends_on`.
 
 ##### classes
 

--- a/examples/tutorials/masterfiles_policy_framework_upgrade.markdown
+++ b/examples/tutorials/masterfiles_policy_framework_upgrade.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Masterfiles Policy Framework Upgrade
+title: Masterfiles Policy Framework upgrade
 published: true
 sorting: 14
 tags: [MPF, upgrade, masterfiles, tutorial]

--- a/examples/tutorials/report_inventory_remediate_sec_vulnerabilities.markdown
+++ b/examples/tutorials/report_inventory_remediate_sec_vulnerabilities.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Reporting and Remediation of Security Vulnerabilities
+title: Reporting and remediation of security vulnerabilities
 sorting: 10
 published: true
 tags: [Examples, Tutorials, Enterprise, Inventory, Dashboard, Alerts]

--- a/examples/tutorials/reporting/command-line-reports.markdown
+++ b/examples/tutorials/reporting/command-line-reports.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Command-Line Reports
+title: Command-Line reports
 published: true
 sorting: 60
 ---
@@ -11,19 +11,19 @@ sorting: 60
 
 The following report topics are included:
 
-[CFEngine output levels][Command-Line Reports#CFEngine output levels]
+[CFEngine output levels][Command-Line reports#CFEngine output levels]
 
-[Creating custom reports][Command-Line Reports#Creating custom reports]
+[Creating custom reports][Command-Line reports#Creating custom reports]
 
-[Including data in reports][Command-Line Reports#Including data in reports]
+[Including data in reports][Command-Line reports#Including data in reports]
 
-[Excluding data from reports][Command-Line Reports#Excluding data from reports]
+[Excluding data from reports][Command-Line reports#Excluding data from reports]
 
-[Creating custom logs][Command-Line Reports#Creating custom logs]
+[Creating custom logs][Command-Line reports#Creating custom logs]
 
-[Redirecting output to logs][Command-Line Reports#Redirecting output to logs]
+[Redirecting output to logs][Command-Line reports#Redirecting output to logs]
 
-[Change detection: tripwires][Command-Line Reports#Change detection: tripwires]
+[Change detection: tripwires][Command-Line reports#Change detection: tripwires]
 
 
 ### CFEngine output levels

--- a/examples/tutorials/reporting/monitoring-reporting.markdown
+++ b/examples/tutorials/reporting/monitoring-reporting.markdown
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Monitoring and Reporting
+title: Monitoring and reporting
 published: true
 sorting: 10
 ---
 
-## What are Monitoring and Reporting?
+## What are Monitoring and reporting?
 
 Monitoring is the sampling of system variables at regular intervals in
 order to present an overview of actual changes taking place over time.

--- a/examples/tutorials/tags.markdown
+++ b/examples/tutorials/tags.markdown
@@ -34,7 +34,7 @@ so it's available out of the box in either Community or Enterprise.
 
 In the Enterprise Mission Portal, you can then make a report for
 "Ports listening" across all your machines. For more details, see
-[Enterprise Reporting][Enterprise Reporting]
+[Enterprise reporting][Enterprise reporting]
 
 Class tags work exactly the same way, you just apply them to a
 `classes` promise with the `meta` attribute.
@@ -102,12 +102,12 @@ This will create class `x` and variable `a` with tag `inventory`.
 Then it will create class `y` and variable `b` with tags `report` and
 `attribute_name=My vars`.
 
-## Enterprise Reporting with tags
+## Enterprise reporting with tags
 
 In CFEngine Enterprise, you can build reports based on tagged variables and
 classes.
 
-Please see [Enterprise Reporting][Enterprise Reporting] for a full tutorial,
+Please see [Enterprise reporting][Enterprise reporting] for a full tutorial,
 including troubleshooting possible errors. In short, this is an extremely easy
 way to categorize various data accessible to the agent.
 

--- a/examples/tutorials/write-cfengine-policy.markdown
+++ b/examples/tutorials/write-cfengine-policy.markdown
@@ -18,7 +18,7 @@ you normally reference bundles and other policy files.
 ## Bundles, Promise types, and Classes oh my!
 
 These concepts are core to CFEngine so they are covered in brief here. For more
-detailed information see the Language Concepts section of the Reference manual.
+detailed information see the Language concepts section of the Reference manual.
 
 ### Bundles
 

--- a/examples/tutorials/writing-and-serving-policy.markdown
+++ b/examples/tutorials/writing-and-serving-policy.markdown
@@ -1,21 +1,21 @@
 ---
 layout: default
-title: Writing and Serving Policy
+title: Writing and serving policy
 published: true
 sorting: 100
 ---
 
-* [About Policies and Promises][Writing and Serving Policy#About Policies and Promises]
-	* [What Are Promises][Writing and Serving Policy#What Are Promises]
-	* [The Value of a Promise][Writing and Serving Policy#The Value of a Promise]
-	* [Anatomy of a Promise][Writing and Serving Policy#Anatomy of a Promise]
-* [Policy Workflow][Writing and Serving Policy#Policy Workflow]
-* [How Promises Work][Writing and Serving Policy#How Promises Work]
-	* [Summary for Writing, Deploying and Using Promises][Writing and Serving Policy#Summary for Writing, Deploying and Using Promises]
-* [Best Practices][Writing and Serving Policy#Best Practices]
-* [Layers of Abstraction in Policy][Layers of Abstraction in Policy]
-* [Promises Available in CFEngine][Promises Available in CFEngine]
-* [Authoring Policy Tools & Workflow][Authoring Policy Tools & Workflow]
+* [About Policies and Promises][Writing and serving policy#About Policies and Promises]
+	* [What Are Promises][Writing and serving policy#What Are Promises]
+	* [The Value of a Promise][Writing and serving policy#The Value of a Promise]
+	* [Anatomy of a Promise][Writing and serving policy#Anatomy of a Promise]
+* [Policy Workflow][Writing and serving policy#Policy Workflow]
+* [How Promises Work][Writing and serving policy#How Promises Work]
+	* [Summary for Writing, Deploying and Using Promises][Writing and serving policy#Summary for Writing, Deploying and Using Promises]
+* [Best practices][Writing and serving policy#Best practices]
+* [Layers of abstraction in policy][Layers of abstraction in policy]
+* [Promises available in CFEngine][Promises available in CFEngine]
+* [Authoring policy tools & workflow][Authoring policy tools & workflow]
 
 ## About Policies and Promises ##
 
@@ -59,7 +59,7 @@ Everything in CFEngine can be thought of as a promise to be kept by different re
 Writing, deploying, and using CFEngine `promises` will generally follow these simple steps:
 
 1. Using a text editor, create a new file (e.g. `hello_world.cf`).
-2. Create a bundle and promise in the file (see ["Hello World" Policy Example][Examples and Tutorials#"Hello World" Policy Example]).
+2. Create a bundle and promise in the file (see ["Hello World" Policy Example][Examples and tutorials#"Hello World" Policy Example]).
 3. Save the file on the policy server somewhere under `/var/cfengine/masterfiles` (can be under a sub-directory).
 4. Let CFEngine know about the `promise` on the `policy server`, generally in the file `/var/cfengine/masterfiles/promises.cf`, or a file elsewhere but referred to in `promises.cf`.
 
@@ -67,7 +67,7 @@ Writing, deploying, and using CFEngine `promises` will generally follow these si
 
 5. Verify the `policy file` was deployed and successfully run.
 
-See [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples] for a more detailed step by step tutorial.
+See [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples] for a more detailed step by step tutorial.
 
 ## Policy Workflow ##
 
@@ -110,13 +110,13 @@ recover from deployment errors easily. By placing the burden of responsibility
 for decision at the top, and for implementation at the bottom, we avoid
 needless fragility and keep two independent quality assurance processes apart.
 
-## Best Practices ##
+## Best practices ##
 
-* [Policy Style Guide][Policy Style Guide] This covers punctuation, whitespace, and other styles to remember when writing policy.
+* [Policy style guide][Policy style guide] This covers punctuation, whitespace, and other styles to remember when writing policy.
 
-* [Bundles Best Practices][Bundles Best Practices] Refer to this page as you decide when to make a bundle and when to use classes and/or variables in them.
+* [Bundles best practices][Bundles best practices] Refer to this page as you decide when to make a bundle and when to use classes and/or variables in them.
 
-* [Testing Policies][Testing Policies] This page describes how to locally test CFEngine and play with configuration files.
+* [Testing policies][Testing policies] This page describes how to locally test CFEngine and play with configuration files.
 
 
 ## See Also ##

--- a/examples/tutorials/writing-and-serving-policy/authoring-policy-tools-and-workflow.markdown
+++ b/examples/tutorials/writing-and-serving-policy/authoring-policy-tools-and-workflow.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Authoring Policy Tools & Workflow
+title: Authoring policy tools & workflow
 published: true
 sorting: 5
 ---

--- a/examples/tutorials/writing-and-serving-policy/bundles-best-practices.markdown
+++ b/examples/tutorials/writing-and-serving-policy/bundles-best-practices.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Bundles Best Practices
+title: Bundles best practices
 published: true
 sorting: 20
 tags: [manuals, bundles, policy, best practices]

--- a/examples/tutorials/writing-and-serving-policy/controlling-frequency.markdown
+++ b/examples/tutorials/writing-and-serving-policy/controlling-frequency.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Controlling Frequency
+title: Controlling frequency
 published: true
 sorting: 90
 tags: [manuals, systems, configuration management, automation, control, frequency, performance]
@@ -46,7 +46,7 @@ body agent control
 This setting tells CFEngine not to verify promises until 60 minutes have
 elapsed, ie ensures that the global frequency for all promise verification is
 one hour. This global setting of one hour could be changed for a specific
-promise body by setting [`ifelapsed`][Promise Types#ifelapsed] in the promise body.
+promise body by setting [`ifelapsed`][Promise types#ifelapsed] in the promise body.
 
 ```cf3
 body action example

--- a/examples/tutorials/writing-and-serving-policy/external_data.markdown
+++ b/examples/tutorials/writing-and-serving-policy/external_data.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: External Data
+title: External data
 published: true
 sorting: 50
 tags: [manuals, writing policy, external data, augments]

--- a/examples/tutorials/writing-and-serving-policy/policy-layers-abstraction.markdown
+++ b/examples/tutorials/writing-and-serving-policy/policy-layers-abstraction.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Layers of Abstraction in Policy
+title: Layers of abstraction in policy
 published: true
 sorting: 2
 tags: [overviews, writing policy, policy]

--- a/examples/tutorials/writing-and-serving-policy/policy-style.markdown
+++ b/examples/tutorials/writing-and-serving-policy/policy-style.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Policy Style Guide
+title: Policy style guide
 published: true
 sorting: 10
 tags: [manuals, style, policy]
@@ -23,7 +23,7 @@ guide.
 ## Promise Ordering
 
 There are two common styles that are used when writing policy. The
-[Normal Order][Normal Ordering] style dictates that promises should be
+[Normal Order][Normal ordering] style dictates that promises should be
 written in in the Normal Order that the agent evaluates promises
 in. The other is reader optimized where promises are written in the
 order they make sense to the reader. Both styles have their merits,
@@ -35,7 +35,7 @@ Here is an example of a policy written in the Normal Order. Note how
 `packages` are listed after `files`. This could confuse a novice who
 thinks that it is necessary for the files promise to only be attempted
 after the package promise is kept. However this style can be useful to
-a policy expert who is familiar with Normal Ordering.
+a policy expert who is familiar with Normal ordering.
 
 ```cf3
 bundle agent main
@@ -76,7 +76,7 @@ Here is an example of a policy written to be optimized for the reader.
 Note how packages are listed before files in the order which users
 think about taking imperitive action. This style can make it
 significantly easier for a novice to understand the desired state, but
-it is important to remember that Normal Ordering still applies and
+it is important to remember that Normal ordering still applies and
 that the promises will not be actuated in the order they are written.
 
 ```cf3

--- a/examples/tutorials/writing-and-serving-policy/promises-available-in-cfengine.markdown
+++ b/examples/tutorials/writing-and-serving-policy/promises-available-in-cfengine.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Promises Available in CFEngine
+title: Promises available in CFEngine
 sorting: 4
 published: true
 tags: [overviews, promises]

--- a/examples/tutorials/writing-and-serving-policy/testing-policies.markdown
+++ b/examples/tutorials/writing-and-serving-policy/testing-policies.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Testing Policies
+title: Testing policies
 published: true
 sorting: 50
 tags: [manuals, systems, configuration management, automation, testing, work directory]

--- a/getting-started.markdown
+++ b/getting-started.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Getting Started
+title: Getting started
 published: true
 sorting: 20
 ---
@@ -19,6 +19,6 @@ Afterwards, we will continue to more advanced topics, such as policy writing and
 
 1. [Part 1: Installation][Installation]
 2. [Part 2: Modules from CFEngine Build][Modules from CFEngine Build]
-3. [Part 3: Reporting and Web UI][Reporting and Web UI]
+3. [Part 3: Reporting and web UI][Reporting and web UI]
 4. [Part 4: Writing policy][Writing policy]
 5. [Part 5: Developing modules][Developing modules]

--- a/getting-started/developing-modules.markdown
+++ b/getting-started/developing-modules.markdown
@@ -136,5 +136,5 @@ There are several places to look for more information or inspiration when writin
 * [The real git promise type code](https://github.com/cfengine/modules/tree/c3b7329b240cf7ad062a0a64ee8b607af2cb912a/promise-types/git/)
 * [HTTP promise type module](https://github.com/cfengine/modules/tree/c861789d4b376147d904fccd76963a92e65eaa97/promise-types/http/)
 * [CFEngine custom promise type specification](./reference-promise-types-custom.html)
-* [Blog post: How to implement CFEngine Custom Promise Types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
-* [Blog post: How to implement CFEngine Custom Promise Types in Bash](https://cfengine.com/blog/2021/how-to-implement-cfengine-custom-promise-types-in-bash/)
+* [Blog post: How to implement CFEngine Custom Promise types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
+* [Blog post: How to implement CFEngine Custom Promise types in Bash](https://cfengine.com/blog/2021/how-to-implement-cfengine-custom-promise-types-in-bash/)

--- a/getting-started/installation/general-installation.markdown
+++ b/getting-started/installation/general-installation.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: General Installation
+title: General installation
 published: true
 sorting: 20
 tags: [guide, installation, install]
@@ -10,7 +10,7 @@ tags: [guide, installation, install]
 
 ## Before Installation ##
 
-Check the [Pre-Installation Checklist][Pre-Installation Checklist] and [Supported Platforms and Versions][Supported Platforms and Versions] for requirements and other information that is useful for the installation procedure.
+Check the [Pre-installation checklist][Pre-installation checklist] and [Supported platforms and versions][Supported platforms and versions] for requirements and other information that is useful for the installation procedure.
 
 ## Install Packages ##
 
@@ -125,11 +125,11 @@ Edit `/etc/hosts` and add an entry for the IP address and hostname of the server
 See: [What steps should I take after installing CFEngine Enterprise?][FAQ#What steps should I take after installing CFEngine Enterprise]
 
 
-## More Detailed Installation Guides ##
+## More Detailed Installation guides ##
 
 Although most install procedures follow the same general workflow, there are several ways of installing CFEngine depending on your environment and which version of CFEngine you are using.
 
-* [Installing Enterprise for Production][Installing Enterprise for Production]
+* [Installing Enterprise for production][Installing Enterprise for production]
 * Install and test the latest version using our [native version][Installing Enterprise 25 Free], for free!
 * Installing CFEngine on virtual machine instances using [Amazon Web Services' (AWS) EC2 service][Using Amazon Web Services]
 	* This is especially useful for people running Windows on their workstation or laptop.
@@ -138,4 +138,4 @@ Although most install procedures follow the same general workflow, there are sev
 
 ## Next Steps ##
 
-* Learn about [Writing and Serving Policy][Writing and Serving Policy]
+* Learn about [Writing and serving policy][Writing and serving policy]

--- a/getting-started/installation/general-installation/common_next_steps.markdown
+++ b/getting-started/installation/general-installation/common_next_steps.markdown
@@ -1,11 +1,11 @@
 # Next Steps
 
-* [Writing and Serving Policy][Writing and Serving Policy]
-* [Examples and Tutorials][Examples and Tutorials]
-* ["Hello World" Tutorial][Examples and Tutorials#Tutorial for Running Examples]
+* [Writing and serving policy][Writing and serving policy]
+* [Examples and tutorials][Examples and tutorials]
+* ["Hello World" Tutorial][Examples and tutorials#Tutorial for Running Examples]
 
 ## See also
 
-* [General Installation][General Installation]
-* [Post-Installation Configuration][General Installation#Post-Installation Configuration]
+* [General installation][General installation]
+* [Post-Installation Configuration][General installation#Post-Installation Configuration]
 * [FAQ][FAQ]

--- a/getting-started/installation/general-installation/installation-enterprise-free-aws-rhel.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-free-aws-rhel.markdown
@@ -189,7 +189,7 @@ Note: You can install CFEngine Enterprise on up to 25 hosts using the script abo
 
 ### Tutorials ###
 
-* [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples]
+* [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples]
 
 * [Distribute files from a central location.][Distribute files from a central location]
 
@@ -198,4 +198,4 @@ Note: You can install CFEngine Enterprise on up to 25 hosts using the script abo
 
 ### Recommended Reading ###
 
-* [Tutorials and Examples][Examples and Tutorials]
+* [Tutorials and Examples][Examples and tutorials]

--- a/getting-started/installation/general-installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-free.markdown
@@ -116,7 +116,7 @@ number you use in your **Vagrantfile** (e.g. policyserver.vm.network "forwarded_
 
 ## Tutorials
 
-* [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples]
+* [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples]
 
 * [Distribute files from a central location.][Distribute files from a central location]
 
@@ -125,4 +125,4 @@ number you use in your **Vagrantfile** (e.g. policyserver.vm.network "forwarded_
 
 ## Recommended Reading
 
-* [Tutorials and Examples][Examples and Tutorials]
+* [Tutorials and Examples][Examples and tutorials]

--- a/getting-started/installation/general-installation/installation-enterprise-generic-tarball.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-generic-tarball.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Installing from Binary tarball
+title: Installing from binary tarball
 published: true
 sorting: 50
 tags: [getting started, installation]

--- a/getting-started/installation/general-installation/installation-enterprise-vagrant.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-vagrant.markdown
@@ -29,7 +29,7 @@ and motherboards necessarily support hardware virtualization.
 
 If your system lacks this support you will need to choose another computer to
 take advantage of the 64-bit virtual machines or [install CFEngine using a
-different approach][General Installation#More Detailed Installation Guides].
+different approach][General installation#More Detailed Installation guides].
 
 ## Overview
 

--- a/getting-started/installation/general-installation/installation-enterprise.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Installing Enterprise for Production
+title: Installing Enterprise for production
 published: true
 sorting: 40
 tags: [getting started, installation, enterprise production]
@@ -266,6 +266,6 @@ through your web browser at http://`<IP address of your Policy Server>`.
 
 Learn more about CFEngine by using the following resources:
 
-* Tutorial: [Tutorial for Running Examples][Examples and Tutorials#Tutorial for Running Examples]
+* Tutorial: [Tutorial for Running Examples][Examples and tutorials#Tutorial for Running Examples]
 
-* [Tutorials and Examples][Examples and Tutorials]
+* [Tutorials and Examples][Examples and tutorials]

--- a/getting-started/installation/installation-overview.markdown
+++ b/getting-started/installation/installation-overview.markdown
@@ -10,20 +10,20 @@ tags: [getting started, installation]
 
 [%CFEngine_include_markdown(include-install-bootstrap-configure-summary.markdown)%]
 
-See [General Installation][General Installation] for a more detailed guide for how to install CFEngine, and links to installation guides for various versions of CFEngine and different configurations.
+See [General installation][General installation] for a more detailed guide for how to install CFEngine, and links to installation guides for various versions of CFEngine and different configurations.
 
-See [Secure Bootstrap] for a guide on bootstrapping CFEngine in untrusted networks.
+See [Secure bootstrap] for a guide on bootstrapping CFEngine in untrusted networks.
 
-See also: [Pre-Installation Checklist][Pre-Installation Checklist], [Supported Platforms and Versions][Supported Platforms and Versions]
+See also: [Pre-installation checklist][Pre-installation checklist], [Supported platforms and versions][Supported platforms and versions]
 
 ## Setup & Configuration ##
 
 Additional options for configuring CFEngine policy are as follows:
 
-* [Controlling Frequency]
+* [Controlling frequency]
 Learn how to control frequency settings for verifying CFEngine policy.
 
-* [Version Control]
+* [Version control]
 Learn how to put your CFEngine policies under version control.
 
 * [Masterfiles Policy Framework]

--- a/getting-started/installation/pre-installation-checklist.markdown
+++ b/getting-started/installation/pre-installation-checklist.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Pre-Installation Checklist
+title: Pre-installation checklist
 published: true
 sorting: 10
 tags: [guide, installation]
@@ -12,8 +12,8 @@ tags: [guide, installation]
 
 ## System requirements
 
-Please see [Installing Enterprise for Production][Installing Enterprise for Production] for hardware and configuration requirements, and
-for [Supported Platforms and Versions][Supported Platforms and Versions] operating system support.
+Please see [Installing Enterprise for production][Installing Enterprise for production] for hardware and configuration requirements, and
+for [Supported platforms and versions][Supported platforms and versions] operating system support.
 
 ## Required knowledge
 

--- a/getting-started/installation/secure-bootstrap.markdown
+++ b/getting-started/installation/secure-bootstrap.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Secure Bootstrap
+title: Secure bootstrap
 published: true
 sorting: 20
 tags: [guide, installation, install, security]

--- a/getting-started/installation/upgrading.markdown
+++ b/getting-started/installation/upgrading.markdown
@@ -74,7 +74,7 @@ anything goes wrong.
    root@hub:~# find /etc -name 'cfengine*' | tar cfz /tmp/$(date +%Y-%m-%d)-cfengine-init-backup.tar.gz -T -
    ```
 
-   **See also:** [Hub administration backup and restore][Backup and Restore]
+   **See also:** [Hub administration backup and restore][Backup and restore]
 
 3. Copy the archive to a safe location.
 
@@ -102,7 +102,7 @@ Normally most files can be replaced with new ones, files that typically contain
 user modifications include `promises.cf`, `controls/*.cf`, and
 `services/main.cf`.
 
-- [Masterfiles Policy Framework Upgrade Tutorial][Masterfiles Policy Framework Upgrade]
+- [Masterfiles Policy Framework upgrade Tutorial][Masterfiles Policy Framework upgrade]
 
 Once the Masterfiles Policy Framework has been qualified and distributed to all
 agents you are ready to begin binary upgrades.

--- a/getting-started/installation/version-control.markdown
+++ b/getting-started/installation/version-control.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Version Control
+title: Version control
 published: true
 sorting: 60
 tags: [manuals, writing policy, version control, git, subversion]
@@ -16,7 +16,7 @@ CFEngine Enterprise ships with
 [masterfiles-stage](https://github.com/cfengine/core/tree/master/contrib/masterfiles-stage),
 tooling to assist with deploying policy from a version control system.
 
-Enterprise users can configure automatic publication of policy from Mission Portal as described in [Policy Deployment] or by using the [VCS settings API][VCS settings API]. Community users can also install and use this tooling by following the
+Enterprise users can configure automatic publication of policy from Mission Portal as described in [Policy deployment] or by using the [VCS settings API][VCS settings API]. Community users can also install and use this tooling by following the
 [installation instructions](https://github.com/cfengine/core/tree/master/contrib/masterfiles-stage#installation).
 
 ## Commit hooks

--- a/getting-started/modules-from-cfengine-build.markdown
+++ b/getting-started/modules-from-cfengine-build.markdown
@@ -169,4 +169,4 @@ cfbs build && cf-remote deploy
 
 In the next tutorial we will look more at the reporting and Web UI, called Mission Portal:
 
-[Reporting and Web UI][Reporting and Web UI]
+[Reporting and web UI][Reporting and web UI]

--- a/getting-started/reporting-and-web-ui.markdown
+++ b/getting-started/reporting-and-web-ui.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Reporting and Web UI
+title: Reporting and web UI
 published: true
 sorting: 30
 tags: [guide, getting started, mission portal]

--- a/getting-started/writing-policy.markdown
+++ b/getting-started/writing-policy.markdown
@@ -212,6 +212,6 @@ Next, we will look at implementing modules, such as the git promise type we used
 
 If you would like to learn more about policy writing, these are some good resources to look at:
 
-* [Language concepts][Language Concepts]
-* [Promise Types][Promise Types]
+* [Language concepts][Language concepts]
+* [Promise types][Promise types]
 * [Functions][Functions]

--- a/guide.markdown
+++ b/guide.markdown
@@ -31,7 +31,7 @@ CFEngine Community, a free GPL v3 open source edition.
 
 See also:
 
-* [Supported Platforms and Versions][Supported Platforms and Versions]
+* [Supported platforms and versions][Supported platforms and versions]
 
 ## Install It
 
@@ -45,11 +45,11 @@ CFEngine up and running for various environments.
 Walk through the examples, tutorials and how to guides to get a better
 feel for the power and value of CFEngine:
 
-* [Policy Examples and Tutorials][Examples and Tutorials]
+* [Policy Examples and tutorials][Examples and tutorials]
 
 ## Learn More
 
-Take a look at the [Getting Started][] section to learn more about CFEngine's architecture and components, as well as how to write policy that can help manage IT systems.
+Take a look at the [Getting started][] section to learn more about CFEngine's architecture and components, as well as how to write policy that can help manage IT systems.
 
 Check out [External resources][External resources], for more guides, demos, and other resources from our CFEngine staff and our special CFEngine contributors.
 
@@ -62,16 +62,16 @@ experts if you need more help. Contact us!
 ## CFEngine Guide ##
 
 * [Overview][]
-* [Release Notes][]
+* [Release notes][]
 * [Installation][]
-	* [Pre-Installation Checklist]
-	* [General Installation]
+	* [Pre-installation checklist]
+	* [General installation]
 	* [Upgrading]
-	* [Secure Bootstrap]
-* [Writing and Serving Policy][]
-	* [Language Concepts][]
-	* [Promises Available in CFEngine][]
-	* [Authoring Policy Tools & Workflow][]
+	* [Secure bootstrap]
+* [Writing and serving policy][]
+	* [Language concepts][]
+	* [Promises available in CFEngine][]
+	* [Authoring policy tools & workflow][]
 * [Reports][]
 * [FAQ][]
 * [External Resources][]

--- a/index.markdown
+++ b/index.markdown
@@ -29,7 +29,7 @@ alias: index.html
             <div>Use modules to easily add reports or get things done without writing any code.</div>
          </li>
          <li>
-            <a href="getting-started-reporting-and-web-ui.html">Reporting and Web UI</a>
+            <a href="getting-started-reporting-and-web-ui.html">Reporting and web UI</a>
             <div>Know more about your infrastructure and hosts, their data, compliance and make changes from within the Web UI.</div>
          </li>
          <li>

--- a/overview.markdown
+++ b/overview.markdown
@@ -19,7 +19,7 @@ Those policies are distributed across all hosts within the system via download f
 
 CFEngine continually monitors all of the hosts in real-time, and should the system's current state begin to drift away from the intended state then CFEngine will automatically take corrective action to bring everything back into compliance.
 
-See Also: [Language Concepts][], [Writing and Serving Policy][]
+See Also: [Language concepts][], [Writing and serving policy][]
 
 ## CFEngine Policy Servers and Hosts ##
 
@@ -27,7 +27,7 @@ There are basically two categories of machines in a CFEngine environment: policy
 
 The role of a particular machine where CFEngine is deployed determines which of the components will be installed and running at any given moment.
 
-See Also: [Writing and Serving Policy][]
+See Also: [Writing and serving policy][]
 
 ## CFEngine Component Applications and Daemons ##
 

--- a/overview/client-server-communication.markdown
+++ b/overview/client-server-communication.markdown
@@ -64,7 +64,7 @@ variety of forms, usually files, but sometimes console output.
 
 ## Bootstrapping
 
-[Bootstrap][General Installation#Bootstrap] is the manual first run of cf-agent that establishes
+[Bootstrap][General installation#Bootstrap] is the manual first run of cf-agent that establishes
 communication with the policy server.
 Bootstrapping executes the `failsafe.cf` policy that connects to
 the server, establishes trust to the server's key, and that starts the

--- a/overview/directory-structure.markdown
+++ b/overview/directory-structure.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: CFEngine Directory Structure
+title: CFEngine directory structure
 published: true
 sorting: 20
 tags: [guide, system, system overview, directory structure, directories, files]
@@ -8,18 +8,18 @@ tags: [guide, system, system overview, directory structure, directories, files]
 
 The CFEngine application is fully contained within the /var/cfengine directory tree. Here is a quick breakdown of the directory structure and some of the files and functions associated with each subdirectory.
 
-* [/var/cfengine/bin][CFEngine Directory Structure#/var/cfengine/bin]
-* [Directories for Policy Files][CFEngine Directory Structure#Directories for Policy Files]
-* [Output Directories][CFEngine Directory Structure#Output Directories]
-* [Log Files in /var/cfengine][CFEngine Directory Structure#Log Files in /var/cfengine]
-* [Database Files in /var/cfengine][CFEngine Directory Structure#Database Files in /var/cfengine]
-* [Process (AKA PID) Files in /var/cfengine][CFEngine Directory Structure#Process (AKA PID) Files in /var/cfengine]
-* [Sockets in /var/cfengine][CFEngine Directory Structure#Sockets in /var/cfengine]
-* [Datafiles in /var/cfengine][CFEngine Directory Structure#Datafiles in /var/cfengine]
-* [Binary Files in /var/cfengine][CFEngine Directory Structure#Binary Files in /var/cfengine]
-* [git in /var/cfengine/bin][CFEngine Directory Structure#git in /var/cfengine/bin]
-* [Misc. in /var/cfengine/bin][CFEngine Directory Structure#Misc. in /var/cfengine/bin]
-* [Postgres in /var/cfengine/bin][CFEngine Directory Structure#Postgres in /var/cfengine/bin]
+* [/var/cfengine/bin][CFEngine directory structure#/var/cfengine/bin]
+* [Directories for Policy Files][CFEngine directory structure#Directories for Policy Files]
+* [Output Directories][CFEngine directory structure#Output Directories]
+* [Log Files in /var/cfengine][CFEngine directory structure#Log Files in /var/cfengine]
+* [Database Files in /var/cfengine][CFEngine directory structure#Database Files in /var/cfengine]
+* [Process (AKA PID) Files in /var/cfengine][CFEngine directory structure#Process (AKA PID) Files in /var/cfengine]
+* [Sockets in /var/cfengine][CFEngine directory structure#Sockets in /var/cfengine]
+* [Datafiles in /var/cfengine][CFEngine directory structure#Datafiles in /var/cfengine]
+* [Binary Files in /var/cfengine][CFEngine directory structure#Binary Files in /var/cfengine]
+* [git in /var/cfengine/bin][CFEngine directory structure#git in /var/cfengine/bin]
+* [Misc. in /var/cfengine/bin][CFEngine directory structure#Misc. in /var/cfengine/bin]
+* [Postgres in /var/cfengine/bin][CFEngine directory structure#Postgres in /var/cfengine/bin]
 
 ## /var/cfengine/bin ##
 

--- a/overview/glossary.markdown
+++ b/overview/glossary.markdown
@@ -49,7 +49,7 @@ CFEngine's data types describe what a variable can contain.  A variable can't be
 #### Directories ####
 #### Distribution ####
 #### Enterprise API ####
-#### Enterprise Reporting ####
+#### Enterprise reporting ####
 #### File Structure ####
 #### Frequency ####
 #### Functions ####
@@ -68,7 +68,7 @@ A software component in CFEngine Enterprise that acts as a single point of manag
 #### Monitoring ####
 #### Namespaces ####
 #### Networking ####
-#### Normal Ordering ####
+#### Normal ordering ####
 #### Operators ####
 #### Pattern Matching ####
 
@@ -90,7 +90,7 @@ A policy is a set of intentions about the system, coded as a list of promises. A
 
 #### Precedence ####
 #### Promise Attributes ####
-#### Promise Types ####
+#### Promise types ####
 #### Promise ####
 
 The CFEngine software manages every intended system outcome as "promises" to be kept. A CFEngine Promise corresponds roughly to a rule in other software products, but importantly promises are always things that can be kept and repaired continuously, on a real time basis, not just once at install-time.
@@ -114,11 +114,11 @@ In CFEngine, cf-serverd is a software component that serves files from one compu
 
 The special server that others consult for the latest policies is called the Policy Server.
 
-#### Special Variables ####
+#### Special variables ####
 #### Standard Library ####
 
 The standard library lives in a `masterfiles/lib` subdirectory.  It's a collection of useful bundles and bodies you can use.
 
 #### Syntax ####
 #### Variables ####
-#### Version Control ####
+#### Version control ####

--- a/overview/how-cfengine-works.markdown
+++ b/overview/how-cfengine-works.markdown
@@ -19,7 +19,7 @@ compliance and easy reporting. Using CFEngine, can be described in the following
 As an end-user you can use the CFEngine Domain Specific Language (DSL) to define
 desired states. CFEngine allows you to define a variety of states ranging from
 process management to software deployment and file integrity. You can check out
-CFEngine Promise Types to get an idea of the most common states you can define.
+CFEngine Promise types to get an idea of the most common states you can define.
 
 Normally, all desired states are stored in `.cf` text-files in the
 `/var/cfengine/masterfiles` directory on one or more central distribution points,

--- a/overview/what-is-cfengine-and-why.markdown
+++ b/overview/what-is-cfengine-and-why.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: What is CFEngine and Why?
+title: What is CFEngine and why?
 published: true
 sorting: 1
 tags: [getting started, faq]

--- a/reference.markdown
+++ b/reference.markdown
@@ -12,14 +12,14 @@ Language elements that belong together are typically documented on the same
 page.
 
 * [Components][Components]
-* [Promise Types][Promise Types]
+* [Promise types][Promise types]
 * [Functions][Functions]
-* [Language Concepts][Language Concepts]
-* [Special Variables][Special Variables]
-* [Enterprise API Reference][Enterprise API Reference]
-* [Syntax, identifiers and names][Language Concepts#Syntax, identifiers and names]
+* [Language concepts][Language concepts]
+* [Special variables][Special variables]
+* [Enterprise API reference][Enterprise API reference]
+* [Syntax, identifiers and names][Language concepts#Syntax, identifiers and names]
 * [Masterfiles Policy Framework][Masterfiles Policy Framework]
-* [All Promise and Body Types][All Promise and Body Types]
+* [All promise and body types][All promise and body types]
 * [Macros][Macros]
 
-See Also: [All Promise Types][All Promise and Body Types#All Promise Types], [All Body Types][All Promise and Body Types#All Body Types]
+See Also: [All Promise types][All promise and body types#All Promise types], [All Body Types][All promise and body types#All Body Types]

--- a/reference/all-types.markdown
+++ b/reference/all-types.markdown
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: All Promise and Body Types
+title: All promise and body types
 published: true
 sorting: 110
 tags: [reference]
 ---
 
-* [All Promise Types][All Promise and Body Types#All Promise Types]
-* [All Body Types][All Promise and Body Types#All Body Types]
+* [All Promise types][All promise and body types#All Promise types]
+* [All Body Types][All promise and body types#All Body Types]
 
-## All Promise Types
+## All Promise types
 
 [%CFEngine_syntax_map(promiseTypes)]
 

--- a/reference/common-attributes-include.markdown
+++ b/reference/common-attributes-include.markdown
@@ -1,23 +1,23 @@
 ### Common Attributes
 
 Common attributes are available to all promise types. Full details for common
-attributes can be found in the [Common Promise Attributes section][Promise Types#Common Promise Attributes] of
-the [Promise Types] page. The common attributes are as follows:
+attributes can be found in the [Common Promise Attributes section][Promise types#Common Promise Attributes] of
+the [Promise types] page. The common attributes are as follows:
 
-#### [action][Promise Types#action]
+#### [action][Promise types#action]
 
-#### [classes][Promise Types#classes]
+#### [classes][Promise types#classes]
 
-#### [comment][Promise Types#comment]
+#### [comment][Promise types#comment]
 
-#### [depends_on][Promise Types#depends_on]
+#### [depends_on][Promise types#depends_on]
 
-#### [handle][Promise Types#handle]
+#### [handle][Promise types#handle]
 
-#### [if][Promise Types#if]
+#### [if][Promise types#if]
 
-#### [meta][Promise Types#meta]
+#### [meta][Promise types#meta]
 
-#### [with][Promise Types#with]
+#### [with][Promise types#with]
 
 <hr>

--- a/reference/common-body-attributes-include.markdown
+++ b/reference/common-body-attributes-include.markdown
@@ -2,12 +2,12 @@
 
 Common body attributes are available to all body types. Full details for common
 body attributes can be found in the
-[Common Body Attributes section][Promise Types#Common Body Attributes]
-of the [Promise Types] page. The common attributes are as
+[Common Body Attributes section][Promise types#Common Body Attributes]
+of the [Promise types] page. The common attributes are as
 follows:
 
-##### [inherit_from][Promise Types#inherit_from]
+##### [inherit_from][Promise types#inherit_from]
 
-##### [meta][Promise Types#meta]
+##### [meta][Promise types#meta]
 
 <hr>

--- a/reference/components.markdown
+++ b/reference/components.markdown
@@ -193,7 +193,7 @@ runs of e.g. `cf-agent` and `cf-promises`.
 cache_system_functions => "true";
 ```
 
-**See also:** [`ifelapsed` in action bodies][Promise Types#ifelapsed]
+**See also:** [`ifelapsed` in action bodies][Promise types#ifelapsed]
 
 **History:**
 - Introduced in version 3.6.0.

--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -713,7 +713,7 @@ expireafter => "240";   # 4 hours
 }
 ```
 
-**See also:** [`body action expireafter`][Promise Types#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
+**See also:** [`body action expireafter`][Promise types#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
 
 ### files_auto_define
 
@@ -846,7 +846,7 @@ ifelapsed   => "180";   # 3 hours
 }
 ```
 
-**See also:** [Promise locking][Promises#Promise Locking], [ifelapsed action body attribute][Promise Types#ifelapsed]
+**See also:** [Promise locking][Promises#Promise Locking], [ifelapsed action body attribute][Promise types#ifelapsed]
 
 ### inform
 
@@ -906,7 +906,7 @@ max_children => "10";
 }
 ```
 
-**See also:** [`background` in action bodies][Promise Types#background]
+**See also:** [`background` in action bodies][Promise types#background]
 
 ### maxconnections
 

--- a/reference/components/cf-execd.markdown
+++ b/reference/components/cf-execd.markdown
@@ -86,7 +86,7 @@ set it to `120` and you are using a 5-minute agent schedule, a
 maximum of 120 / 5 = 24 agents should be enforced.
 
 
-**See also:** [`body action expireafter`][Promise Types#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter]
+**See also:** [`body action expireafter`][Promise types#expireafter], [`body contain exec_timeout`][commands#exec_timeout], [`body agent control expireafter`][cf-agent#expireafter]
 
 ### executorfacility
 

--- a/reference/components/cf-runagent.markdown
+++ b/reference/components/cf-runagent.markdown
@@ -9,7 +9,7 @@ keywords: [runagent]
 
 `cf-runagent` connects to a list of running instances of
 `cf-serverd`. It allows foregoing the usual `cf-execd` schedule to activate `cf-agent`.
-Additionally, a user may send [classes][Classes and Decisions] to be defined
+Additionally, a user may send [classes][Classes and decisions] to be defined
 on the remote host. Two kinds of classes may be sent: classes to decide on
 which hosts `cf-agent` will be started, and classes that the user requests
 `cf-agent` should define on execution. The latter type is regulated by

--- a/reference/components/file_control_promises.markdown
+++ b/reference/components/file_control_promises.markdown
@@ -24,7 +24,7 @@ bundle agent private
 This directive can be given multiple times within any file,
 outside of body and bundle definitions.
 
-Only [soft classes][Classes and Decisions] from common bundles can
+Only [soft classes][Classes and decisions] from common bundles can
 be used in class decisions inside `file control bodies`.
 
 ### inputs

--- a/reference/functions.markdown
+++ b/reference/functions.markdown
@@ -57,7 +57,7 @@ bundle agent main
 **Note:** the truth of a class expression or the result of a function call may
 change during evaluation, but typically, a class, once defined, will stay defined.
 
-**See also:** [persistence in classes and decisions][Classes and Decisions#persistence]
+**See also:** [persistence in classes and decisions][Classes and decisions#persistence]
 
 ### Promise attributes and function calls
 
@@ -112,11 +112,11 @@ When enabled
 [cached functions](https://docs.cfengine.com/docs/{{site.cfengine.branch}}/search.html?q=The+return+value+is+cached)
 are **not executed on every pass of convergence**. Instead, the function will
 only be executed once during the
-[agent evaluation step][Normal Ordering#Agent evaluation step]
+[agent evaluation step][Normal ordering#Agent evaluation step]
 and its result will be cached until the end of that agent execution.
 
 **Note:** Cached functions are executed multiple times during
-[policy validation and pre-evaluation][Normal Ordering#cf-promises policy validation step].
+[policy validation and pre-evaluation][Normal ordering#cf-promises policy validation step].
 Function caching is *per-process*, so results will not be cached between
 separate components e.g. `cf-agent`, `cf-serverd` and `cf-promises`.
 Additionally functions are cached by hashing the function arguments. If you have
@@ -127,7 +127,7 @@ occurrences.
 
 Function caching can be globally disabled by setting `cache_system_functions` in
 body common control to `false` or locally for a specific promise by using
-`ifelapsed => "0"` in the [action body][Promise Types#ifelapsed]
+`ifelapsed => "0"` in the [action body][Promise types#ifelapsed]
 of the promise.
 
 ## Function Skipping

--- a/reference/functions/classesmatching.markdown
+++ b/reference/functions/classesmatching.markdown
@@ -17,7 +17,7 @@ classes. The search order is hard, soft, then local to the current bundle.
 
 When any tags are given, only the classes with those tags matching the given
 [anchored][anchored] regular expressions are returned. Class tags are set
-using the [`meta`][Promise Types#meta] attribute.
+using the [`meta`][Promise types#meta] attribute.
 
 [%CFEngine_function_attributes(name, tag1, tag2, ...)%]
 

--- a/reference/functions/getclassmetatags.markdown
+++ b/reference/functions/getclassmetatags.markdown
@@ -7,7 +7,7 @@ tags: [reference, data functions, functions, getclassmetatags, meta, tags]
 
 [%CFEngine_function_prototype(classname, optional_tag)%]
 
-**Description:** Returns the list of [`meta`][Promise Types#meta] tags for class `classname`.
+**Description:** Returns the list of [`meta`][Promise types#meta] tags for class `classname`.
 
 [%CFEngine_function_attributes(classname, optional_tag)%]
 

--- a/reference/functions/getvariablemetatags.markdown
+++ b/reference/functions/getvariablemetatags.markdown
@@ -7,7 +7,7 @@ tags: [reference, data functions, functions, getvariablemetatags, meta, tags]
 
 [%CFEngine_function_prototype(varname, optional_tag)%]
 
-**Description:** Returns the list of [`meta`][Promise Types#meta] tags for variable `varname`.
+**Description:** Returns the list of [`meta`][Promise types#meta] tags for variable `varname`.
 
 Make sure you specify the correct scope when supplying the name of the
 variable.

--- a/reference/functions/variablesmatching.markdown
+++ b/reference/functions/variablesmatching.markdown
@@ -21,7 +21,7 @@ but not `inventory`, *both* are returned by variablesmatching(".*", "inventory",
 If you want logical AND semantics instead, you can make two calls to the function
 with one tag in each call and use the `intersection` function on the return values.
 
-Variable tags are set using the [`meta`][Promise Types#meta] attribute.
+Variable tags are set using the [`meta`][Promise types#meta] attribute.
 
 This function behaves exactly like `variablesmatching_as_data()` but returns
 just the list of all the variables. If you want their contents as well, see that

--- a/reference/functions/variablesmatching_as_data.markdown
+++ b/reference/functions/variablesmatching_as_data.markdown
@@ -22,7 +22,7 @@ but not `inventory`, *both* are returned by variablesmatching_as_data(".*", "inv
 If you want logical AND semantics instead, you can make two calls to the function
 with one tag in each call and use the `intersection` function on the return values.
 
-Variable tags are set using the [`meta`][Promise Types#meta] attribute.
+Variable tags are set using the [`meta`][Promise types#meta] attribute.
 
 This function behaves exactly like `variablesmatching()` but returns a data
 container with the full contents of all the variables instead of just their

--- a/reference/language-concepts.markdown
+++ b/reference/language-concepts.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Language Concepts
+title: Language concepts
 published: true
 sorting: 50
 tags: [overviews, language, syntax, concepts, promises]
@@ -66,9 +66,9 @@ scalar value or a list of scalar values: a string, integer or real number.
 
 This documentation about the language concepts introduces in addition
 
-* [**normal ordering**][Normal Ordering],
+* [**normal ordering**][Normal ordering],
 * [**loops**][Loops],
-* [**pattern matching and referencing**][Pattern Matching and Referencing],
+* [**pattern matching and referencing**][Pattern matching and referencing],
   and
 * [**namespaces**][namespaces]
 
@@ -161,7 +161,7 @@ Paths beginning with a backslash are assumed to be win32 paths.
 They must begin with a drive letter or double-slash server name.
 
 Note that in many cases, you have `sys.inputdir` and other
-[Special Variables] that work equally well on Windows and non-Windows
+[Special variables] that work equally well on Windows and non-Windows
 system.
 
 Note in recent versions of Cygwin you can decide to use the

--- a/reference/language-concepts/augments.markdown
+++ b/reference/language-concepts/augments.markdown
@@ -315,12 +315,12 @@ Variables of other types than string can be defined too, like in this example
 This key is supported in both `host_specific.json`, `def.json`, `def_preferred.json`, and augments loaded by the augments key.
 
 Any class defined via augments will be evaluated and installed as
-[**soft** classes][Classes and Decisions]. This key supports both
+[**soft** classes][Classes and decisions]. This key supports both
 _array_ and _dict_ formats.
 
 For an array each element of the array is tested against currently defined
 classes as an [anchored regular expression][anchored] unless the string ends with ```::``` indicating it should be interpreted as a
-[*class expression*][Classes and Decisions].
+[*class expression*][Classes and decisions].
 
 **For example:**
 
@@ -364,9 +364,9 @@ are supported when using the _dict_ structure.
 ```
 
 Note that augments is processed at the very beginning of agent evaluation. You
-can use any **hard** classes, [**persistent** classes][Classes and Decisions]
+can use any **hard** classes, [**persistent** classes][Classes and decisions]
 , or classes defined earlier in the augments list. Test carefully,
-custom [**soft** classes][Classes and Decisions] may not be defined early enough
+custom [**soft** classes][Classes and decisions] may not be defined early enough
 for use. Thus:
 
 ```json

--- a/reference/language-concepts/classes.markdown
+++ b/reference/language-concepts/classes.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Classes and Decisions
+title: Classes and decisions
 published: true
 sorting: 50
 tags: [manuals, language, syntax, concepts, classes, decisions]
@@ -26,7 +26,7 @@ namespace scope.
 
 In [CFEngine Enterprise](https://cfengine.com/product-overview/), classes that are defined can be reported to the
 CFEngine Database Server and can be used there for reporting, grouping of hosts
-and inventory management. For more information about how this is configured please read the documentation on [Enterprise Reporting][].
+and inventory management. For more information about how this is configured please read the documentation on [Enterprise reporting][].
 
 ## Listing Classes
 
@@ -68,7 +68,7 @@ Classes and variables have tags that describe their provenance (who
 created them) and purpose (why were they created).
 
 While you can provide your own tags for soft classes in policy with
-the [`meta`][Promise Types#meta] attribute, there are some tags applied to hard classes and
+the [`meta`][Promise types#meta] attribute, there are some tags applied to hard classes and
 other special cases.  This list may change in future versions of
 CFEngine.
 
@@ -179,7 +179,7 @@ of a week.
     * **See also:** `sys.fqhost`, `sys.uqhost`.
 -   An arbitrary user-defined string (as specified in the `-D`
     command line option, or defined in a [`classes` promise][classes] promise or
-    [`classes` body][Promise Types#classes],
+    [`classes` body][Promise types#classes],
     `restart_class` in a `processes` promise, etc).
 -   The IP address octets of any active interface (in the form
     `ipv4_192_0_0_1<!-- /@w -->`, `ipv4_192_0_0<!-- /@w -->`,
@@ -593,7 +593,7 @@ above and add [`and`][classes#and] or [`xor`][classes#xor] constraints to the
 single promise.
 
 Additionally classes can be defined or undefined as the result of a promise by
-using a [classes body][Promise Types#classes]. To set a class if
+using a [classes body][Promise types#classes]. To set a class if
 a promise is repaired, one might write:
 
 ```cf3
@@ -603,7 +603,7 @@ a promise is repaired, one might write:
 ```
 
 These classes are `namespace` scoped by default. The
-[`scope`][Promise Types#scope] attribute can be used to make them
+[`scope`][Promise types#scope] attribute can be used to make them
 local to the bundle.
 
 It is recommended to use bundle scoped classes whenever possible. This example
@@ -700,9 +700,9 @@ The standard library in the Masterfiles Policy Framework contains
 the [`feature`][lib/feature.cf] bundle which implements a useful model for
 defining classes for a period of time as well as canceling them on demand.
 
-**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise Types#persist_time], [`lib/event.cf`][lib/event.cf] in the MPF, [`lib/feature.cf`][lib/feature.cf] in the MPF
+**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time], [`lib/event.cf`][lib/event.cf] in the MPF, [`lib/feature.cf`][lib/feature.cf] in the MPF
 
 ## Canceling classes
 
-You can cancel a class with a [`classes`][Promise Types#classes] body.
+You can cancel a class with a [`classes`][Promise types#classes] body.
 See the `cancel_kept`, `cancel_notkept`, and `cancel_repaired` attributes.

--- a/reference/language-concepts/modules.markdown
+++ b/reference/language-concepts/modules.markdown
@@ -15,7 +15,7 @@ cfbs (CFEngine Build System) Modules provide a way to share and consume CFEngine
 ### Specification
 {% endcomment %}
 
-## Promise Modules
+## Promise modules
 
 Promise modules allow for the implementation of [*custom* promise types][promise-type-custom], extending the CFEngine Language. They communicate with `cf-agent` using the [*Promise Module Protocol*][promise-type-custom-protocol].
 
@@ -23,9 +23,9 @@ Promise modules allow for the implementation of [*custom* promise types][promise
 
 * Introduced 3.17.0
 
-## Package Modules
+## Package modules
 
-[Package Modules][Package Modules] implement the logic behind *packages* type promises, superseding the *package\_method* based implementation. They interact with package managers like `yum`, `apt`, `msiexec`, and `pip` to determine which packages are currently installed or have updates available as well as installing, upgrading or un-installing packages.
+[Package modules][Package modules] implement the logic behind *packages* type promises, superseding the *package\_method* based implementation. They interact with package managers like `yum`, `apt`, `msiexec`, and `pip` to determine which packages are currently installed or have updates available as well as installing, upgrading or un-installing packages.
 
 Package modules communicate with `cf-agent` via the [Package Module Protocol][package-modules-the-api].
 
@@ -33,13 +33,13 @@ Package modules communicate with `cf-agent` via the [Package Module Protocol][pa
 
 * Introduced 3.7.0
 
-## Variables and Classes Modules
+## Variables and classes modules
 
-Variables and Classes Modules are the original way to extend CFEngine. The Variable and Class Module Protocol allows for *variables* and *classes* to be defined. The protocol can be interpreted by functions like [`usemodule()`][usemodule] and [`read_module_protocol()`][read_module_protocol] as well as output from [*commands* type promises][commands] with the [`module => "true"`][commands#module] attribute.
+Variables and classes modules are the original way to extend CFEngine. The Variable and Class Module Protocol allows for *variables* and *classes* to be defined. The protocol can be interpreted by functions like [`usemodule()`][usemodule] and [`read_module_protocol()`][read_module_protocol] as well as output from [*commands* type promises][commands] with the [`module => "true"`][commands#module] attribute.
 
 The choice of interpretation can depend on many factors but a primary differentiate between functions and classes relate to CFEngine's evaluation details. Functions are evaluated during early during policy execution unless they are explicitly guarded to delay execution. Commands promises are not executed until the bundle is actuated for it's three pass evaluation.
 
-Variables and Classes Modules are intended for use as system probes rather than additional configuration promises, especially now that promise modules are available.
+Variables and classes modules are intended for use as system probes rather than additional configuration promises, especially now that promise modules are available.
 
 ### Specification
 

--- a/reference/language-concepts/modules/package-module-api.markdown
+++ b/reference/language-concepts/modules/package-module-api.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Package Modules
+title: Package modules
 published: true
 sorting: 70
 tags: [reference, language concepts, modules, package module api]

--- a/reference/language-concepts/namespaces.markdown
+++ b/reference/language-concepts/namespaces.markdown
@@ -48,12 +48,12 @@ A common mistake is forgetting to specify `default:` when using bodies from the 
 
 ## Variables
 
-Variables (except for Special Variables) are assumed to be within the same scope
+Variables (except for Special variables) are assumed to be within the same scope
 as the promiser but can also be referenced fully qualified with the namespace.
 
 [%CFEngine_include_example(namespace_variable_references.cf)%]
 
-[Special variables][Special Variables] are always accessible without a namespace
+[Special variables][Special variables] are always accessible without a namespace
   prefix. For example, `this`, `mon`, `sys`, and `const` fall in this category.
 
 [%CFEngine_include_example(namespace_special_var_exception.cf)%]
@@ -74,7 +74,7 @@ colon (`:`).
 
 [%CFEngine_include_example(namespace_classes.cf)%]
 
-[Hard classes][Classes and Decisions#Hard Classes] exist in all namespaces and
+[Hard classes][Classes and decisions#Hard Classes] exist in all namespaces and
 thus can be referred to from any namespace without qualification.
 
 [%CFEngine_include_example(namespace_hard_classes.cf)%]

--- a/reference/language-concepts/normal-ordering.markdown
+++ b/reference/language-concepts/normal-ordering.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Normal Ordering
+title: Normal ordering
 published: true
 sorting: 40
 tags: [manuals, language, syntax, concepts, ordering, depends_on]

--- a/reference/language-concepts/pattern-matching-and-referencing.markdown
+++ b/reference/language-concepts/pattern-matching-and-referencing.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Pattern Matching and Referencing
+title: Pattern matching and referencing
 published: true
 sorting: 80
 tags: [manuals, language, syntax, concepts, pattern, regexp, matching]

--- a/reference/language-concepts/promises.markdown
+++ b/reference/language-concepts/promises.markdown
@@ -23,7 +23,7 @@ the proper owner to serve web pages via Apache.
 This simple but powerful idea allows a very practical uniformity in CFEngine
 syntax.
 
-### Promise Types
+### Promise types
 
 The `promise_type` defines what kind of object is making the promise. The type
 dictates how CFEngine interprets the promise body. These promise types are
@@ -34,7 +34,7 @@ systems such as rpm and apt.
 Some promise types are common to all CFEngine components, while others can
 only be executed by one of them. `cf-serverd` cannot keep `packages` promises,
 and `cf-agent` cannot keep `access` promises. See the
-[Promise Type reference][Promise Types] for a comprehensive
+[Promise Type reference][Promise types] for a comprehensive
 list of promise types.
 
 ### The Promiser
@@ -99,7 +99,7 @@ Promise locks can be useful for controlling frequency.
 `access`, `classes`, `defaults`, `meta`, `roles` and `vars` type promises do not
 participate in locking.
 
-**See also:** [ifelapsed in body agent control][cf-agent#ifelapsed], [ifelapsed action body attribute][Promise Types#ifelapsed]
+**See also:** [ifelapsed in body agent control][cf-agent#ifelapsed], [ifelapsed action body attribute][Promise types#ifelapsed]
 
 ### Promise Attributes
 

--- a/reference/masterfiles-policy-framework/cfe_internal-enterprise-federation-federation.markdown
+++ b/reference/masterfiles-policy-framework/cfe_internal-enterprise-federation-federation.markdown
@@ -5,6 +5,6 @@ published: true
 tags: [reference, MPF, cfe_internal, federated reporting]
 ---
 
-This policy file handles Federated Reporting setup and ongoing operations.
+This policy file handles Federated reporting setup and ongoing operations.
 
 [%CFEngine_library_include(cfe_internal/enterprise/federation/federation)%]

--- a/reference/masterfiles-policy-framework/cfe_internal-enterprise-federation.markdown
+++ b/reference/masterfiles-policy-framework/cfe_internal-enterprise-federation.markdown
@@ -5,4 +5,4 @@ published: true
 tags: [reference, MPF, cfe_internal, federated reporting]
 ---
 
-This directory contains assets related to the function and configuration of [CFEngine Enterprise Federated Reporting][Federated Reporting].
+This directory contains assets related to the function and configuration of [CFEngine Enterprise Federated reporting][Federated reporting].

--- a/reference/masterfiles-policy-framework/lib-common.markdown
+++ b/reference/masterfiles-policy-framework/lib-common.markdown
@@ -6,7 +6,7 @@ tags: [reference, standard library, common, MPF]
 ---
 
 See
-the [common promise attributes][Promise Types#Common Promise Attributes]
+the [common promise attributes][Promise types#Common Promise Attributes]
 documentation for a comprehensive reference on the body types and attributes
 used here.
 

--- a/reference/promise-types.markdown
+++ b/reference/promise-types.markdown
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Promise Types
+title: Promise types
 published: true
 sorting: 20
 tags: [reference, bundles, common, promises]
 ---
 
 Within a bundle, the promise types are executed in a round-robin fashion in the
-following [normal ordering][Normal Ordering]. Which promise types are available
+following [normal ordering][Normal ordering]. Which promise types are available
 depends on the [bundle][bundles] type:
 
 | Promise Type   | common | agent | server | monitor |
@@ -903,7 +903,7 @@ body classes example
 }
 ```
 
-**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise Types#persist_time]
+**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time]
 
 #### timer_policy
 
@@ -1103,7 +1103,7 @@ skip.
 
 ### ifvarclass
 
-**Description:** Deprecated, use [`if`][Promise Types#if] instead.
+**Description:** Deprecated, use [`if`][Promise types#if] instead.
 
 **History:** New name `if` was introduced in 3.7.0, `ifvarclass` deprecated in 3.17.0.
 

--- a/reference/promise-types/access.markdown
+++ b/reference/promise-types/access.markdown
@@ -445,7 +445,7 @@ Here are the built-in `report_data_select` bodies `default_data_select_host()` a
 
 [%CFEngine_include_snippet(controls/reports.cf, .+default_data_select_policy_hub, \})%]
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 **History:**
 

--- a/reference/promise-types/classes.markdown
+++ b/reference/promise-types/classes.markdown
@@ -308,7 +308,7 @@ classes:
 
 **History:** Was introduced in CFEngine 3.3.0
 
-**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise Types#persist_time]
+**See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time]
 
 ### not
 
@@ -365,7 +365,7 @@ classes:
       scope => "bundle";
 ```
 
-**See also:** [`scope` in `body classes`][Promise Types#scope]
+**See also:** [`scope` in `body classes`][Promise types#scope]
 
 ### select_class
 

--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -183,7 +183,7 @@ exec_timeout => "60";
 }
 ```
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### useshell
 
@@ -324,7 +324,7 @@ exec_timeout => "30";
 }
 ```
 
-**See also:** [`body action expireafter`][Promise Types#expireafter],  [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
+**See also:** [`body action expireafter`][Promise types#expireafter],  [`body agent control expireafter`][cf-agent#expireafter], [`body executor control agent_expireafter`][cf-execd#agent_expireafter]
 
 #### chdir
 
@@ -451,7 +451,7 @@ This attribute determines whether or not to expect the CFEngine module protocol.
   * `^meta=a,b,c` sets the class and variable tags for any following definitions to `a`, `b`, and `c`
   * `^persistence=10` sets any following classes to persist for 10 minutes (use 0 to reset)
   * `^persistence=0` sets any following classes to have no persistence (this is the default)
-* lines which begin with a `+` are treated as classes to be defined (like -D). **NOTE:** classes are defined with the [`namespace` scope][Classes and Decisions].
+* lines which begin with a `+` are treated as classes to be defined (like -D). **NOTE:** classes are defined with the [`namespace` scope][Classes and decisions].
 * lines which begin with a `-` are treated as classes to be undefined (like -N)
 * lines which begin with `=` are scalar variables to be defined
 * lines which begin with `=` and include `[]` are array variables to be defined

--- a/reference/promise-types/custom.markdown
+++ b/reference/promise-types/custom.markdown
@@ -16,8 +16,8 @@ This documentation article provides a complete and detailed specification.
 It includes how to use them, how to implement them using modules, how the protocol works, etc.
 If you are interested in shorter tutorials, there are a few different ones available:
 
-* [Introducing CFEngine Custom Promise Types - Installation and usage](https://cfengine.com/blog/2020/introducing-cfengine-custom-promise-types/)
-* [How to implement CFEngine Custom Promise Types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
+* [Introducing CFEngine Custom Promise types - Installation and usage](https://cfengine.com/blog/2020/introducing-cfengine-custom-promise-types/)
+* [How to implement CFEngine Custom Promise types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
 * [How to implement CFEngine custom promise types in bash](https://cfengine.com/blog/2021/how-to-implement-cfengine-custom-promise-types-in-bash/)
 * [Custom Promise outcomes in Mission Portal](https://cfengine.com/blog/2021/custom-promise-outcomes-in-mission-portal/)
 
@@ -99,7 +99,7 @@ Due to the implementation details, the following attributes from the `classes` b
 ### Evaluation passes and normal order
 
 In CFEngine, each bundle is evaluated in multiple passes (3 main passes for most promise types).
-Within each evaluation pass of a bundle, the promises are not evaluated from top to bottom, but based on a [normal order][Normal Ordering] of the promise types.
+Within each evaluation pass of a bundle, the promises are not evaluated from top to bottom, but based on a [normal order][Normal ordering] of the promise types.
 Custom promise types are added dynamically and don't have a predefined order, they are evaluated as they appear within a bundle (top to bottom), but at the end of each evaluation pass, after all the built in promise types.
 As with other promise types, we recommend not relying too much on this ordering, if you want some promises to be evaluated before others, use the `bundlesequence` or `depends_on` attribute to achieve this.
 
@@ -539,7 +539,7 @@ This enables the agent to filter the log messages based on log level, and also p
 
 See these tutorials / blog posts, for more examples or inspiration:
 
-* [Introducing CFEngine Custom Promise Types - Installation and usage](https://cfengine.com/blog/2020/introducing-cfengine-custom-promise-types/)
-* [How to implement CFEngine Custom Promise Types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
-* [How to implement CFEngine Custom Promise Types in Bash](https://cfengine.com/blog/2021/how-to-implement-cfengine-custom-promise-types-in-bash/)
+* [Introducing CFEngine Custom Promise types - Installation and usage](https://cfengine.com/blog/2020/introducing-cfengine-custom-promise-types/)
+* [How to implement CFEngine Custom Promise types in Python](https://cfengine.com/blog/2020/how-to-implement-cfengine-custom-promise-types-in-python/)
+* [How to implement CFEngine Custom Promise types in Bash](https://cfengine.com/blog/2021/how-to-implement-cfengine-custom-promise-types-in-bash/)
 * [Custom Promise outcomes in Mission Portal](https://cfengine.com/blog/2021/custom-promise-outcomes-in-mission-portal/)

--- a/reference/promise-types/databases.markdown
+++ b/reference/promise-types/databases.markdown
@@ -157,7 +157,7 @@ a hierarchy of depth 1.
 
 **Type:** `body database_server`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### db_server_owner
 

--- a/reference/promise-types/files.markdown
+++ b/reference/promise-types/files.markdown
@@ -323,7 +323,7 @@ alter such a socket. This is a known issue, documented in
 
 **Type:** `body acl`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 **History:**
 
@@ -649,7 +649,7 @@ specify_default_aces => {  "all:r" };
 
 **Type:** `body changes`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### hash
 
@@ -771,7 +771,7 @@ The copy_from body specifies the details for making remote copies.
 are re-used. Currently connection caching is done per pass in each bundle
 activation.
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### source
 
@@ -931,7 +931,7 @@ body copy_from example
 }
 ```
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes], [`default_repository` in ```body agent control```][cf-agent#default_repository], [`edit_backup` in ```body edit_defaults```][files#edit_backup]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes], [`default_repository` in ```body agent control```][cf-agent#default_repository], [`edit_backup` in ```body edit_defaults```][files#edit_backup]
 
 #### encrypt
 
@@ -1460,7 +1460,7 @@ if the `create` attribute is explicitly used.
 
 **Type:** `body delete`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### dirlinks
 
@@ -1539,7 +1539,7 @@ This should be used in combination with `file_select`.
 
 **Type:** `body depth_search`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### depth
 
@@ -1684,7 +1684,7 @@ body depth_search example
 
 **Type:** `body edit_defaults`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### edit_backup
 
@@ -2021,7 +2021,7 @@ bundle agent example
 
 **See also:** [template_method][files#template_method], `template_data`, `readjson()`, `parsejson()`,
 `readyaml()`, `parseyaml()`, `mergedata()`,
-`data`, [Customize Message of the Day][Customize Message of the Day]
+`data`, [Customize message of the day][Customize message of the day]
 
 ### edit_template_string
 
@@ -2042,7 +2042,7 @@ bundle agent example
 
 **See also:** [template_method][files#template_method], `template_data`, `readjson()`, `parsejson()`,
 `readyaml()`, `parseyaml()`, `mergedata()`,
-`data`, [Customize Message of the Day][Customize Message of the Day]
+`data`, [Customize message of the day][Customize message of the day]
 
 ### edit_xml
 
@@ -2052,7 +2052,7 @@ bundle agent example
 
 **Type:** `body file_select`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### leaf_name
 
@@ -2474,7 +2474,7 @@ fifo
 
 **Type:** `body link_from`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### copy_patterns
 
@@ -2754,7 +2754,7 @@ separator.
 
 **Type:** `body perms`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### bsdflags
 
@@ -2889,7 +2889,7 @@ This is ignored on Windows, as the permission model uses ACLs.
 
 **Type:** `body rename`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### disable
 

--- a/reference/promise-types/files/edit_line.markdown
+++ b/reference/promise-types/files/edit_line.markdown
@@ -190,7 +190,7 @@ Output:
 
 [%CFEngine_include_snippet(select_region.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### Scope and lifetime
 

--- a/reference/promise-types/files/edit_line/delete_lines.markdown
+++ b/reference/promise-types/files/edit_line/delete_lines.markdown
@@ -44,7 +44,7 @@ promise.
 
 **Type:** `body delete_select`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### delete_if_startwith_from_list
 

--- a/reference/promise-types/files/edit_line/field_edits.markdown
+++ b/reference/promise-types/files/edit_line/field_edits.markdown
@@ -115,7 +115,7 @@ body edit_field col(split, col, newval, method)
 }
 ```
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### allow_blank_fields
 

--- a/reference/promise-types/files/edit_line/insert_lines.markdown
+++ b/reference/promise-types/files/edit_line/insert_lines.markdown
@@ -204,7 +204,7 @@ Gimme three steps
 
 **Type:** `body insert_select`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### insert_if_startwith_from_list
 
@@ -360,7 +360,7 @@ insert_if_not_contains_from_list => { "find_me_1", "find_me_2" };
 
 **Type:** `body location`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes], [`location` bodies in the standard library](reference-masterfiles-policy-framework-lib-files.html#location-bodies), [`start` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#location-bodies), [`before(srt)` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#before), [`after(srt)` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#after)
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes], [`location` bodies in the standard library](reference-masterfiles-policy-framework-lib-files.html#location-bodies), [`start` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#location-bodies), [`before(srt)` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#before), [`after(srt)` location body in the standard library](reference-masterfiles-policy-framework-lib-files.html#after)
 
 #### before_after
 

--- a/reference/promise-types/files/edit_line/replace_patterns.markdown
+++ b/reference/promise-types/files/edit_line/replace_patterns.markdown
@@ -49,7 +49,7 @@ pattern will match.
 
 **Type:** `body replace_with`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### occurrences
 

--- a/reference/promise-types/guest_environments.markdown
+++ b/reference/promise-types/guest_environments.markdown
@@ -94,7 +94,7 @@ This attribute is required.
 
 **Type:** `body environment_interface`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### env_addresses
 
@@ -182,7 +182,7 @@ host2::
 
 **Type:** `body environment_resources`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### env_cpus
 

--- a/reference/promise-types/measurements.markdown
+++ b/reference/promise-types/measurements.markdown
@@ -105,7 +105,7 @@ cf-check dump /var/cfengine/state/cf_observations.lmdb
 
 By default in the [Masterfiles Policy Framework][Masterfiles Policy Framework], `cf-serverd` uses two variables, `def.default_data_select_host_monitoring_include` and `def.default_data_select_policy_hub_monitoring_include` to [configure which measurements will be included in enterprise reporting][mpf-configure-measurement-collection].
 
-On the hub side, reports are collected and measurements data is inserted into the [`MonitoringHG`][SQL Schema#Table: MonitoringYrMeta]  [`MonitoringMgMeta`][SQL Schema#Table: MonitoringMgMeta] and [`MonitoringYrMeta`][SQL Schema#Table: MonitoringYrMeta] tables of the Enterprise Hub database.
+On the hub side, reports are collected and measurements data is inserted into the [`MonitoringHG`][SQL schema#Table: MonitoringYrMeta]  [`MonitoringMgMeta`][SQL schema#Table: MonitoringMgMeta] and [`MonitoringYrMeta`][SQL schema#Table: MonitoringYrMeta] tables of the Enterprise Hub database.
 
 A diagnostic query to run with a [Custom Report in Mission Portal][Reporting UI].
 
@@ -292,7 +292,7 @@ This is an arbitrary string used in documentation only.
 
 **Type:** `body match_value`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### select_line_matching
 

--- a/reference/promise-types/packages-deprecated.markdown
+++ b/reference/promise-types/packages-deprecated.markdown
@@ -265,7 +265,7 @@ packages:
 
 **Type:** `body package_method`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### package_add_command
 
@@ -593,7 +593,7 @@ package_list_update_ifelapsed => "240";        # 4 hours
 
 #### package_list_update_ifelapsed
 
-**Description:** The [`ifelapsed`][Promise Types#ifelapsed]
+**Description:** The [`ifelapsed`][Promise types#ifelapsed]
 locking time in between updates of the package list
 
 **Type:** `int`

--- a/reference/promise-types/packages.markdown
+++ b/reference/promise-types/packages.markdown
@@ -17,7 +17,7 @@ does not currently cover. To read about the old package promise, go to the
 [old package promise section][packages (deprecated)].
 
 The actual communication with the package manager on the system is handled by so
-called [package modules][Package Modules], which are specifically written for
+called [package modules][Package modules], which are specifically written for
 each type of package manager.
 
 In this example, we want the software package "apache2" to be present on the
@@ -205,7 +205,7 @@ platform dependent, see
 and Common Control. The name of the body is expected to be the same as the name
 of the package module inside `/var/cfengine/modules/packages`.
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### default_options
 
@@ -252,11 +252,11 @@ body package_module apt_get
 ```
 
 **Note for `package_module` authors**:
-[`list-installed`][Package Modules#list-installed] will be called when the agent
+[`list-installed`][Package modules#list-installed] will be called when the agent
 repairs a package using the given `package_module`, when the lock has expired or
 when the agent is run without locks.
 
-**See also:** `Package Modules`
+**See also:** `Package modules`
 
 #### query_updates_ifelapsed
 
@@ -285,12 +285,12 @@ body package_module apt_get
 ```
 
 **Note for `package_module` authors**:
-[`list-updates`][Package Modules#list-updates] will be called when the lock has
+[`list-updates`][Package modules#list-updates] will be called when the lock has
 expired or when the agent is run without locks.
-[`list-updates-local`][Package Modules#list-updates-local] is called in all
+[`list-updates-local`][Package modules#list-updates-local] is called in all
 other conditions.
 
-**See also:** `Package Modules`
+**See also:** `Package modules`
 
 #### interpreter
 
@@ -315,7 +315,7 @@ body package_module apt_get
 }
 ```
 
-**See also:** `Package Modules`
+**See also:** `Package modules`
 
 **History:** Introduced in 3.13.0, 3.12.2
 
@@ -343,7 +343,7 @@ body package_module yum_all_repos
 }
 ```
 
-**See also:** `Package Modules`
+**See also:** `Package modules`
 
 **History:** Introduced in 3.13.0, 3.12.2
 

--- a/reference/promise-types/processes.markdown
+++ b/reference/promise-types/processes.markdown
@@ -99,7 +99,7 @@ commands:
 
 **Type:** `body process_count`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### in_range_define
 
@@ -168,7 +168,7 @@ out_of_range_define => { "process_anomaly", "anomaly_$(s)"};
 
 **Type:** `body process_select`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### command
 

--- a/reference/promise-types/reports.markdown
+++ b/reference/promise-types/reports.markdown
@@ -91,7 +91,7 @@ and has no effect. Deprecated in CFEngine 3.4.
 
 **Type:** `body printfile`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### file_to_print
 

--- a/reference/promise-types/services.markdown
+++ b/reference/promise-types/services.markdown
@@ -315,7 +315,7 @@ and `$(this.service_policy)` (the policy state the service should have).
 
 **Notes:** `service_bundle` is not used when `service_type` is ```windows```.
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### service_args
 

--- a/reference/promise-types/storage.markdown
+++ b/reference/promise-types/storage.markdown
@@ -56,7 +56,7 @@ body mount nfs(server,source)
 
 **Type:** `body mount`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### edit_fstab
 
@@ -180,7 +180,7 @@ unmount => "true";
 
 **Type:** `body volume`
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### check_foreign
 

--- a/reference/promise-types/users.markdown
+++ b/reference/promise-types/users.markdown
@@ -205,7 +205,7 @@ body password user_password
 }
 ```
 
-**See also:** [Common Body Attributes][Promise Types#Common Body Attributes]
+**See also:** [Common Body Attributes][Promise types#Common Body Attributes]
 
 #### format
 

--- a/reference/promise-types/vars.markdown
+++ b/reference/promise-types/vars.markdown
@@ -378,7 +378,7 @@ two_example_com::
     comment => "Define a global domain for hosts in the two.example.com domain";
 ```
 
-(Promises within the same bundle are evaluated top to bottom, so vars promises further down in a bundle can overwrite previous values of a variable. See [**normal ordering**][Normal Ordering] for more information).
+(Promises within the same bundle are evaluated top to bottom, so vars promises further down in a bundle can overwrite previous values of a variable. See [**normal ordering**][Normal ordering] for more information).
 
 ## Defining variables in foreign bundles
 

--- a/reference/special-variables.markdown
+++ b/reference/special-variables.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Special Variables
+title: Special variables
 published: true
 sorting: 50
 tags: [reference, variables]

--- a/reference/special-variables/this.markdown
+++ b/reference/special-variables/this.markdown
@@ -74,8 +74,8 @@ attributes:
 * `edit_template`
 * [`source`][files#source] in `copy_from`
 * `exec_program` in `file_select`
-* class names in [`body classes`][Promise Types#classes]
-* logging attributes in [`body action`][Promise Types#action]
+* class names in [`body classes`][Promise types#classes]
+* logging attributes in [`body action`][Promise types#action]
 * promised service name in `service_method`
 
 For example:

--- a/release-notes.markdown
+++ b/release-notes.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Release Notes
+title: Release notes
 published: true
 sorting: 30
 tags: [overviews, releases, latest release, platforms, versions]
@@ -9,8 +9,8 @@ tags: [overviews, releases, latest release, platforms, versions]
 * [New in CFEngine][New in CFEngine]
   Learn about the newest features in CFEngine {{site.cfengine.branch}}
 
-* [Supported Platforms and Versions][Supported Platforms and Versions]
+* [Supported platforms and versions][Supported platforms and versions]
   These are the supported platforms for the current release.
 
-* [Known Issues][Known Issues]
+* [Known issues][Known issues]
   View any issues of which we are currently aware and investigating. View possible workarounds.

--- a/release-notes/known-issues.markdown
+++ b/release-notes/known-issues.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Known Issues
+title: Known issues
 sorting: 50
 published: true
 tags: [overviews, releases, latest release, platforms, versions, known issues]
@@ -77,7 +77,7 @@ ERROR - 2016-06-15 07:24:15 --> Severity: Warning --> readfile(https://myhostnam
 
 The solution is to generate a new certificate with the correct CN,
 i.e. the one you use to access the CFEngine Server. To see how to do
-this, look at the documentation for using a [Custom SSL certificate][Custom SSL Certificate].
+this, look at the documentation for using a [Custom SSL certificate][Custom SSL certificate].
 
 ### Enterprise software inventory is not out-of-the-box
 

--- a/release-notes/supported-platforms.markdown
+++ b/release-notes/supported-platforms.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Supported Platforms and Versions
+title: Supported platforms and versions
 sorting: 20
 published: true
 tags: [overviews, releases, latest release, platforms, versions, support]
@@ -11,7 +11,7 @@ provide support for the platforms most frequently used by our users. CFEngine
 provides [binary packages of the Enterprise edition][enterprise software download page]
 for all supported platforms and [binary packages for popular Linux distributions for the Community edition][community download page].
 
-## Enterprise Server ##
+## Enterprise server ##
 
 | Platform    | Versions                   | Architecture |
 |:-----------:|:--------------------------:|:------------:|
@@ -39,7 +39,7 @@ Any supported host can be a policy server in Community installations of CFEngine
 | Windows     | 2012, 2016, 2019          | x86-64, x86   |
 
 
-[Known Issues][] also includes platform-specific notes.
+[Known issues][] also includes platform-specific notes.
 
 
 CFEngine Enterprise has [Virtual I/O Server (VIOS) Recognized status](http://www.ibm.com/partnerworld/gsd/solutiondetails.do?solution=48493) from IBM.

--- a/release-notes/whatsnew.markdown
+++ b/release-notes/whatsnew.markdown
@@ -8,6 +8,6 @@ tags: [what's new]
 
 See what's new in this release.
 
-* [Core Changelog][Changelog]
-* [Enterprise Changelog][Enterprise Changelog]
-* [Masterfiles Changelog][Masterfiles Changelog]
+* [Core changelog][Changelog]
+* [Enterprise changelog][Enterprise changelog]
+* [Masterfiles changelog][Masterfiles changelog]

--- a/release-notes/whatsnew/changelog-core.markdown
+++ b/release-notes/whatsnew/changelog-core.markdown
@@ -6,7 +6,7 @@ sorting: 10
 tags: [what's new]
 ---
 
-**See also:** [Enterprise Changelog][Enterprise Changelog], [Masterfiles Changelog][Masterfiles Changelog]
+**See also:** [Enterprise changelog][Enterprise changelog], [Masterfiles changelog][Masterfiles changelog]
 
 <pre>
 {% raw %}

--- a/release-notes/whatsnew/changelog-enterprise.markdown
+++ b/release-notes/whatsnew/changelog-enterprise.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Enterprise ChangeLog
+title: Enterprise changelog
 published: true
 sorting: 30
 tags: [what's new, enterprise]
 ---
 
-**See also:** [Core Changelog][Changelog], [Masterfiles Changelog][Masterfiles Changelog]
+**See also:** [Core changelog][Changelog], [Masterfiles changelog][Masterfiles changelog]
 
 <pre>
 {% raw %}

--- a/release-notes/whatsnew/changelog-masterfiles-policy-framework.markdown
+++ b/release-notes/whatsnew/changelog-masterfiles-policy-framework.markdown
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Masterfiles ChangeLog
+title: Masterfiles changelog
 published: true
 sorting: 20
 tags: [what's new, MPF, masterfiles]
 ---
 
-**See also:** [Core Changelog][Changelog], [Enterprise Changelog][Enterprise Changelog]
+**See also:** [Core changelog][Changelog], [Enterprise changelog][Enterprise changelog]
 
 <pre>
 {% raw %}

--- a/resources/best-practices.markdown
+++ b/resources/best-practices.markdown
@@ -1,16 +1,16 @@
 ---
 layout: default
-title: Best Practices
+title: Best practices
 sorting: 100
 published: true
 tags: [cfengine enterprise, best practices, user interface, mission portal]
 ---
 
-## Policy Style Guide ##
+## Policy style guide ##
 
-When writing CFEngine policy using our [Policy Style Guide][Policy Style Guide] helps make your policy easily understood, debuggable and maintainable.
+When writing CFEngine policy using our [Policy style guide][Policy style guide] helps make your policy easily understood, debuggable and maintainable.
 
-## Version Control and Configuration Policy ##
+## Version control and Configuration Policy ##
 
 CFEngine users version their policies.  It's a reasonable, easy thing
 to do: you just put `/var/cfengine/masterfiles` under version control
@@ -54,7 +54,7 @@ infrastructure.
 
 ### How to enable it ###
 
-Follow detailed instructions in the [Policy Deployment][Policy Deployment] guide.
+Follow detailed instructions in the [Policy deployment][Policy deployment] guide.
 
 ## Scalability ##
 

--- a/resources/faq/bootstrap-failed.markdown
+++ b/resources/faq/bootstrap-failed.markdown
@@ -140,7 +140,7 @@ See also: [`def.acl`][Masterfiles Policy Framework#acl], [`def.trustkeysfrom`][M
 
 ### `trustkeysfrom` in `body server control`
 
-This defines networks from which a host will automatically trust hosts. If you do not use automatic trust establishment you must arrange trust separately. The [Secure Bootstrap guide][Secure Bootstrap] details a step-by-step procedure to securely bootstrap hosts.
+This defines networks from which a host will automatically trust hosts. If you do not use automatic trust establishment you must arrange trust separately. The [Secure bootstrap guide][Secure bootstrap] details a step-by-step procedure to securely bootstrap hosts.
 
 `cf-serverd` logs verbose and notice messages relating to un-trusted clients trying to connect:
 

--- a/resources/faq/enterprise-report-collection.markdown
+++ b/resources/faq/enterprise-report-collection.markdown
@@ -113,7 +113,7 @@ $ curl -s -u admin:admin http://hub/api/query -X POST -d @agent_execution_time_i
 ]
 ```
 
-**See also:** `Enterprise API Reference`, `Enterprise API Examples`
+**See also:** `Enterprise API reference`, `Enterprise API examples`
 
 ## How are hosts not reporting determined?
 
@@ -134,7 +134,7 @@ Note: It's called "blueHostHorizon" because older versions of Mission Portal
 would turn these hosts to a blue color as an indication of "hypoxia" (lack
 of oxygen, where oxygen is access to latest policy) to indicate a health issue.
 
-**See also:** `Enterprise API Reference`, `Enterprise API Examples`, [Enterprise Settings][Settings#preferences]
+**See also:** `Enterprise API reference`, `Enterprise API examples`, [Enterprise Settings][Settings#preferences]
 
 ## Which hosts are pending trust revocation?
 

--- a/resources/faq/enterprise.markdown
+++ b/resources/faq/enterprise.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Enterprise Reporting database
+title: Enterprise reporting database
 published: true
 sorting: 90
 tags: [getting started, installation, faq]
@@ -28,8 +28,8 @@ The database runs under the `cfpostgres` user.
 
 ### General Information
 
-* [Pre-Installation Checklist][Pre-Installation Checklist]
-* [Supported Platforms and Versions][Supported Platforms and Versions]
+* [Pre-installation checklist][Pre-installation checklist]
+* [Supported platforms and versions][Supported platforms and versions]
 
 ### Users and Permissions
 
@@ -38,7 +38,7 @@ The database runs under the `cfpostgres` user.
 
 ## How does Enterprise Scale?
 
-See best practices on [scalability][Best Practices#Scalability]
+See best practices on [scalability][Best practices#Scalability]
 
 ## Is it normal to have many cf-hub processes running?
 
@@ -47,7 +47,7 @@ See best practices on [scalability][Best Practices#Scalability]
 ## What steps should I take after installing CFEngine Enterprise?
 
 There are general steps to be taken outlined in
-[Post-Installation Configuration][General Installation#Post-Installation Configuration].
+[Post-Installation Configuration][General installation#Post-Installation Configuration].
 
 In addition to this, Enterprise uses the local mail relay, and it is assumed
 that the server where CFEngine Enterprise is installed on has proper mail setup.

--- a/resources/faq/manual-execution.markdown
+++ b/resources/faq/manual-execution.markdown
@@ -103,4 +103,4 @@ This command will run `cf-agent` with the additional class `patch_and_reboot` on
 classes it is using must be resolvable during pre-evaluation as the full
 evaluation is only allowed when the classes are found to be defined.
 
-**See also:** [How is "recently seen" determined][Components#lastseenexpireafter], [`cf-runagent`][cf-runagent], [pre-evaluation][Normal Ordering#agent pre-evaluation step]
+**See also:** [How is "recently seen" determined][Components#lastseenexpireafter], [`cf-runagent`][cf-runagent], [pre-evaluation][Normal ordering#agent pre-evaluation step]

--- a/resources/faq/what-did-cfengine-change.markdown
+++ b/resources/faq/what-did-cfengine-change.markdown
@@ -135,7 +135,7 @@ verbose: Outcome of version (not specified) (agent-0): Promises observed - Total
 
 ### Promise logging
 
-Promises can be configured to [log their outcomes][Promise Types#log_repaired]
+Promises can be configured to [log their outcomes][Promise types#log_repaired]
 to a file with `log_kept`, `log_repaired`, and `log_failed` attributes in an action body.
 
 ```cf3
@@ -261,7 +261,7 @@ GROUP BY namespace, bundlename, promisetype,promisehandle,promiser
 ORDER BY count DESC
 ```
 
-Reference: [query api examples][SQL Query Examples]
+Reference: [query api examples][SQL query examples]
 
 ### promise_log.jsonl
 

--- a/web-ui.markdown
+++ b/web-ui.markdown
@@ -54,7 +54,7 @@ underlying issue to avoid unnecessary triggering and notifications.
 Alerts can have three different states: OK, triggered, and paused. It is easy to
 filter by state on each widget's alert overview.
 
-Find out more: [Alerts and Notifications][]
+Find out more: [Alerts and notifications][]
 
 ### Changes widget
 
@@ -136,7 +136,7 @@ regularly.
 
 Find out more: [Reporting][Reporting UI]
 
-Follow along in the [custom inventory tutorial][Custom Inventory] or read the
+Follow along in the [custom inventory tutorial][Custom inventory] or read the
 [MPF policy that provides inventory][inventory/].
 
 ## Sharing

--- a/web-ui/alerts-and-notifications.markdown
+++ b/web-ui/alerts-and-notifications.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Alerts and Notifications
+title: Alerts and notifications
 sorting: 40
 published: true
 tags: [cfengine enterprise, user interface, mission portal]

--- a/web-ui/custom-actions-for-alerts.markdown
+++ b/web-ui/custom-actions-for-alerts.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Custom actions for Alerts
+title: Custom actions for alerts
 sorting: 50
 published: true
 tags: [cfengine enterprise, user interface, mission portal]

--- a/web-ui/enterprise-reporting.markdown
+++ b/web-ui/enterprise-reporting.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Enterprise Reporting
+title: Enterprise reporting
 sorting: 50
 published: true
 tags: [cfengine enterprise, user interface, mission portal]
@@ -10,7 +10,7 @@ CFEngine Enterprise can report on promise outcomes (changes made by `cf-agent`
 across your infrastructure), variables, classes, and measurements taken by
 `cf-monitord`. Reports cover fine grained policy details, explore all the
 options by checking out the [custom reports section][Reporting UI#query builder]
-of the Enterprise Reporting module.
+of the Enterprise reporting module.
 
 Specifically which information allowed to be collected by the hub for reporting
 is configured by [`report_data_select` bodies][access#report_data_select].
@@ -39,7 +39,7 @@ Framework). The MPF includes ```inventory``` and ```report``` in
 
 If it's desirable for the classes and variables to be available in specialized
 inventory subsystem then it should be tagged with `inventory` and given an
-additional `attribute_name=` tag as described in the [custom inventory example][Custom Inventory].
+additional `attribute_name=` tag as described in the [custom inventory example][Custom inventory].
 
 ```cf-hub``` collects information resulting from all other promise types (except
 `reports`, and `defaults` which cf-hub does not collect for). This can be

--- a/web-ui/enterprise-reporting/client-initiated-reporting.markdown
+++ b/web-ui/enterprise-reporting/client-initiated-reporting.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Client Initiated Reporting / Call collect
+title: Client initiated reporting / call collect
 sorting: 60
 published: true
 tags: [cfengine enterprise, reporting, call collect]

--- a/web-ui/enterprise-reporting/reporting-architecture.markdown
+++ b/web-ui/enterprise-reporting/reporting-architecture.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Reporting Architecture
+title: Reporting architecture
 published: true
 sorting: 10
 tags: [manuals, enterprise, reporting, architecture, cf-hub]

--- a/web-ui/enterprise-reporting/reporting_ui.markdown
+++ b/web-ui/enterprise-reporting/reporting_ui.markdown
@@ -31,8 +31,8 @@ You can also filter on the type of promise: user defined, system defined, or all
 
 See also:
 
-* [Reporting Architecture][Reporting Architecture]
-* [SQL Queries Using the Enterprise API][SQL Queries Using the Enterprise API]
+* [Reporting architecture][Reporting architecture]
+* [SQL queries using the Enterprise API][SQL queries using the Enterprise API]
 
 ## Query Builder ##
 
@@ -70,7 +70,7 @@ the following defines the attribute `Role` which is set to
 	}
 	```
 
-* note the [`meta`][Promise Types#meta] tag `inventory`
+* note the [`meta`][Promise types#meta] tag `inventory`
 
 * The hub must be able to collect the reports from the client. TCP
 port 5308 must be open and, because 3.6 uses TLS, should not be

--- a/web-ui/enterprise-reporting/sql-queries-enterprise-api.markdown
+++ b/web-ui/enterprise-reporting/sql-queries-enterprise-api.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: SQL Queries Using the Enterprise API
+title: SQL queries using the Enterprise API
 published: true
 sorting: 20
 tags: [manuals, enterprise, reporting]
@@ -9,7 +9,7 @@ tags: [manuals, enterprise, reporting]
 The CFEngine Enterprise Hub collects information about the
 environment in a centralized database. Data is collected every 5
 minutes from all bootstrapped hosts. This data can be accessed through
-the Enterprise Reporting API.
+the Enterprise reporting API.
 
 Through the API, you can run CFEngine Enterprise reports with SQL
 queries. The API can create the following report queries:

--- a/web-ui/federated-reporting.markdown
+++ b/web-ui/federated-reporting.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Federated Reporting
+title: Federated reporting
 published: true
 sorting: 60
 tags: [enterprise, guide, federated reporting]
@@ -8,10 +8,10 @@ tags: [enterprise, guide, federated reporting]
 
 ## Overview ##
 
-Federated Reporting enables the collection of data from multiple Hubs to provide
+Federated reporting enables the collection of data from multiple Hubs to provide
 a view in Mission Portal which can scale up beyond the capabilities of a Hub
 which manages hosts. CFEngine supports a large number of hosts per hub, around
-5,000 hosts per hub depending on many factors. With Federated Reporting it is
+5,000 hosts per hub depending on many factors. With Federated reporting it is
 possible to scale up to 100,000 hosts or more for the purposes of analysis and
 reporting.
 
@@ -24,16 +24,16 @@ configure and connect the Superhub and Feeder hubs. For Feeder hubs with an
 earlier version than 3.14.0 some manual steps must be taken. Links to these
 are provided at each stage of installation and setup that follows.
 
-* [Requirements][Federated Reporting#Requirements]
-* [Installation][Federated Reporting#Installation]
-* [Setup][Federated Reporting#Setup]
-* [Operation][Federated Reporting#Operation]
-* [Duplicate Host Management][Federated Reporting#Duplicate Host Management]
-* [Troubleshooting][Federated Reporting#Troubleshooting]
-* [API Setup][Federated Reporting#API Setup]
-* [Disable Feeder][Federated Reporting#Disable Feeder]
-* [Uninstall][Federated Reporting#Uninstall]
-* [Superhub Upgrade][Federated Reporting#Superhub Upgrade]
+* [Requirements][Federated reporting#Requirements]
+* [Installation][Federated reporting#Installation]
+* [Setup][Federated reporting#Setup]
+* [Operation][Federated reporting#Operation]
+* [Duplicate Host Management][Federated reporting#Duplicate Host Management]
+* [Troubleshooting][Federated reporting#Troubleshooting]
+* [API Setup][Federated reporting#API Setup]
+* [Disable Feeder][Federated reporting#Disable Feeder]
+* [Uninstall][Federated reporting#Uninstall]
+* [Superhub Upgrade][Federated reporting#Superhub Upgrade]
 
 ## Requirements ##
 
@@ -46,7 +46,7 @@ is untested and unsupported.
 ### Software Requirements ###
 
 If your hub will have SELinux enabled, the `semanage` command must be installed.
-This allows Federated Reporting policy to manage the trust between the superhub and
+This allows Federated reporting policy to manage the trust between the superhub and
 feeder hubs.
 
 Add the `cfengine_mp_fr_dependencies_auto_install` to your augments file to allow
@@ -74,7 +74,7 @@ to HW requirements for the Superhub are:
 * The amount of data gathered on the Feeders from the reports sent by the
   hosts bootstrapped to them.
 
-The current implementation of Federated Reporting is not aggregating monitoring
+The current implementation of Federated reporting is not aggregating monitoring
 data on the Superhub which saves a lot of network traffic, processing power and
 disk space on the Superhub.
 
@@ -105,7 +105,7 @@ and 5000 hosts per connected Feeder is:
   * 135 KiB of network data transfer per host per one pull of the data from
     Feeders.
 
-The Federated Reporting process is logging information to the system log and so
+The Federated reporting process is logging information to the system log and so
 timestamps from the log messages can be used to determine how long each round of
 the pull-import process has taken. If it is close to the configured refresh
 interval, the interval needs to be made longer or the hardware configuration of
@@ -118,7 +118,7 @@ connecting more Feeders.
 
 ## Installation ##
 
-The [General Installation][General Installation] instructions should be used to
+The [General installation][General installation] instructions should be used to
 install CFEngine Hub on a Superhub as well as Feeder hubs.
 
 ## Setup ##
@@ -134,9 +134,9 @@ by clicking the `On` radio button for Hub management in the Status column.
 
 Note: for pre 3.14 feeders this step is not performed.
 
-### Enable Federated Reporting ###
+### Enable Federated reporting ###
 
-<img src="fr-hub-management-default.png" alt="Enable Federated Reporting" width="700px">
+<img src="fr-hub-management-default.png" alt="Enable Federated reporting" width="700px">
 
 The Hub management app should now appear in the bottom left corner of mission
 portal.
@@ -146,16 +146,16 @@ cause some configuration to be written in the filesystem and on next agent run
 policy will make the needed changes. You can speed up this process by running
 the agent manually.
 
-Note: for pre 3.14 feeders, you must [Enable feeder without API][Federated Reporting#Enable feeder without API].
+Note: for pre 3.14 feeders, you must [Enable feeder without API][Federated reporting#Enable feeder without API].
 
 ### Connect Feeder Hubs ###
 
 <img src="fr-superhub-enabled-no-feeders.png" alt="Connect Feeder Hubs" width="700px">
 
-Refresh the Hub management on each hub to see that Federated Reporting is
+Refresh the Hub management on each hub to see that Federated reporting is
 enabled.
 
-After all hubs have Federated Reporting enabled visit Hub management on the
+After all hubs have Federated reporting enabled visit Hub management on the
 Superhub to connect the Feeder hubs.
 
 On the Superhub, click on the Connect hub button to show the Connect a hub dialog.
@@ -275,16 +275,16 @@ This class only has an effect on the superhub host.
 Please refer to `/var/cfengine/output`, `/var/log/postgresql.log` and
 `/opt/cfengine/federation/superhub/import/*.log.gz` when problems occur. Sending
 these logs to us in bug reports will help significantly as we fine tune the
-Federated Reporting feature.
+Federated reporting feature.
 
-Also see [Disable Feeder][Federated Reporting#Disable Feeder] for information
-about how to temporarily disable a feeder's participation in Federated Reporting
+Also see [Disable Feeder][Federated reporting#Disable Feeder] for information
+about how to temporarily disable a feeder's participation in Federated reporting
 in case that is causing an issue for the Feeder Hub.
 
 ## API Setup ##
 
 An API may be used instead of the UI. This could be used to automate the setup
-of infrastructure related to Federated Reporting and Feeder hubs.
+of infrastructure related to Federated reporting and Feeder hubs.
 
 Command line examples follow using [curl](https://curl.haxx.se/) and
 [cf-remote](https://github.com/cfengine/cf-remote).
@@ -455,7 +455,7 @@ $ curl -k -i -s -X POST -u admin:$PASSWORD https://$FEEDER/api/fr/federation-con
 (The second API call is needed to save the updated config to file,
 `federation-config.json`).
 
-Note: for pre 3.14 feeders, you must [Add superhub to feeder without API][Federated Reporting#Add superhub to feeder without API]
+Note: for pre 3.14 feeders, you must [Add superhub to feeder without API][Federated reporting#Add superhub to feeder without API]
 
 #### Add superhub to feeder without API
 
@@ -578,7 +578,7 @@ $ cf-remote sudo -H $CLOUD_USER$SUPERHUB,$CLOUD_USER$FEEDER "/var/cfengine/bin/c
 <img src="fr-edit-hub-disable.png" alt="Edit Hub Disable" width="420px">
 
 A Feeder Hub may be disabled from the Hub Management app so that it will no
-longer participate in Federated Reporting. No further attempts to pull data from
+longer participate in Federated reporting. No further attempts to pull data from
 that feeder will occur until it is enabled again.
 
 Click the edit button for the feeder, enter URL and credentials information as
@@ -591,9 +591,9 @@ The list of connected hubs should now reflect the disabled state.
 
 ## Uninstall
 
-Uninstalling Federated Reporting from a superhub is not possible at this time.
+Uninstalling Federated reporting from a superhub is not possible at this time.
 
-In order to remove Federated Reporting from a feeder you must set the `target_state`
+In order to remove Federated reporting from a feeder you must set the `target_state`
 to `off`. On the next agent run the `cftransport` user will be removed, thus removing
 the trust established with the superhub and causing no further dump/import procedures
 to occur.
@@ -771,7 +771,7 @@ For versions 3.15.5, and 3.18.1 and older the superhub can not be directly upgra
 Typically the superhub doesn't have unique information or serve policy.
 This makes it reasonable and easy to upgrade the superhub with a fresh install.
 If there are unique items like custom reports, dashboards, alerts or conditions on the superhub which need to be preserved
-you may use the [Import & Export API] or Mission Portal Settings UI to export and then import after upgrading.
+you may use the [Import & export API] or Mission Portal Settings UI to export and then import after upgrading.
 
 Follow this procedure:
 
@@ -832,10 +832,10 @@ Follow this procedure:
       ```console
       # /var/cfengine/bin/psql cfsettings -c 'TRUNCATE remote_hubs'
       ```
-* Reinstall and configure the superhub as described in [Installation][Federated Reporting#Installation]
-* Import any saved information into Mission Portal via the [Import & Export API] or Mission Portal Settings UI
+* Reinstall and configure the superhub as described in [Installation][Federated reporting#Installation]
+* Import any saved information into Mission Portal via the [Import & export API] or Mission Portal Settings UI
 * Wait 20 minutes for federated reporting to be updated from feeders to superhub
 
   or
 
-  * run `cf-agent -KI` on each feeder, and then `cf-agent -KI` on the superhub to manually force a Federated Reporting collection cycle.
+  * run `cf-agent -KI` on each feeder, and then `cf-agent -KI` on the superhub to manually force a Federated reporting collection cycle.

--- a/web-ui/hub_administration.markdown
+++ b/web-ui/hub_administration.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Hub Administration
+title: Hub administration
 published: true
 sorting: 80
 tags: [cfengine enterprise, hub administration]
@@ -8,4 +8,4 @@ tags: [cfengine enterprise, hub administration]
 
 Find out how to perform common hub administration tasks like
 [resetting admin credentials][Reset administrative credentials], or
-[using custom SSL certificates][Custom SSL Certificate].
+[using custom SSL certificates][Custom SSL certificate].

--- a/web-ui/hub_administration/adjusting-schedules.markdown
+++ b/web-ui/hub_administration/adjusting-schedules.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Adjusting Schedules
+title: Adjusting schedules
 published: true
 tags: [cfengine enterprise, hub administration, scheduling, cf-execd, cf-agent, cf-hub]
 ---

--- a/web-ui/hub_administration/backup-and-restore.markdown
+++ b/web-ui/hub_administration/backup-and-restore.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Backup and Restore
+title: Backup and restore
 published: true
 tags: [cfengine enterprise, hub administration, backup, restore]
 ---

--- a/web-ui/hub_administration/custom-https-certificate.markdown
+++ b/web-ui/hub_administration/custom-https-certificate.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Custom SSL Certificate
+title: Custom SSL certificate
 published: true
 tags: [cfengine enterprise, hub administration, SSL]
 ---

--- a/web-ui/hub_administration/custom-ldap-port.markdown
+++ b/web-ui/hub_administration/custom-ldap-port.markdown
@@ -13,7 +13,7 @@ encryption. This controls the encryption and the port to connect to.
 If you want to configure LDAP authentication to use a custom port you can do so
 via the Status and Setting REST API.
 
-Status and Settings REST API
+Status and settings REST API
 This example shows using jq to preserve the existing settings and update the
 SSL LDAP port to `3269`.
 

--- a/web-ui/hub_administration/custom-ldaps-certificate.markdown
+++ b/web-ui/hub_administration/custom-ldaps-certificate.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Custom LDAPs Certificate
+title: Custom LDAPs certificate
 published: true
 tags: [cfengine enterprise, hub administration, LDAP, authentication]
 ---

--- a/web-ui/hub_administration/extending-query-builder.markdown
+++ b/web-ui/hub_administration/extending-query-builder.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Extending Query Builder in Mission Portal
+title: Extending query builder in Mission Portal
 published: true
 sorting: 90
 tags: [faq, mission portal, hub administration, query builder]

--- a/web-ui/hub_administration/lookup-license-info.markdown
+++ b/web-ui/hub_administration/lookup-license-info.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Lookup License Info
+title: Lookup license info
 published: true
 tags: [cfengine enterprise, hub administration, license]
 ---

--- a/web-ui/hub_administration/policy-deployment.markdown
+++ b/web-ui/hub_administration/policy-deployment.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Policy Deployment
+title: Policy deployment
 published: true
 tags: [cfengine enterprise, hub administration]
 ---

--- a/web-ui/hub_administration/regenerate-self-signed-cert.markdown
+++ b/web-ui/hub_administration/regenerate-self-signed-cert.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Regenerate Self Signed SSL Certificate
+title: Regenerate self signed SSL certificate
 published: true
 tags: [cfengine enterprise, hub administration, SSL]
 ---

--- a/web-ui/hub_administration/reinstall.markdown
+++ b/web-ui/hub_administration/reinstall.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Re-installing Enterprise Hub
+title: Re-installing Enterprise hub
 published: true
 tags: [cfengine enterprise, hub administration, re-install]
 ---

--- a/web-ui/settings.markdown
+++ b/web-ui/settings.markdown
@@ -14,7 +14,7 @@ Settings view.
 * [User Management][Settings#User Management]
 * [Role Management][Settings#Role Management]
 * [Manage Apps][Settings#Manage Apps]
-* [Version Control Repository][Settings#Version Control Repository]
+* [Version control Repository][Settings#Version control Repository]
 * [Host Identifier][Settings#Host Identifier]
 * [Mail Settings][Settings#Mail settings]
 * [Authentication settings][Settings#Authentication settings]
@@ -150,12 +150,12 @@ Application settings can help adjust some of CFEngine Enterprise UI
 app features, including the order in which the apps appear and their
 status (on or off).
 
-## Version Control Repository ##
+## Version control Repository ##
 
-<img src="settings-vcs.png" alt="Version Control Repository" width="700px">
+<img src="settings-vcs.png" alt="Version control Repository" width="700px">
 
 The repository holding the organization's masterfiles can be adjusted
-on the Version Control Repository screen.
+on the Version control Repository screen.
 
 ## Host Identifier ##
 
@@ -222,7 +222,7 @@ Mission Portal's configuration can be exported and imported.
 
 <img src="settings-export-import-3.18.0.png" alt="Export/Import" width="590px">
 
-**See also:** [Export/Import API][Import & Export API]
+**See also:** [Export/Import API][Import & export API]
 
 ## Role based access control ##
 


### PR DESCRIPTION
This was inconsistent before, so I am trying to make it consistent.

Our preferred style is sentence case, so I am moving towards using
using that everywhere.

This commit only touches titles (not sub-headings within documents).
