### PR TITLE
Stopped using imperative tense in docs tutorials titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,24 @@ Some names should always be capitalized in a specific way:
 * Mission Portal
 * UI, CVE, TCP, TLS, API, HTTP, JSON (and other abbreviations)
 
+### Titles and verb tenses
 
+Avoid imperative tense in titles.
+Use `-ing` or nouns instead, some examples:
+
+* What not to do:
+  * "Write policy"
+  * "Manage packages"
+  * "Install CFEngine"
+  * "Get started"
+* Titles you can use instead:
+  * "Policy writing" (or "Writing policy")
+  * "Package management" (or "Managing packages")
+  * "CFEngine installation" (or "Installing CFEngine")
+  * "Getting started"
+
+Since anything can be managed, "managing" tends to be used a lot.
+Try to use other words: "editing", "updating", "changing", "creating", "setting".
 
 ## Documentation structure
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CFEngine Documentation
+# CFEngine documentation
 
 This repository holds the sources for the technical
 [CFEngine documentation](https://docs.cfengine.com/docs/) in
@@ -15,7 +15,7 @@ category when you create bugs. And of course you can search the bug tracker
 for known issues with the documentation, and help the community of
 CFEngine users by correcting some of them.
 
-## Writing Documentation
+## Writing documentation
 
 The CFEngine documentation is written in regular
 [markdown](https://daringfireball.net/projects/markdown/syntax), with some
@@ -35,7 +35,23 @@ It is in general advisable to make small commits that are submitted through
 pull requests frequently. Otherwise any structural changes to documentation
 content can cause merge conflicts that are hard to resolve.
 
-## Documentation Structure
+### Capitalization
+
+Avoid capitalizing things unnecessarily (features, concepts, titles).
+Titles and headings use sentence case (so don't capitalize each word).
+Some names should always be capitalized in a specific way:
+
+* CFEngine
+* CFEngine Build
+* CFEngine Docs
+* CFEngine Enterprise
+* Linux, macOS, Windows, Unix (and other names of operating systems)
+* Mission Portal
+* UI, CVE, TCP, TLS, API, HTTP, JSON (and other abbreviations)
+
+
+
+## Documentation structure
 
 ### Structure
 
@@ -209,7 +225,7 @@ expression `begin_rx`, and injects all lines **verbatim** from there
 until the first line that matches `end_rx`. If `end_rx` is omitted,
 all lines until the end of the file will be injected.
 
-#### Documenting Policy Libraries
+#### Documenting policy libraries
 
 * `[%CFEngine_library_include(filename)%]`
 
@@ -247,7 +263,7 @@ will be emitted.
 
 All comments before the first doxygen-style tag will be ignored.
 
-#### Documenting CFEngine Syntax Elements
+#### Documenting CFEngine syntax elements
 
 The following macros require the syntax map to be generated
 via `cf-promises -s` into a file `syntax_map.json` within the
@@ -344,7 +360,7 @@ Renders a table of built-in functions, grouped by function category.
 
 Renders a nested tree of CFEngine words, starting at `subtree`.
 
-#### Other Macros
+#### Other macros
 
 * `[%CFEngine_redirect(target)]`
 
@@ -352,7 +368,7 @@ Injects javascript that redirects the current page to the HTML page for `target`
 which needs to be a title or title#section combination as in regular `[text][title#section]`
 links.
 
-## Content Style Guide
+## Content style guide
 
 Make sure you follow this style guide to make using CFEngine and the
 documentation a consistent and pleasant experience.

--- a/examples/tutorials/dashboard-alerts.markdown
+++ b/examples/tutorials/dashboard-alerts.markdown
@@ -8,7 +8,7 @@ tags: [Examples, Tutorials, Dashboard, Alerts, Enterprise]
 
 At 5 minutes intervals, the CFEngine hub gathers information from all of its connected agents about the current state of the system, including the outcome of its runs. All of this information is available to you. In this tutorial we will show how to use the Dashboard to create compliance overview at a glance
 
-**Note:** This tutorial builds upon [another tutorial that manages local users][Manage local users].
+**Note:** This tutorial builds upon [another tutorial that manages local users][Managing local users].
 
 We will create 3 alerts, one that shows when CFEngine repairs the system (promise repaired), one that shows when CFEngine does not need to make a change (promise kept), and one that shows CFEngine failing to repair the system (promise not kept).
 

--- a/examples/tutorials/distribute-files-from-a-central-location.markdown
+++ b/examples/tutorials/distribute-files-from-a-central-location.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Distribute files from a central location
+title: Distributing files from a central location
 sorting: 10
 published: true
 tags: [Examples, Tutorials, file distribution]

--- a/examples/tutorials/files-tutorial.markdown
+++ b/examples/tutorials/files-tutorial.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Create, modify, and delete Files
+title: File editing
 sorting: 10
 published: true
 tags: [Examples, Tutorials]

--- a/examples/tutorials/manage-local-users.markdown
+++ b/examples/tutorials/manage-local-users.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Manage local users
+title: Managing local users
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/examples/tutorials/manage-ntp.markdown
+++ b/examples/tutorials/manage-ntp.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Manage network time protocol
+title: Managing network time protocol
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/examples/tutorials/manage-packages.markdown
+++ b/examples/tutorials/manage-packages.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Manage packages
+title: Package management
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/examples/tutorials/manage-processes-and-services.markdown
+++ b/examples/tutorials/manage-processes-and-services.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Manage processes and services
+title: Managing processes and services
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/examples/tutorials/render-files-with-mustache-templates.markdown
+++ b/examples/tutorials/render-files-with-mustache-templates.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Render files with Mustache templates
+title: Rendering files with Mustache templates
 sorting: 15
 published: true
 tags: [Examples, Tutorials, mustache]

--- a/examples/tutorials/write-cfengine-policy.markdown
+++ b/examples/tutorials/write-cfengine-policy.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Write CFEngine policy
+title: Writing CFEngine policy
 published: true
 sorting: 3
 tags: [getting started, tutorial]

--- a/getting-started/installation/general-installation/installation-enterprise-free-aws-rhel.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-free-aws-rhel.markdown
@@ -191,7 +191,7 @@ Note: You can install CFEngine Enterprise on up to 25 hosts using the script abo
 
 * [Tutorial for running examples][Examples and tutorials#Tutorial for running examples]
 
-* [Distribute files from a central location.][Distribute files from a central location]
+* [Distributing files from a central location.][Distributing files from a central location]
 
   Whereas the first tutorial in this list teaches you how to deploy business policy
   through the Mission Portal, this advanced, command-line tutorial shows you how to distribute policy files from the Policy Server to all pertinent Hosts.

--- a/getting-started/installation/general-installation/installation-enterprise-free.markdown
+++ b/getting-started/installation/general-installation/installation-enterprise-free.markdown
@@ -118,7 +118,7 @@ number you use in your **Vagrantfile** (e.g. policyserver.vm.network "forwarded_
 
 * [Tutorial for running examples][Examples and tutorials#Tutorial for running examples]
 
-* [Distribute files from a central location.][Distribute files from a central location]
+* [Distributing files from a central location.][Distributing files from a central location]
 
   Whereas the first tutorial in this list teaches you how to deploy business policy
   through the Mission Portal, this advanced, command-line tutorial shows you how to distribute policy files from the Policy Server to all pertinent Hosts.

--- a/index.markdown
+++ b/index.markdown
@@ -60,7 +60,7 @@ alias: index.html
             <div>Learn about bundles, bodies, promises, variables, classes and decisions.</div>
          </li>
          <li>
-            <a href="examples-tutorials-manage-packages.html">Manage packages</a>
+            <a href="examples-tutorials-manage-packages.html">Package management</a>
             <div>Learn how to install, manage, and remove packages using CFEngine.</div>
          </li>
          <li class="cfe-build">


### PR DESCRIPTION
- README.md: Fixed capitalization and added guidelines for capitalization
- Standardized verb tense for tutorials
- README.md: Added guidelines for verb tenses in titles
