### PR TITLE
ENT-10203: Clarified how TLS settings impact behavior of various components (3.18)

### DIFF
--- a/guide/introduction/networking.markdown
+++ b/guide/introduction/networking.markdown
@@ -194,7 +194,7 @@ authentication. Secrets should not be transferred through policy, encrypted or
 not. Policy files should be considered public, and any leakage should not
 reveal secret information.
 
-**Note:** Connections from the cf-agent are cached as described in the
+**Note:** Connections from the `cf-agent` are cached as described in the
 documentation for body [`copy_from`][files#copy_from].
 
 ### Protocol Classic
@@ -209,18 +209,18 @@ and server hosts. After the initial connection is established
 subsequent connections and data transfer is encrypted by a randomly
 generated Blowfish key that is refreshed each session.
 
-With the classic protocol cf-serverd has the ability to enforce that a
+With the classic protocol `cf-serverd` has the ability to enforce that a
 file transfer be encrypted by setting the
 [`ifencrypted` access attribute][access#ifencrypted]. When ACLs that
-require encryption have unencrypted access attempts cf-serverd logs an
+require encryption have unencrypted access attempts `cf-serverd` logs an
 error message indicating the file requires encryption. Access to files
-that cf-serverd requires to be encrypted can be logged by setting the
+that `cf-serverd` requires to be encrypted can be logged by setting the
 [body server control `logencryptedtransfers` attribute][cf-serverd#logencryptedtransfers].
 
 ### Protocol 2
 
 3.6 introduced a new protocol option for communication with
-cf-serverd. [Protocol 2][Components#protocol_version]
+`cf-serverd`. [Protocol 2][Components#protocol_version]
 is the default in 3.7+ and uses a TLS session for encryption.
 
 **Note:** When protocol 2 is in use legacy encryption attributes are **noop**.
@@ -234,21 +234,21 @@ The following attributes are affected:
 
 The specific encryption algorithm used depends on the cipher
 negotiated between the client and the server. You can control which
-ciphers are allowed by cf-serverd for **incoming** connections by
+ciphers are allowed by `cf-serverd` for both **incoming** and **outgoing** (in the case of client initiated reporting in CFEngine Enterprise) connections by
 setting the
 [body server control `allowciphers` attribute][cf-serverd#allowciphers]. Controlling
-which ciphers are allowed to be used in **outgoing** connections is
+which ciphers are allowed to be used by `cf-agent` is
 done by setting
 [body common control `tls_ciphers`][Components#tls_ciphers].
 
-Additionally the minimum version of TLS required for **incoming**
+Additionally the minimum version of TLS required for **incoming** and **outgoing** (in the case of client initiated reporting in CFEngine Enterprise)
 connections can be set in
 [body server control `allowtlsversion`][cf-serverd#allowtlsversion]
-and the minimum version of TLS required for **outgoing** connections
-can be set in
+and the minimum version of TLS required for connections
+from `cf-agent` can be set in
 [body common control `tls_min_version`][Components#tls_min_version].
 
-There are debug and verbose level logs produced by cf-agent to
+There are debug and verbose level logs produced by `cf-agent` to
 indicate when TLS is in use.
 
 The following was captured by running the agent update policy in debug
@@ -269,9 +269,9 @@ verbose: Server is TRUSTED, received key 'SHA=5d20c01e4230aa53863eb36686eaa88209
   debug: TLSRecvLines(): OK WELCOME USERNAME=root
 ```
 
-cf-serverd emits verbose and debug log messages indicating when TLS is in use.
+`cf-serverd` emits verbose and debug log messages indicating when TLS is in use.
 
-The following was captured by starting cf-serverd in the foreground
+The following was captured by starting `cf-serverd` in the foreground
 with debug mode.
 
 `/var/cfenigne/bin/cf-serverd -Fd`

--- a/reference/components.markdown
+++ b/reference/components.markdown
@@ -581,7 +581,7 @@ body common control
 
 ### tls_ciphers
 
-**Description:** List of ciphers allowed when making **outgoing** connections.
+**Description:** List of ciphers allowed when making **outgoing** connections from components other than `cf-serverd`.
 
 For a list of possible ciphers, see man page for "openssl ciphers".
 
@@ -603,7 +603,7 @@ body common control
 
 ### tls_min_version
 
-**Description:** Minimum tls version to allow for **outgoing** connections.
+**Description:** Minimum tls version to allow for **outgoing** connections from components other than `cf-serverd`.
 
 [%CFEngine_promise_attribute(1.0)%]
 

--- a/reference/components/cf-serverd.markdown
+++ b/reference/components/cf-serverd.markdown
@@ -144,7 +144,7 @@ specify a list of hosts allowed to use the legacy protocol.
 
 ### allowciphers
 
-**Description:** List of TLS ciphers the server accepts for **incoming** connections.
+**Description:** List of TLS ciphers the server accepts both **incoming** and **outgoing** (in the case of client initiated reporting with CFEngine Enterprise) connections using `cf-serverd`.
 For a list of possible ciphers, see man page for "openssl ciphers".
 
 [%CFEngine_promise_attribute(AES256-GCM-SHA384:AES256-SHA)%]
@@ -177,7 +177,7 @@ this does not do anything as the classic protocol does not support TLS ciphers.
 
 ### allowtlsversion
 
-**Description:** Minimum TLS version allowed for **incoming** connections.
+**Description:** Minimum TLS version allowed for both **incoming** and **outgoing** (in the case of client initiated reporting with CFEngine Enterprise) connections using `cf-serverd`.
 
 [%CFEngine_promise_attribute(1.0)%]
 


### PR DESCRIPTION
The difference between body server control and body common control does not have
to do with directionality as much as it has to do with component behavior. body
server control settings do influence outbound connections, at least in the case
of client initiated reporting with CFEngine Enterprise.

While common control should impact behavior of non cf-serverd components it
currently only seems to impact cf-agent specifically. There are tickets about
correcting the behavior for other components like cf-hub and cf-runagent.