### PR TITLE
ENT-9968: Increased heading level of many headings within docs (3.21)

### DIFF
--- a/api/enterprise-api-ref/build-api.markdown
+++ b/api/enterprise-api-ref/build-api.markdown
@@ -7,11 +7,11 @@ tags: [reference, enterprise, API, build, modules]
 
 The Build API enables you to easily manage policy projects and their respective CFEngine Build modules.
 
-# Projects API
+## Projects API
 
 A project is a set of CFEngine Build modules and custom files/json/policy files.
 
-## Create project
+### Create project
 
 **URI:** https://hub.cfengine.com/api/build/projects
 
@@ -82,7 +82,7 @@ HTTP 200 Ok
 | 422 Unprocessable entity | Validation error occurred |
 | 500 Internal server error | Internal server error |
 
-## Update project
+### Update project
 
 By changing the repository url or branch you will initialize a new project and the current one will be removed from the
 file system and any un-pushed/un-deployed(terminology in Mission Portal UI) changes will be lost.
@@ -150,7 +150,7 @@ HTTP 200 OK
 | 422 Unprocessable entity | Validation error occurred |
 | 500 Internal server error | Internal server error |
 
-## Get project
+### Get project
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id
 
@@ -199,7 +199,7 @@ HTTP 200 OK
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## Get projects list
+### Get projects list
 
 **URI:** https://hub.cfengine.com/api/build/projects
 
@@ -270,7 +270,7 @@ HTTP 200 OK
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## Delete project
+### Delete project
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id
 
@@ -303,7 +303,7 @@ HTTP 204 No content
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## Sync project
+### Sync project
 
 **URI:** https://hub.cfengine.com/build/projects/:id/sync
 
@@ -346,7 +346,7 @@ HTTP 204 No content
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-##  Refresh project
+###  Refresh project
 
 Fetch upstream repository and return the current state.
 
@@ -395,7 +395,7 @@ HTTP 200 OK
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## List of CFEngine Build modules added to project
+### List of CFEngine Build modules added to project
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules
 
@@ -469,7 +469,7 @@ HTTP 200 OK
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## Add CFEngine Build module to project
+### Add CFEngine Build module to project
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules/:module
 
@@ -512,7 +512,7 @@ HTTP 201 Created
 | 422 Unprocessable entity | Validation error occurred |
 | 500 Internal server error | Internal server error |
 
-## Delete CFEngine Build module from project
+### Delete CFEngine Build module from project
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules/:module
 
@@ -547,7 +547,7 @@ HTTP 204 No content
 | 404 Not found | Project not found |
 | 500 Internal server error | Internal server error |
 
-## Update CFEngine Build module version
+### Update CFEngine Build module version
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules/:module
 
@@ -590,7 +590,7 @@ HTTP No content
 | 422 Unprocessable entity | Validation error occurred |
 | 500 Internal server error | Internal server error |
 
-## Get list of available CFEngine Build modules
+### Get list of available CFEngine Build modules
 
 **URI:** https://hub.cfengine.com/api/build/modules
 
@@ -674,7 +674,7 @@ HTTP 200 OK
 | 200 Ok | Successful response  |
 | 500 Internal server error | Internal server error |
 
-## Update list of available CFEngine Build modules
+### Update list of available CFEngine Build modules
 
 Modules will be received from the official CFEngine Build modules catalogue https://build.cfengine.com
 
@@ -703,7 +703,7 @@ curl --user <username>:<password> \
 | 204 No content | Modules list successfully updated |
 | 500 Internal server error | Internal server error |
 
-## Get CFEngine build module by name
+### Get CFEngine build module by name
 
 **URI:** https://hub.cfengine.com/api/build/modules/:name
 
@@ -767,7 +767,7 @@ HTTP 200 OK
 | 404 Not found | Module not found  |
 | 500 Internal server error | Internal server error |
 
-## Get specific version of a CFEngine Build module by name
+### Get specific version of a CFEngine Build module by name
 
 **URI:** https://hub.cfengine.com/api/build/modules/:name/:version/
 
@@ -835,7 +835,7 @@ HTTP 200 OK
 | 500 Internal server error | Internal server error |
 
 
-## Get CFEngine Build module input data
+### Get CFEngine Build module input data
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules/:name/input
 
@@ -913,7 +913,7 @@ HTTP 200 OK
 | 500 Internal server error | Internal server error       |
 
 
-## Set CFEngine Build module input data
+### Set CFEngine Build module input data
 
 **URI:** https://hub.cfengine.com/api/build/projects/:id/modules/:name/input
 

--- a/api/enterprise-api-ref/federated-reporting-api.markdown
+++ b/api/enterprise-api-ref/federated-reporting-api.markdown
@@ -7,12 +7,12 @@ tags: [reference, enterprise, API, reporting]
 
 This API is used for configuring hubs so that a single hub can be used to report on any host connected to participating feeder hubs.
 
-# Remote hubs
+## Remote hubs
 
 Federated reporting must be enabled before it is possible to use the remote hubs API, please
 see the `Enable hub for federated reporting` section below.
 
-## Remote hubs list
+### Remote hubs list
 
 **URI:** https://hub.cfengine.com/api/fr/remote-hub
 
@@ -56,7 +56,7 @@ HTTP 200 OK
 }
 ```
 
-## Get remote hub
+### Get remote hub
 
 **URI:** https://hub.cfengine.com/api/fr/remote-hub/:remote_hub_id
 
@@ -88,7 +88,7 @@ HTTP 200 OK
 }
 ```
 
-## Add remote hub
+### Add remote hub
 
 **URI:** https://hub.cfengine.com/api/fr/remote-hub
 
@@ -113,7 +113,7 @@ HTTP 200 OK
 HTTP 201 CREATED
 ```
 
-## Update remote hub
+### Update remote hub
 
 **URI:** https://hub.cfengine.com/api/fr/remote-hub/:remote_hub_id
 
@@ -140,7 +140,7 @@ HTTP 201 CREATED
 HTTP 202 ACCEPTED
 ```
 
-## Delete remote hub
+### Delete remote hub
 
 **URI:** https://hub.cfengine.com/api/fr/remote-hub/:remote_hub_id
 
@@ -157,9 +157,9 @@ HTTP 202 ACCEPTED
 HTTP 202 ACCEPTED
 ```
 
-# Enable hub for federated reporting
+## Enable hub for federated reporting
 
-## Enable hub as a superhub
+### Enable hub as a superhub
 
 **URI:** https://hub.cfengine.com/api/fr/setup-hub/superhub
 
@@ -172,7 +172,7 @@ HTTP 202 ACCEPTED
 ```
 
 
-## Enable hub as a feeder
+### Enable hub as a feeder
 
 **URI:** https://hub.cfengine.com/api/fr/setup-hub/feeder
 
@@ -184,7 +184,7 @@ HTTP 202 ACCEPTED
 HTTP 202 ACCEPTED
 ```
 
-## Hub status
+### Hub status
 
 **URI:** https://hub.cfengine.com/api/fr/hub-status
 
@@ -203,13 +203,13 @@ HTTP 202 ACCEPTED
 }
 ```
 
-# Federation config
+## Federation config
 
 Federated reporting must be enabled before generating or removing federation configuration, please
 see `Enable hub for federated reporting` section above. Otherwise an error will be thrown and
 config file will not be created/deleted.
 
-## Generate federation config
+### Generate federation config
 
 **URI:** https://hub.cfengine.com/api/fr/federation-config
 
@@ -221,7 +221,7 @@ config file will not be created/deleted.
 HTTP 202 ACCEPTED
 ```
 
-## Delete federation config
+### Delete federation config
 
 **URI:** https://hub.cfengine.com/api/fr/federation-config
 

--- a/api/enterprise-api-ref/ssh-keys-api.markdown
+++ b/api/enterprise-api-ref/ssh-keys-api.markdown
@@ -7,9 +7,9 @@ tags: [reference, enterprise, API, build, SSH]
 
 The SSH keys API enables you to generate a key pair that can be used for authorization.
 
-# SSH keys API
+## SSH keys API
 
-## Generate SSH key
+### Generate SSH key
 
 Generates a key with 4096 bits, sha2-512 digest and in rfc4716 (default openssh) format.
 
@@ -42,7 +42,7 @@ HTTP 200 Ok
 | 200 OK | SSH key successfully created |
 | 500 Internal server error | Internal server error |
 
-## Get SSH keys list
+### Get SSH keys list
 
 **URI:** https://hub.cfengine.com/api/ssh-key
 
@@ -83,7 +83,7 @@ HTTP 200 OK
 | 200 Ok | Successful response  |
 | 500 Internal server error | Internal server error |
 
-## Get SSH key
+### Get SSH key
 
 **URI:** https://hub.cfengine.com/api/ssh-key/:id
 
@@ -122,7 +122,7 @@ HTTP 200 OK
 | 404 Not found | SSH key not found |
 | 500 Internal server error | Internal server error |
 
-## Delete SSH key
+### Delete SSH key
 
 **URI:** https://hub.cfengine.com/api/ssh-key/:id
 

--- a/examples/example-snippets/general.markdown
+++ b/examples/example-snippets/general.markdown
@@ -17,7 +17,7 @@ To get started with CFEngine, you can imagine the following template for enterin
 
 [%CFEngine_include_snippet(basic_example.cf, .* )%]
 
-# The general pattern
+## The general pattern
 
 The general pattern of the syntax is like this (colors in html version: red, CFEngine word; blue, user-defined word):
 
@@ -27,7 +27,7 @@ bundle component name(parameters)
 what_type:
  where_when::
 
-  # Traditional comment
+  ## Traditional comment
 
 
   "promiser" -> { "promisee1", "promisee2" },
@@ -38,11 +38,11 @@ what_type:
 }
 ```
 
-## Hello world
+### Hello world
 
 
 [%CFEngine_include_snippet(hello_world.cf, .* )%]
 
-## Array example ##
+### Array example
 
 [%CFEngine_include_snippet(array_example.cf, .* )%]

--- a/resources/additional-topics/agility.markdown
+++ b/resources/additional-topics/agility.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# Understanding agility
+## Understanding agility
 
 We intuitively recognize agility as the capability to respond rapidly enough and
 flexibly enough to a difficult challenge. If we imagine an animal surviving in
@@ -35,7 +35,7 @@ associated with a lack of agility: a blow, a fall or a loss.
 * Comprehension
 * Efficiency
 
-## What make agility possible?
+### What make agility possible?
 
 
 To understand agility, we have to understand time and the capacity for change.
@@ -62,7 +62,7 @@ can help with this, if we adopt sound practices.
 Intuitively, we understand agility to be related to our capacity to respond to a
 situation. Let's try to pin this idea down more precisely.
 
-## The capacity of a system
+### The capacity of a system
 
 The capacity of a system is defined to be its maximum rate of change. Most
 often, this refers to speed of the system response to a single request1.
@@ -70,7 +70,7 @@ often, this refers to speed of the system response to a single request1.
 In engineering, capacity is measured in changes per second, so it represents the
 maximum speed of a system within a single thread of activity2.
 
-## Speed
+### Speed
 
 Speed is the rate at which change takes place. For a configuration tool like
 CFEngine, speed can be measured either as
@@ -160,7 +160,7 @@ agility. Remarkably this is usually unexpected for most practitioners, and most
 of system planning goes into first time deployment, rather than maintaining
 operational state.
 
-## Precision
+### Precision
 
 Acting quickly is not enough: we also need to be accurate in responding to
 change[^4]. We need to be able to:
@@ -288,7 +288,7 @@ We can now summarize some qualities of CFEngine that favour agility:
 
 * Increasing system capacity - by scaling
 
-## What agility means in different environments
+### What agility means in different environments
 
 Let's examine some example cases where agility plays a role. Agility only has
 meaning relative to an environment, so in the following sections, we cite the
@@ -306,7 +306,7 @@ that limber systems must prevail in IT's evolutionary jungle.
 * Finance
 * Manufacturing
 
-### Desktop management
+#### Desktop management
 
 "The desktop space can be a very volatile environment, with multiple platforms."
 
@@ -347,7 +347,7 @@ Precision:
     greatly reduce the time needed to return to the most current enterprise
     build.
 
-### Web shops
+#### Web shops
 
 Modern web-based companies often base their entire financial operations around
 an active web site. Down-time of the web service is mission critical.
@@ -386,7 +386,7 @@ Precision:
     Customization and individuality is a large part of a website's business
     competitiveness. Maintaining precise
 
-### Cloud providers
+#### Cloud providers
 
 Speed:
 
@@ -403,7 +403,7 @@ Precision:
     demand is probably the fastest rate of change.
 
 
-### High performance computing
+#### High performance computing
 
 High Performance clusters are typically found in the oil and gas industry, in
 movie, financial, weather and aviation industries, and any other modelling
@@ -434,7 +434,7 @@ Precision:
     impossible to make a precise change when you don't fully comprehend the
     environment."
 
-### Government
+#### Government
 
 Speed:
 
@@ -452,7 +452,7 @@ Precision:
     Finance is big money trying to make more big money. Government is focused
     more on compliance with its own regulations."
 
-### Finance
+#### Finance
 
 Speed:
 
@@ -474,7 +474,7 @@ Precision:
     past, but this will have to change as the rest of the world's IT services
     accelerate.
 
-### Manufacturing
+#### Manufacturing
 
 SCADA (supervisory control and data acquisition) generally refers to industrial
 control systems (ICS): computer systems that monitor and control industrial,
@@ -507,7 +507,7 @@ Precision:
     probe to detect microscopic fractures in the layers, one tool may just track
     it's position in line. Supply and demand, cost and revenue."
 
-## Separating what from how (DevOps)
+### Separating what from how (DevOps)
 
 
 If you have to designs a programmatic solution to a challenge, it will cost you
@@ -626,7 +626,7 @@ bundle agent example
 }
 ```
 
-## How abstraction improves agility
+### How abstraction improves agility
 
 Abstraction allows us to turn special cases into general patterns. This leads to
 a compression of information, as we can make defaults for the general patterns,
@@ -662,7 +662,7 @@ need the promise, with only a small amount of work.
 Thus, simplicity is assured by having consistency of interface and low cost
 barrier to changing the meaning of the definition.
 
-## Increasing system capacity (by scaling)
+### Increasing system capacity (by scaling)
 
 Capacity in IT infrastructure is increased by increasing machine power. Today,
 at the limit of hardware capacity, this typically means increasing the number of
@@ -702,7 +702,7 @@ lowest-common-denominator standardization.
 Scalability is addressed in a separate document: Scale and Scalability, so we
 shall not discuss it further here.
 
-# Agility in your work
+## Agility in your work
 
 * Easy versus simple
 * How does complexity affect agility?
@@ -711,7 +711,7 @@ shall not discuss it further here.
 * What does agility cost?
 * Who is responsible for agility?
 
-## Easy versus simple
+### Easy versus simple
 
 Just as we separate goals from actions, and strategy from tactics, so we can
 separate what is easy from what is simple. Easy brings short-term gratification,
@@ -738,7 +738,7 @@ only what you want to happen. This is always done by using the same kinds of
 declarations, based on the same model. You don't need to learn new principles
 and ideas, just more of the same.
 
-## How does complexity affect agility?
+### How does complexity affect agility?
 
 
 In the past[^11], it was common to manage change by making everything the same.
@@ -803,7 +803,7 @@ However, the ability to respond to complex scenarios often requires us to dabble
 with diversity. Avoiding it merely creates a lack of agility, as one is held
 back by the need to over-simplify.
 
-## An effective understanding helps agility
+### An effective understanding helps agility
 
 
 All configuration issues, including fitness for purpose, boil down to three
@@ -820,7 +820,7 @@ In configuration `what' represents transitory knowledge, while `how' is often
 more lasting and can be absorbed into the infrastructure. The consistency and
 repairability of `how' makes it simpler to change what without risk.
 
-## Maximizing business imperatives
+### Maximizing business imperatives
 
 Agility allows companies and public services to compete and address the needs of
 continuous service improvement. This requires insight into IT operations from
@@ -859,7 +859,7 @@ to work. Thus one is reduced to a more even state of affairs: learning to work
 with the environment `as is', with clear expectations of what is possible and
 controlling only certain parts on which crucial things depend.
 
-## What does agility cost?
+### What does agility cost?
 
 CFEngine is designed to have a low Total Cost of Ownership, by being
 exceptionally lightweight and conceptually simple. The investment in CFEngine is
@@ -878,7 +878,7 @@ replacement the clock-time required for system updates went from 45 minutes to
 The total cost of providing for agility can be costly or it can be cheap. By
 design, CFEngine aims to make scale and agility inexpensive in the long run.
 
-## Who is responsible for agility?
+### Who is responsible for agility?
 
 The bottom line is: you are! Diversity and customization are basic freedoms that
 user-driven services demand in today's world, and having the agility to meet

--- a/resources/additional-topics/application-management.markdown
+++ b/resources/additional-topics/application-management.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is application management?
+## What is application management?
 
 Application management concerns the deployment and updating of software, as well
 as customization of for actual use, in other words all the activities required
@@ -24,7 +24,7 @@ issues.
 Using CFEngine, you can verify that the software is in a promised state and is
 properly customized for use.
 
-# How can CFEngine help?
+## How can CFEngine help?
 
 
 CFEngine assists with application management in a number of ways. Following the
@@ -50,7 +50,7 @@ BDMA lifecycle, we note:
     CFEngine can monitor and report on packages and patches installed on systems
     and their versions and status.
 
-# Package management
+## Package management
 
 
 Application management is simple today on most operating systems due to the
@@ -85,7 +85,7 @@ package manager to query information and get the system into the desired state.
 CFEngine can edit configuration files in real time to ensure that applications
 are customized to local needs at all times.
 
-# Enterprise software reporting
+## Enterprise software reporting
 
 In commercial releases of CFEngine, the state of software installation is
 reported centrally and is easily accessible through the Knowledge Map.
@@ -94,7 +94,7 @@ Commercial editions of CFEngine also support querying Windows machines for
 installed MSI packages and thus allows for easy software deployment in
 heterogeneous Unix and Windows environments.
 
-# Integrated software installation
+## Integrated software installation
 
 CFEngine gives complete freedom to users, so there are many ways to design a
 system that achieves a desired software end-state. Consider the following
@@ -111,7 +111,7 @@ standard library.
 
 ![Package Management Flow](./package-flow.png)
 
-## Distributing software packages to client hosts
+### Distributing software packages to client hosts
 
 To begin with, we promise that the relevant software packages will be locally
 available to the agents from software servers, i.e. we promise that a local copy
@@ -143,7 +143,7 @@ When the agent copies a relevant software package from the software server
 defined. This class can act as a trigger to stop the application, update it, and
 start it again.
 
-## Stopping and restarting an application for update
+### Stopping and restarting an application for update
 
 On some operating systems, software cannot be updated while it is running.
 CFEngine can promise to enure that a program is stopped before update:
@@ -219,7 +219,7 @@ package is already installed, but installs the largest version available if it
 is not. Use package_select => "==" to install the exact version instead of the
 largest.
 
-## Adapting to Windows
+### Adapting to Windows
 
 To adapt our example to Windows, we change the path to the local software
 repository from/software_repotoc:\software_repo, to support the Windows path
@@ -232,7 +232,7 @@ package_method           => msi_version("c:\software_repo"),
 
 Refer to the msi_version body in the standard library.
 
-## Notes on Windows systems
+### Notes on Windows systems
 
 CFEngine implements Windows packaging using the MSI subsystem, internally
 querying the Windows Management Interface for information. However, not all
@@ -251,7 +251,7 @@ For the formats to match, we can change the product name to 7zip and the version
 to 4.65 in the msi-package. Free tools such as InstEd can both view and change
 the product name and version (Tables->Property->ProductName and ProductVersion).
 
-# Customizing applications
+## Customizing applications
 
 
 By definition, we cannot explain how to customize software for all cases. For
@@ -298,7 +298,7 @@ bundle agent my_application_customize
 You can also create file templates with customizable variables using
 theexpand_templatemethod from the standard library.
 
-# Starting and stopping software
+## Starting and stopping software
 
 CFEngine is promise or compliance oriented. You promise whether software will be
 running or not running at different times and locations by making processes or
@@ -355,7 +355,7 @@ bundle agent example
 }
 ```
 
-# Auditing software applications
+## Auditing software applications
 
 Commercial Editions of CFEngine generate reports about installed software,
 showing package names and versions that are installed. There is a huge variety

--- a/resources/additional-topics/build-deploy-manage-audit.markdown
+++ b/resources/additional-topics/build-deploy-manage-audit.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide, BDMA]
 ---
 
-# What is BDMA?
+## What is BDMA?
 
 The four mission phases are sometimes referred to as
 
@@ -45,7 +45,7 @@ The four mission phases are sometimes referred to as
 
 ![BDMA Knowledge Management Diagram](./BDMA-model.png)
 
-# Stem cell hosts
+## Stem cell hosts
 
 At CFEngine we talk about stem cell hosts. A stem cell host is a generic
 foundation of software that is the necessary and sufficient basis for any future
@@ -59,7 +59,7 @@ rather, you use CFEngine to implement and maintain the morphology of the
 differences. Stem cell hosts are normally built using PXE services by booting
 and installing automatically from the network.
 
-# Recommendations for Build
+## Recommendations for Build
 
 There are many approaches to building complete systems. When you use CFEngine,
 you should try to progress from thinking only about putting bytes on disks, to
@@ -91,7 +91,7 @@ optimized build that can shave off many minutes from the build time for
 machines. CFEngine can then take over where rPath leaves off, performing
 surgically precise customization.
 
-# Recommendations for Deploy
+## Recommendations for Deploy
 
 Deploying a policy is a potentially dangerous operation, as it will lead to
 change, with associated risk. Side-effects are common, and often result from
@@ -131,7 +131,7 @@ CFEngine allows you to apply changes at a much finer level of granularity than
 any package based management system, thus it complements basic package
 management with its deployment and real time repair (see next section).
 
-# Recommendations for Manage
+## Recommendations for Manage
 
 Managing systems is an almost trivial task with CFEngine. Once a model for
 desired state has been created, you just sit back and watch. You should be ready
@@ -153,7 +153,7 @@ computers in a single day. Learning to trust the software saves unnecessary
 communication and needless human involvement. The Nova Mission Portal makes
 notification and alerting largely unnecessary.
 
-# Recommendations for Audit
+## Recommendations for Audit
 
 Auditing systems is a continuous process when using CFEngine Nova. Report data
 are collected on a continuous and distributed basis. These data are then
@@ -232,7 +232,7 @@ detail.
 
   Current variable values expanded on different hosts.
 
-# Summary BDMA workflow
+## Summary BDMA workflow
 
 * Define a stem cell host template.
 

--- a/resources/additional-topics/change-management.markdown
+++ b/resources/additional-topics/change-management.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is change management?
+## What is change management?
 
 Change Management is about the planning and implementation of intended changes
 to an IT system, as well as the detection, documentation and possible repair of
@@ -20,7 +20,7 @@ CFEngine automation, some of these approaches are considered antiquated. This
 guide explains change management in the framework of CFEngine's self-healing
 automation.
 
-# Regulation: authorized and unauthorized change
+## Regulation: authorized and unauthorized change
 
 It is common to speak of authorized and unauthorized change in the IT industry. Many
 organizations think in these authoritarian terms and use management techniques
@@ -75,7 +75,7 @@ period of stable operations is like a smooth flight, on course to the correct
 destination. If unintended changes happen to change that, like the weather,
 immediate course corrections should be made to avoid loss.
 
-# Intended and unintended change
+## Intended and unintended change
 
 To institue a rational approach to change management, i.e. one that is suited to
 business's operational time-scales, we need to think about separating change
@@ -96,7 +96,7 @@ without switching them off. A mandatory level of risk must be anticipated.
 It is by defining a desired operational state that one can avoid re-processing
 every since repair to a system.
 
-# How fast should changes be made?
+## How fast should changes be made?
 
 Time scales are crucially important in engineering, and deserve equal importance
 in IT management. Ask yourself: how do you know if something is changing or not?
@@ -137,7 +137,7 @@ system at twice this rate 2R. In CFEngine, we have chosen a repair resolution of
 5 minutes for configuration sampling, because measurements show that many system
 characteristics have auto-correlations times of 10-20 minutes[^2].
 
-# Partially centralized change
+## Partially centralized change
 
 It is not necessary to assume a central model of authority to manage change.
 Indeed, many CFEngine users have highly devolved organizations with many
@@ -155,7 +155,7 @@ Mission Portal. This shows the policy itself in different regions, as well as
 reports about the compliance of systems. Users can also exchange messages about
 their intentions, through policy comments and personal logs in the system.
 
-# The decision point
+## The decision point
 
 By making all changes through a single point of control and verification, you
 avoid[^3] the problem of multiple intentions, because all intentions will be clear
@@ -168,7 +168,7 @@ If you work in a federated environment, then each distinct region of policy can
 have its own policy server or hub. These will not conflict, unless a host
 subscribes to updates from more than one hub.
 
-# Promises about change vs state
+## Promises about change vs state
 
 CFEngine works by keeping promises, so think about how promises apply to change.
 
@@ -204,7 +204,7 @@ CFEngine uses promises in the same way, to guide systems to their desired
 outcomes, not merely a script of relative corrections. So CFEngine works
 somewhat like a system auto-pilot.
 
-# Promises about change
+## Promises about change
 
 To help you think of change in terms of promises, consider the following
 promises made during change management, with CFEngine examples.
@@ -291,7 +291,7 @@ management:
 If you have made no promise about your system state, you should not be surprised
 by anything that happens there. You cannot assume that no change will happen.
 
-# Change management and knowledge management
+## Change management and knowledge management
 
 
 The decision to manage change is an economic trade-off. The more promises we
@@ -317,7 +317,7 @@ unpleasant surprises. The key to predictability in system operations is
 CFEngine's core principle of convergence. CFEngine Missions Specialists always
 think convergence.
 
-# Non-destructive change
+## Non-destructive change
 
 The IT industry, for the most part, has not really progressed beyond the idea of
 baselining systems. In the traditional conception of change management you start
@@ -341,7 +341,7 @@ way, and it is our job to continuously monitor and repair this general
 dilapidation. Rather than assuming a constant state in between changes, CFEngine
 assumes a constant "ideal state" or goal to be achieved at all times.
 
-# Change and convergence
+## Change and convergence
 
 Change requires action, and implementation is the most dangerous part of change,
 as it leads to consquences that a difficult to predict, especially if you have
@@ -362,7 +362,7 @@ repeated a infinite number of times[^4] without adverse consquences, because
 every action will only bring you to the desired state, no matter where you start
 from.
 
-# The change decision process or release management
+## The change decision process or release management
 
 The process of managing intended changes is often called release management. A
 release is a collection of authorized changes to the promises of desired state
@@ -405,7 +405,7 @@ At each stage, we make careful, low-risk incursions on the system and see how it
 responds. Note that some side-effects could take days to emerge, so the schedule
 for change should account for the expected impact.
 
-# Deploying policy changes
+## Deploying policy changes
 
 The following sequence forms a checklist for deploying successful policy change:
 

--- a/resources/additional-topics/cloud-computing.markdown
+++ b/resources/additional-topics/cloud-computing.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is cloud computing?
+## What is cloud computing?
 
 Cloud Computing refers to the commoditization of computing, i.e. a world in
 which computers may be borrowed on demand from a resource pool, like renting a
@@ -22,7 +22,7 @@ and save on redundant investment. You may think of Cloud Computing as
 `Recycle-able Computing' - a world in which you can use something for a short
 time and then discard it, without fear of waste.
 
-# Is cloud computing for everything and everyone?
+## Is cloud computing for everything and everyone?
 
 Cloud Computing does for computers what the database did for information.
 Instead of having to keep reams of paper physically on site, databases allowed
@@ -45,7 +45,7 @@ efficiently. Some people still buy books, cars and dig wells, while others loan
 books, rent cars and get water from the water authority. Different economic
 models have different applications.
 
-# How does CFEngine enable cloud computing?
+## How does CFEngine enable cloud computing?
 
 CFEngine has technology that can quickly bring machines, either real or virtual,
 from an uninitiated state to a fully working and customized state in seconds or
@@ -54,7 +54,7 @@ into a specialized managed service on demand. CFEngine makes it extremely cheap
 to rebuild systems from scratch. This is exactly what a vibrant recycling regime
 needs to work efficiently.
 
-# Permanent infra-structure with vibrant change
+## Permanent infra-structure with vibrant change
 
 Not all your computers should be disposable. Certain key infrastructure items
 like DNS servers, directory servers, databases, etc are part of a permanent
@@ -73,7 +73,7 @@ investment will last you for a long time, unchanged. For that reason, cloud
 services will never solve everyone's needs all the time. It is merely one
 product of choice.
 
-# How does Cloud relate to virtualization?
+## How does Cloud relate to virtualization?
 
 Virtualization is the tool that makes Cloud Computing practical. Every time a
 physical machine needs to be deployed or retired, it requires the physical
@@ -92,7 +92,7 @@ machine software is running on. CFEngine can bring stability to the hosts or the
 virtual guests, or it can keep virtual machines running without the need to
 reboot[^1].
 
-# Isn't virtualization inefficient?
+## Isn't virtualization inefficient?
 
 Virtualized computers run as software simulations, adding an extra layer of
 overhead. Using virtual machines is thus not as fast or processor-efficient as
@@ -114,7 +114,7 @@ dealing with services belonging to different companies or different users on the
 same physical host. The packaging aspect of virtual machines is therefore a form
 of `information management'.
 
-# Challenges for Cloud Computing
+## Challenges for Cloud Computing
 
 Dealing with scale, rapid change and impermanence could quickly lead to a
 processing overhead for humans, i.e. in the management of the cloud computers.
@@ -157,7 +157,7 @@ can be understood both by technicians and management stakeholders.
 
 * Bring systems from any state into compliance.
 
-# What if I change my mind about Cloud Computing?
+## What if I change my mind about Cloud Computing?
 
 CFEngine can be used in a public or in a private cloud, and it can be used on
 local servers, desktops and even mobile devices. CFEngine is designed to be
@@ -167,7 +167,7 @@ you want to move a service or a server-role, it is a simple matter to do so.
 CFEngine will continue to manage the service no matter what the underlying
 resource model.
 
-# The future - molecular computing
+## The future - molecular computing
 
 At CFEngine, we believe that Cloud Computing is just a rehearsal for a real
 change in the way computing services are managed. In the future, the

--- a/resources/additional-topics/content-driven-policy.markdown
+++ b/resources/additional-topics/content-driven-policy.markdown
@@ -7,7 +7,7 @@ tags: [overviews, special topics, guide]
 reviewed: 2019-05-06
 ---
 
-# What is a content-driven policy?
+## What is a content-driven policy?
 
 
 A Content-Driven Policy is a text file with lines containing semi-colon
@@ -35,7 +35,7 @@ of masterfiles since 3.6.0. [`cdp_inputs` was removed](https://github.com/cfengi
 unified base for policy that works with both CFEngine Community and CFEngine
 Enterprise.
 
-# Why should i use content-driven policies?
+## Why should i use content-driven policies?
 
 
 As seen in the example above, Content-Driven Policies are easy to write and
@@ -87,7 +87,7 @@ like the following.
 * Database management
 * Application / script management
 
-# How do content-driven policies work in detail?
+## How do content-driven policies work in detail?
 
 
 The text files in masterfiles/cdp_inputs/(e.g. 'registry_list.txt') are parsed
@@ -98,7 +98,7 @@ policies in the text files.
 The Knowledge Map contains reports specifically designed to match the
 Content-Driven Policies.
 
-# Can I make my own content-driven policies?
+## Can I make my own content-driven policies?
 
 
 It is possible to mimic the structure of the existing Content-Driven Policies to

--- a/resources/additional-topics/devops.markdown
+++ b/resources/additional-topics/devops.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is DevOps?
+## What is DevOps?
 
 DevOps is a term coined by Patrick Debois in 2009, from an amalgamation of
 Development and Operations. It expresses a change in the way companies are
@@ -17,7 +17,7 @@ infrastructure. It is about giving software developers more influence over the
 IT infrastructure their applications run on, and allowing change at the same
 speed as agile development teams.
 
-# Why is DevOps happening now?
+## Why is DevOps happening now?
 
 
 The proliferation of Free and Open Source software has put powerful software
@@ -37,7 +37,7 @@ Traditional IT management methods can be perceived as too slow in such an
 environment. An important part of DevOps is that it naturally encompasses the
 idea of business integration - or IT for a purpose.
 
-# Should Web and IT management be closely related?
+## Should Web and IT management be closely related?
 
 Web frameworks have seen the rise of languages like PHP, Java, Python and Ruby,
 all of which offer frameworks for fast deployment. Languages that work well for
@@ -62,7 +62,7 @@ load balancers in web farms.
 At CFEngine, we believe in lightweight management - made as simple as possible,
 but no simpler.
 
-# How do we make controlled change faster?
+## How do we make controlled change faster?
 
 
 It is important to be able to make changes quickly. Automation can implement
@@ -82,7 +82,7 @@ requirements2. All web-based companies using credit cards will know about the
 need for PCI-DSS compliance, for instance. And US-traded companies will know
 about Sarbanes-Oxley (SOX).
 
-# What role does CFEngine play in DevOps?
+## What role does CFEngine play in DevOps?
 
 The challenges for IT management today are about increasing complexity (driven
 by the circuitry of online applications) and increasing scale.
@@ -105,7 +105,7 @@ The advantage CFEngine brings is that users can have clear expectations about
 their systems at all times. Today's programmers are more sophisticated than
 script monkeys.
 
-# Getting used to declarative expression
+## Getting used to declarative expression
 
 CFEngine uses a pragmatic mixture of the declarative (functional) and imperative
 to represent configurations. Programmers are taught mainly imperative
@@ -120,7 +120,7 @@ optimized for clarity.
 The main goals of CFEngine are convergence to a desired state, repeatability and
 clear intentions.
 
-## Expressing actions or tasks in CFEngine
+### Expressing actions or tasks in CFEngine
 
 Most of the actionable items have builtin operational support, which is designed
 to be convergent and safely repeatable. To keep declarations clear, CFEngine
@@ -153,7 +153,7 @@ bundle agent SomeUserDefinedName
 }
 ```
 
-## Expressing conditionals in CFEngine
+### Expressing conditionals in CFEngine
 
 CFEngine uses the idea of contexts (also called classes or class-contexts3) to
 address declarations to certain environments. The contexts or classes are
@@ -233,7 +233,7 @@ decentralized manner avoiding clogging of network communications that befuddles
 many centralized approaches. This keeps CFEngine execution very fast and with a
 low overhead.
 
-## Expressing loops in CFEngine
+### Expressing loops in CFEngine
 
 Lists and loops go hand in hand, and they are a very effective way of reducing
 syntax and simplifying the expression of intent. Saying `do this to all the
@@ -333,7 +333,7 @@ R: Hello b 4 z
 R: Hello c 4 z
 ```
 
-## Expressing subroutines in CFEngine
+### Expressing subroutines in CFEngine
 
 Subroutines are used for both expressing and reusing parameterizable chunks of
 code, and for naming chunks for better management of intention. In CFEngine you
@@ -372,7 +372,7 @@ commands:
 The use of methods brings multi-dimensional patterns to convergent configuration
 management.
 
-# Using CFEngine to integrate software components
+##Using CFEngine to integrate software components
 
 Integration of software components may be addressed with a variety of approaches
 and techniques:

--- a/resources/additional-topics/distributed-scheduling.markdown
+++ b/resources/additional-topics/distributed-scheduling.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is distributed scheduling?
+## What is distributed scheduling?
 
 Scheduling refers to the execution of non-interactive processes or tasks
 (usually called `jobs') at designated times and places around a network of
@@ -16,7 +16,7 @@ several computers. For example, you schedule a processing job
 on machine1 and machine2, and when these are finished you need to schedule a job
 on machine3. This is distributed scheduling.
 
-# Coordinating dispatch
+## Coordinating dispatch
 
 Dispatch is the term used for starting actually the execution of a job that has
 been scheduled. There are two ways to achieve distributed job scheduling:
@@ -35,7 +35,7 @@ CFEngine is a naturally decentralized system, and only policy definition is
 usually centralized, but you can set up practically any architecture you like,
 in a secure fashion.
 
-# Job scheduling and periodic maintenance
+## Job scheduling and periodic maintenance
 
 You promise to execute tasks or keep promises at distributed places and times:
 
@@ -56,7 +56,7 @@ This list transfers to workflow processes too. If one job needs to follow after
 another (because it depends on it for something), we can ask if this workflow is
 a standard and regular occurrence, or a one-off phenomenon.
 
-## One-off workflows
+### One-off workflows
 
 In CFEngine, you code a one-off workflow by specifying the space-time
 coordinates of the event that starts it. For example, if you want a job to be
@@ -153,7 +153,7 @@ access:
 }
 ```
 
-## Regular workflows
+### Regular workflows
 
 To make a job happen at a specific time, we used a very specific time classifier
 'Day24.January.Year2012.Hr16.Min45_50'. If we now want to make this workflow
@@ -209,7 +209,7 @@ commands:
 ```
 
 
-# Fancy distributed encapsulation
+## Fancy distributed encapsulation
 
 We could try to be fancy about distributed scheduling, packaging it into a
 reusable structure. This may or may not be a good idea, depending on your
@@ -322,7 +322,7 @@ access:
 }
 ```
 
-# More links in the chain
+## More links in the chain
 
 In the examples above, we only had two hosts cooperating about jobs. In general,
 it is not a good idea to link together many different hosts unless there is a
@@ -339,7 +339,7 @@ number of jobs to drive a single follow-up.
 
 ![Scheduling Patterns](./scheduleing-patterns.png)
 
-## Aggregation of multiple jobs
+### Aggregation of multiple jobs
 
 When aggregating jobs, we must combine their exit status using AND or OR. The
 most common case it that we require all the prerequisites in place in order to
@@ -396,7 +396,7 @@ bundle agent example
 }
 ```
 
-## Triggering multiple follow-ups
+### Triggering multiple follow-ups
 
 The converse scenario is to trigger a number of jobs from a single
 pre-requisite. This is simply a case of listing the jobs under the trigger
@@ -432,7 +432,7 @@ commands:
         classes => state_repaired("did_my_job");
 ```
 
-# Self-healing workflows
+## Self-healing workflows
 
 To apply CFEngine's self-healing concepts to workflow scheduling, we can imagine
 the concept of a convergent workflow, i.e. one that, if we repeat everything a
@@ -444,14 +444,14 @@ think in terms of repeatable sustainable outcomes and fault-tolerance.
 
 Beware however, one-off jobs cannot be made convergent, because they only have a single chance to succeed. It is a question of business process design whether you design workflows to be sustainable and repeatable, or whether you trust the outcome of a single shot process. Using the persistent classes in CFEngine together with the if-elapsed locks to send signals between hosts, it is simple and automatic to make convergent self-healing workflows.
 
-# Long workflow chains
+## Long workflow chains
 
 Long workflow chains are those which involve more than one trigger. These can be
 created by repeating the pattern above several times. Note however, that each
 link in the chain introduces a new level of uncertainty and potential failure.
 In general, we would not recommend creating workflows with long chains.
 
-# Summary of distributed scheduling
+## Summary of distributed scheduling
 
 Distributed scheduling is about tying together jobs to create a workflow across
 multiple machines. It introduces a level of fragility into system automation.

--- a/resources/additional-topics/file-content.markdown
+++ b/resources/additional-topics/file-content.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# From boiler-plates to convergent file editing
+## From boiler-plates to convergent file editing
 
 Many configuration management systems allow you to determine configuration file
 content to some extent, usually by over-writing files with boiler-plate
@@ -31,7 +31,7 @@ being predictable. There are three ways to approach this problem. You should
 choose the simplest approach that solves your problem and try not to be
 prejudiced by what you have done before.
 
-# Why is file editing difficult?
+## Why is file editing difficult?
 
 File content is not made up of simple data objects like permission flags or
 process tables: files contain compound, ordered structures (known as grammars)
@@ -48,7 +48,7 @@ formats.
 Remember that all changes are adapted to your local context and implemented at
 the final destination by cf-agent.
 
-# What does file editing involve?
+## What does file editing involve?
 
 
 There are several ways to approach desired state management of file contents:
@@ -77,7 +77,7 @@ of the file you are starting from. Approach 3 is generally required when
 adapting configuration files provided by a third party, since the basic content
 is determined by them.
 
-# Three approaches to managing files
+## Three approaches to managing files
 
 * Copying a finished file template into place
 
@@ -89,7 +89,7 @@ is determined by them.
 
 * Making delta changes to someone else's file
 
-## Copying a finished file template into place
+### Copying a finished file template into place
 
 Use this approach if a simple substution of data will solve the problem in all
 contexts.
@@ -111,7 +111,7 @@ files:
 }
 ```
 
-## Contextual adaptation of a file template
+### Contextual adaptation of a file template
 
 There are several approaches here:
 
@@ -232,7 +232,7 @@ nameserver 2
 nameserver 3
 ```
 
-## Example file template
+### Example file template
 
 ```
 [%CFEngine any:: %]
@@ -266,7 +266,7 @@ nameserver 3
 [%CFEngine END %]
 ```
 
-## Combining copy with template expansion
+### Combining copy with template expansion
 
 What about getting your template to the end-host? To convergently copy a file
 from a source and then edit it, use the following construction with a staging
@@ -297,7 +297,7 @@ replace_patterns:
 }
 ```
 
-## Making delta changes to someone else's file
+### Making delta changes to someone else's file
 
 Edit a file with multiple promises about its state, when you do not want to
 determine the entire content of the file, or if it is unsafe to make unilateral
@@ -349,7 +349,7 @@ delete_lines:
 }
 ```
 
-# Constructing files from promises
+## Constructing files from promises
 
 
 Making finished templates for files and filling in the blanks using variables is
@@ -416,7 +416,7 @@ host$ more /tmp/my_result
    e.g Mary had a little lamb
 ```
 
-## Adding a line here and there
+### Adding a line here and there
 
 A simple file like this could also be defined in-line, without a separate
 template file:
@@ -455,7 +455,7 @@ files:
 }
 ```
 
-## Lists inline
+### Lists inline
 
 
 Here is a more complicated example, that includes list expansion. List expansion
@@ -693,7 +693,7 @@ insert_lines:
 }
 ```
 
-# Editing bundles
+## Editing bundles
 
 Unlike other aspects of configuration, promising the content of a single file
 object involves possibly many promises about the atoms within the file. Thus we
@@ -732,7 +732,7 @@ insert_lines:
 
 * Expressing expand_template as promises
 
-## Standard library methods for simple editing
+### Standard library methods for simple editing
 
 You may choose to write your own editing bundles for specific purposes; you can
 also use ready-made templates from the standard library for a lot of purposes.
@@ -789,7 +789,7 @@ Some other examples of the standard editing methods are:
 
 You find these in the documentation for the COPBL.
 
-## Expressing expand_template as promises
+### Expressing expand_template as promises
 
 As on CFEngine 3.3.0, CFEngine has a new template mechanism to make it easier to
 encode complex file templates. These templates map simply to edit_line bundles
@@ -820,7 +820,7 @@ bundle agent example
 }
 ```
 
-# Choosing an approach to file editing
+## Choosing an approach to file editing
 
 There are two decisions to make when choosing how to manage file content:
 
@@ -835,7 +835,7 @@ How can the desired content be constructed from the necessary source(s)?
 Use the simplest approach that requires the smallest number of promises to solve
 the problem.
 
-# Pitfalls to watch out for in file editing
+## Pitfalls to watch out for in file editing
 
 File editing is different from most other kinds of configuration promise because
 it is fundamentally an order dependent configuration process. Files contain

--- a/resources/additional-topics/hierarchies.markdown
+++ b/resources/additional-topics/hierarchies.markdown
@@ -8,7 +8,7 @@ tags: [overviews, special topics, guide]
 
 Authority, Structure and Inheritance
 
-# What is a hierarchy?
+## What is a hierarchy?
 
 A hierarchy is an organizational structure with tree-like branches. In a
 hierarchy, parts of the system belong to other parts, like collections of boxes
@@ -47,7 +47,7 @@ that point will disconnect the network.
 
 ![Single points of failure](./single-points-of-failure.png)
 
-# How hierarchy compares to sets
+## How hierarchy compares to sets
 
 Some languages (like Object Oriented languages) are designed to enforce
 hierarchies. CFEngine is not one of these. In CFEngine you can build a hierarchy
@@ -119,7 +119,7 @@ prevents that. The key is to notice that the `.` (dot) operator is really an
 intersection of sets (AND)1, and that this is a much more flexible notion than
 hierarchy.
 
-# Classes are sets
+## Classes are sets
 
     `Sets, sets, sets ... all you ever think about it sets!`
 
@@ -178,7 +178,7 @@ bundle agent example
 Thus the English speakers are those entities belonging to the USA `AND` the UK,
 excepting presumably the legal department.
 
-# For and against hierarchies
+## For and against hierarchies
 
 Hierarchies are good at bringing consistency. They are bad at scaling. They
 bring consistency because the root node acts as a single point of authority,
@@ -200,7 +200,7 @@ CFEngine does not encourage it.
 This document tries to show how to use hierarchy sensibly and usefully to
 simplify rather than to enforce authority.
 
-# Inheritance and its forms
+## Inheritance and its forms
 
 Perhaps the most popular application of hierarchy is to use the property of
 having a single-point of definition to avoid maintaining the same information in
@@ -232,7 +232,7 @@ the users or consumers of the information are so-called derived classes.
 We can use the notion of inheritance at different levels within CFEngine. These
 are a matter of using the global scope with bundle names.
 
-## Inheritance of classes/sets
+### Inheritance of classes/sets
 
 We can aggregate smaller classes into larger ones (yielding multiple inheritance
 of class attributes):
@@ -253,13 +253,13 @@ bundle agent example
 Note that CFEngine naturally forms a bottom-up hierarchy, never a top-down
 hierarchy.
 
-## Inheritance of class definitions
+### Inheritance of class definitions
 
 CFEngine divides its promises into bundles that have private classes and
 variables. Bundles called `common bundles` define global classes, so they are
 automatically inherited by all other bundles.
 
-## Inheritance of variable definitions
+### Inheritance of variable definitions
 
 Variables in CFEngine are globally accessible, but you must say what bundle you
 are talking about by writing '$(bundle.scalar)' or '@(bundle.list)'. If you omit
@@ -285,7 +285,7 @@ The policy ifdefined means that CFEngine will ignore the foreign list if it does
 not exist. This means you can include a number of lists from other bundles to
 extend the behviour of your own, if they are provided.
 
-## Inheritance of bundles
+### Inheritance of bundles
 
 Bundles cannot really be merged like sets, but since they make promises you can
 use them.
@@ -323,7 +323,7 @@ of authority, by promising to use the inheritance, you have subordinated your
 input to the source - or voluntarily given up the right to say no to whatever
 you have subscribed to. You have implicity trusted them.
 
-# Expressing `is a` or `has a`
+## Expressing `is a` or `has a`
 
 Let us re-emphasize for the record that CFEngine is not intended to be an object
 oriented system. At CFEngine we do not believe that Object Orientation is a good
@@ -359,7 +359,7 @@ bundle agent example
 }
 ```
 
-# How to organize your organization
+## How to organize your organization
 
 Faced with the choice of how to classify systems, where does one begin? This is
 the dilemma that programmers face when designing new software, and if they make
@@ -389,7 +389,7 @@ system operations? Some alternatives include:
 However, you choose to begin, you can further subdivide these major categories
 by simply ANDing with other categories.
 
-# Applications of hierarchy
+## Applications of hierarchy
 
 When a small organization uses CFEngine, machines are often configured by "what
 they do" or "what they have" (e.g., they "are a webserver" or they "have

--- a/resources/additional-topics/iteration.markdown
+++ b/resources/additional-topics/iteration.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is iteration?
+## What is iteration?
 
 Iteration is about repeating operations in a list. In CFEngine, iteration is
 used to make a number of related promises, that fall into a pattern based on
@@ -25,7 +25,7 @@ scalar reference `$(list)`, then CFEngine understands this to mean, take each
 scalar item in the list and repeat the current promise, replacing the instance
 with elements of the list in turn.
 
-# Iterated promises
+## Iterated promises
 
 Consider the following set of promises to report on the values of four separate
 monitor values:
@@ -88,7 +88,7 @@ the semantics of the reports from the list of monitoring variables.
 Admittedly, this is a simple example, but if you understand this one, we can
 continue with more compelling examples.
 
-# Iterating across multiple lists
+## Iterating across multiple lists
 
 
 Although iteration is a powerful concept in and of itself, CFEngine can iterate
@@ -124,7 +124,7 @@ report on `value_rootprocs`, `av_rootprocs`, and `dev_rootprocs`, followed next 
 leftward lists are iterated over completely before going to the next value in
 the rightward lists.
 
-# Iterating over nested lists
+## Iterating over nested lists
 
 Recall that CFEngine iterates over complete promise units, not small parts of a
 promise. Let's look at an example that could show a common misunderstanding.
@@ -206,7 +206,7 @@ it will generate an error, because the second promise on the variable monvars
 will overwrite the value promised in the first promise! All that we will see in
 the reports are the second definition of the monvars list.
 
-# Fixing iterating across nested lists
+## Fixing iterating across nested lists
 
 ```cf3
 bundle agent iteration3c
@@ -234,7 +234,7 @@ you. Note that we had to explicitly refer to the two variables that we created:
 `$(monvars_in)` and `$(monvars_out)`, and specifying more will get very messy
 very quickly. However, the next sections show an easier-to-read workaround.
 
-# Iterating across multiple lists, revisted
+## Iterating across multiple lists, revisted
 
 When a list variable is referenced as a scalar variable (that is, when the list
 variable is referenced as `$(list)`) instead of as a list (using `@(list)`),
@@ -298,7 +298,7 @@ commands:
 }
 ```
 
-# Nesting promises workaround
+## Nesting promises workaround
 
 Recall the problem of nesting iterations, we can now see how to repair our
 error. The key is to ensure that there is a distinct and unique promise created
@@ -398,7 +398,7 @@ reports:
 However, this is wrong. We cannot use `@(io_vars)`, because `io_vars` is not a
 list, it is an array! You can only use the `@` dereferencing sigil on lists.
 
-# The power of iteration in CFEngine
+## The power of iteration in CFEngine
 
 Iteration and abstraction are power tools in CFEngine. In closing, consider the
 following simple and straightforward example, where we report on all of the
@@ -457,7 +457,7 @@ reports promise and intelligent use of lists and arrays, we are able to report
 on every one of the 3*(8+2*18+4*2)==156 monitor variables. And to change the
 format of every report, we will only have a single statement to change.
 
-# Summary of iteration
+## Summary of iteration
 
 Used judiciously and intelligently, iterators are a powerful way of expressing
 patterns. They enable you to abstract out the concepts from the nitty-gritty

--- a/resources/additional-topics/itil.markdown
+++ b/resources/additional-topics/itil.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What it ITIL?
+## What it ITIL?
 
 
 The IT Infrastructure Library (ITIL) is a set of human management practices
@@ -31,7 +31,7 @@ end, depends on the concrete instances of ITIL processes in the respective
 scenario.
 
 
-# ITIL history and versions
+## ITIL history and versions
 
 
 ITIL has its roots in the early 1990s, and since then was subject to numerous
@@ -49,7 +49,7 @@ improvement. In the following, we run through the basics of both versions,
 highlighting commonalities and differences.
 
 
-# Basics
+## Basics
 
 
 ITIL is an attempt to implement theDeming Quality Circleas a model for continual
@@ -77,7 +77,7 @@ ITIL means to follow the method of Plan-Do-Check-Act:
   In response to the measured quality, start activities for future improvements.
   This step leads into the Plan phase again.
 
-# Version 2
+## Version 2
 
 Although ITIL version 3 was released during the summer of 2007, it is its
 predecessor that has achieved great acceptance amongst IT service providers all
@@ -93,7 +93,7 @@ Financial Management) are supposed to cover IT service planning like resource
 and quality planning, as well as strategies for customer relationships or
 dealing with unpredictable situations.
 
-# Version 3
+## Version 3
 
 
 In 2007, version 2 was replaced by its successor version 3, aimed at covering
@@ -116,7 +116,7 @@ principles. The five service life cycle stages accordant to versin 3 are:
  * Continual Service Improvement: Methods for planning and achieving service
    improvements at regular intervals
 
-# Service orientation and ITIL
+## Service orientation and ITIL
 
 Why service and process orientation? What is ITIL trying to do? As we mentioned
 in the introduction, the `top down hierarchical` control view of human
@@ -132,7 +132,7 @@ predictable and reliable face for business and IT operations so that customers
 feel confidence, without choking the creative process that lies behind the
 design of new services.
 
-# CFEngine in ITIL clothes?
+## CFEngine in ITIL clothes?
 
 CFEngine users are interested in the ability to manage, i.e. cope with system
 configuration in a way that enables a business or other organization to do its
@@ -163,7 +163,7 @@ services are these? We have to think a little sideways to see the relationship.
   enough people and machines to support the processes of deploying and following
   CFEngine's progress.
 
-# ITIL processes
+## ITIL processes
 
 The following management processes are in scope of ITILv3:
 
@@ -224,20 +224,20 @@ The following management processes are in scope of ITILv3:
 
 * Continual Service Improvement
 
-## Service Strategy
+### Service Strategy
 
 Service strategy is about deciding what services you want to formalize. In other
 words, what parts of your system administration tasks can you wrap in procedural
 formalities to ensure that they are carried out most excellently?
 
-## Service Design
+### Service Design
 
 Service design is about deciding what will be delivered, when it will be
 delivered, how quickly the service will respond to the needs of its clients etc.
 This stage is probably something of a mental barrier to those who are not used
 to service-oriented thinking.
 
-## Service Operation
+### Service Operation
 
 How shall we support service operation? What resources do we need to provide,
 both human and computer? Can we be certain of having these resources at all
@@ -247,7 +247,7 @@ possible misunderstanding. Successfully running services can be more complex at
 task than we expect, and this is why it is useful to formalize them in an ITIL
 fashion.
 
-## Continual Service Improvement
+### Continual Service Improvement
 
 Continual improvement is quite self-explanatory. We are obviously interested in
 learning from our mistakes and improving the quality and efficiency by which we
@@ -259,9 +259,7 @@ mean regular on a time-scale that is representative for the service being
 provided, e.g. reviews once per week, once per month? No one can tell you about
 your needs. You have to decide this from local needs.
 
-
-# Tool support
-
+## Tool support
 
 In the field of tool support for IT Service Management accordant to ITIL,
 various white papers and studies have been published. In addition, there are
@@ -294,7 +292,7 @@ we must show:
 * Which parts (processes and activities) of ITIL can be (partially) supported by
   CFEngine, and how.
 
-# Which ITIL processes apply to CFEngine?
+## Which ITIL processes apply to CFEngine?
 
 ![ITIL and CFEngine](./itil-cfengine.png)
 
@@ -353,7 +351,7 @@ provision.
 * Incident and problem management
 * Service Level Management (SLM)
 
-## ITIL Configuration Management (CM)
+### ITIL Configuration Management (CM)
 
 Perhaps the most obvious example is the term configuration management.
 
@@ -422,7 +420,7 @@ system.
 
 {% endcomment %}
 
-## Change management in the enterprise
+### Change management in the enterprise
 
 If we make changes to a technical installation, or even a business process, this
 can affect the service that customers experience. Major changes to service
@@ -434,7 +432,7 @@ The decision to make a change is more than a single person should usually make
 alone (see the CFEngine Special Topics Guide on Change Management). ITIL
 recommends an advisory board for changes.
 
-## Change management vs convergence
+### Change management vs convergence
 
 We should be especially careful here to decide what we mean by change. ITIL
 assumes a traditional model of change management that CFEngine does not
@@ -462,7 +460,7 @@ goal to be achieved between changes. An important thing to realize about
 including changes of external circumstances is that you cannot "roll back"
 circumstances to an earlier state - they are beyond our control.
 
-## Release management
+### Release management
 
 
 A release in ITIL is a collection of authorized changes to a system. One part of
@@ -476,7 +474,7 @@ scheduling the release, i.e. everything to do with the release process except
 the explicit implementation of it. Deployment or rollout describe the physical
 movement of configuration items as part of a release process.
 
-## Incident and problem management
+### Incident and problem management
 
 ITIL distinguishes betweenincidentsandproblems. An incident is an event that
 might be problematic, but in general would observe incidents over some length of
@@ -498,7 +496,7 @@ Changes can introduce new incidents. An integrated way to make the tracking of
 cause and effect easier is clearly helpful. If we are the cause of our own
 problems, we are in trouble!
 
-## Service Level Management (SLM)
+### Service Level Management (SLM)
 
 
 Also loosely referred to as Quality of Service. This is the process of making
@@ -506,7 +504,7 @@ sure that Service Level Promises are kept, or Service Level Agreements (SLA) are
 adhered to. We must assess the impact of changes on the ability to deliver on
 promises.
 
-# Using CFEngine to implement ITIL objectives
+## Using CFEngine to implement ITIL objectives
 
 
 How does CFEngine fit into the management of a service organization? There are
@@ -532,7 +530,7 @@ CFEngine can manage itself as well as other resources: itself, its software, its
 policy and the resulting plans for the configuration of the system. In other
 words, CFEngine is itself part of the infrastructure that we might change.
 
-# How can CFEngine or promises help an enterprise
+## How can CFEngine or promises help an enterprise
 
 
 Traditional methods of managing IT infrastructure involve working from crisis to
@@ -575,7 +573,7 @@ generality by making this assumption.
 In other words, OO is a design methodology with a philosophy, whereas promises
 are a model for an arbitrary existing system.
 
-# What is maintenance?
+## What is maintenance?
 
 Maintenance is a process that ITIL does not formally spend any time on
 explicitly, but it is central to real-world quality control.
@@ -606,7 +604,7 @@ against. CFEngine is about this process of Maintenance. We call it "convergence"
 to the ideal state, where the ideal state is the specified version release. Keep
 this in mind as you read about ITIL change management.
 
-# ITIL and CFEngine Summary
+## ITIL and CFEngine Summary
 
 ITIL is about processes designed mainly for humans in a workplace. It represents
 a service oriented view of an organization, and as such is more scalable than
@@ -615,13 +613,13 @@ technology, thus there is some overlap of concepts. Indeed CFEngine is a good
 tool for implementing and assisting in certain ITIL processes, but we believe
 that no automation system can really support what ITIL is about.
 
-# Appendix A ITIL glossary
+## Appendix A ITIL glossary
 
 This section lists some of the many terms from ITIL, especially the ISO/IEC
 20000 version of the text, and offers some comments and translations into common
 CFEngine terminology.
 
-## Active Monitoring
+### Active Monitoring
 
 Monitoring of a configuration item or IT service that uses automated regular
 checks to discover the current status.
@@ -630,7 +628,7 @@ CFEngine performs programmed checks of all of its promises each time cfagent is
 started. Cfagent is, in a sense, an active monitor for a set of promises that
 are described in its configuration file.
 
-## Availability
+### Availability
 
 The ability of a component or service to perform its required function.
 
@@ -642,7 +640,7 @@ in a network when remotely connecting to cfservd.
 Intermittency = Successful~ attempts / Total Attempts This is a measurement that
 cfagent automatically makes.
 
-## Alert
+### Alert
 
 A warning that a threshold has been reached, something has changed or a failure
 has occurred.
@@ -650,7 +648,7 @@ has occurred.
 A CFEngine alert fits this description quite well. Most alerts are user-defined,
 but a few are side effects of certain configuration rules.
 
-## Audit
+### Audit
 
 A formal inspection and verification to check whether a standard or set of
 guidelines is being followed.
@@ -660,7 +658,7 @@ However, the data generated by this extra logging information could be collected
 and used in a more detailed examination of CFEngine's operations, suitable for
 use in a formal inspection (e.g. for compliance).
 
-## Baseline
+### Baseline
 
 A snapshot of the state of a service or an individual configuration item at a
 point in time
@@ -671,7 +669,7 @@ the changes we make will not generally be relative to an existing configuration.
 CFEngine encourages users to define the final state (regardless of initial
 state).
 
-## Benchmark
+### Benchmark
 
 The recorded state of something at a specific point in time.
 
@@ -680,14 +678,14 @@ understanding of a "benchmark" is that of a standardized performance measurement
 under special conditions. CFEngine regularly records state and performance data
 in a variety of ways, for example when making file copies.
 
-## Capability
+### Capability
 
 The ability of someone or something to carry out an activity.
 
 CFEngine does not use this concept specifically. The notion of a capability is
 terminology used in role-based access control.
 
-## Change record
+### Change record
 
 A record containing details of which configuration items are affected and how
 they are affected by an authorized change.
@@ -703,7 +701,7 @@ daemon. Both of the foregoing messages give only a simple message of actual
 changes. An "audit" promise is a promise to record extensive details about the
 process that cfagent undergoes in its checking of other promises.
 
-## Chronological Analysis
+### Chronological Analysis
 
 An analysis based on the timeline of recorded events (used to help identify
 possible causes of problems).
@@ -711,7 +709,7 @@ possible causes of problems).
 A timeline analysis could easily be carried out based on audit information,
 system logs and cfenvd behavioural records.
 
-## Configuration
+### Configuration
 
 A group of configuration items (CI) that work together to deliver an IT service.
 
@@ -719,7 +717,7 @@ A configuration is the current state of resources on a system. This is, in
 principle, different from the state we would like to achieve, or what has been
 promised.
 
-## Configuration Item (CI)
+### Configuration Item (CI)
 
 A component of an infrastructure which is or will be under the control of
 configuration management.
@@ -727,7 +725,7 @@ configuration management.
 A configuration item is any object making a promise in CFEngine. We often speak
 of the promise object, or "promiser".
 
-## Configuration Management Database (CMDB)
+### Configuration Management Database (CMDB)
 
 Database containing all the relevant details of each configuration item and
 details of the important relationships between them.
@@ -738,7 +736,7 @@ In the future, CFEngine 3 is likely to extend the notion of promises to allow
 more general records of the CMDB kind, but only to the extent that they can be
 verified autonomically.
 
-## Document
+### Document
 
 Information and its supporting medium.
 
@@ -746,14 +744,14 @@ ITIL originally considered a document to be only a container for information. In
 version 3 it considers also the medium on which the data are recorded, i.e. both
 the file and the filesystem on which it resides.
 
-## Emergency Change
+### Emergency Change
 
 A change that must be introduced as soon as possible - for example to solve a
 major incident or to implement a critical security patch.
 
 CFEngine has no specific concept for this.
 
-## Error
+### Error
 
 A design flaw or malfunction that causes a failure.
 
@@ -762,7 +760,7 @@ configuration from its promised state. The ITIL meaning of the term would
 translated into "bug in the CFEngine software" or "bug in the promised
 configuration".
 
-## Event
+### Event
 
 A change of state that has significance for the management of a configuration
 item or IT service.
@@ -773,7 +771,7 @@ measure and then classify it into approximate expected states. CFEngine class
 attributes (usually from cfenvd) may be considered as event notifications as
 they change.
 
-## Exception, Failure, Event, Summary
+### Exception, Failure, Event, Summary
 
 An event that is generated when a service or device is currently operating
 abnormally.
@@ -781,7 +779,7 @@ abnormally.
 A state in which configuration policy is violated (could lead to a warning or an
 automated correction).
 
-## Failure
+### Failure
 
 Loss of ability to operate to specification or to deliver the required output.
 
@@ -791,7 +789,7 @@ since promises are only allowed to be made about resources for which we have all
 privileges. Occasionally, environmental issues might interfere and lead to
 failure.
 
-## Incident
+### Incident
 
 Any event that is not expected in normal operations and which might cause a
 degradation of service quality.
@@ -803,7 +801,7 @@ problem on its next invocation round. Events which do not impact promises made
 by CFEngine are of no interest to CFEngine, since autonomy means it cannot be
 responsible for anything beyond its own promises.
 
-## Monitoring
+### Monitoring
 
 Repeated observation of a configuration item, IT service or process in order to
 detect events and ensure that the current status is known.
@@ -811,7 +809,7 @@ detect events and ensure that the current status is known.
 CFEngine incorporates a number of different kinds of monitoring, including
 monitoring of kept configuration-promises and passive monitoring of behaviour.
 
-## Passive Monitoring
+### Passive Monitoring
 
 Monitoring of a configuration item or IT service that relies on an alert or
 notification to discover the current status.
@@ -821,7 +819,7 @@ related behaviour and learns about it. It assumes that there is likely to be a
 weekly periodicity in the data in order to best handle its statistical
 inference.
 
-## Policy
+### Policy
 
 Formally documented management expectations and intentions. Policies are used to
 direct decisions, and to ensure consistent and appropriate development and
@@ -836,7 +834,7 @@ make identical promises. Any resource can play a number of roles. Decisions in
 CFEngine are made entirely on the basis of the result of monitoring a host
 environment.
 
-## Proactive Monitoring, Problem, Policy, Summary
+### Proactive Monitoring, Problem, Policy, Summary
 
 Monitoring that looks for patterns of events to predict possible future
 failures.
@@ -844,7 +842,7 @@ failures.
 All CFEngine monitoring is pro-active in the sense that it can lead to automated
 follow-up actions.
 
-## Problem
+### Problem
 
 Unknown underlying cause of one or more incidents.
 
@@ -852,7 +850,7 @@ A repeated deviation from policy that suggests a change of policy or specific
 counter-measures. A promise needs to be reconsidered or new promises are
 required.
 
-## Promise, Reactive Monitoring, Problem, Summary
+### Promise, Reactive Monitoring, Problem, Summary
 
 ITIL does not define this term, although promises are deployed in various ways -
 for instance in terms of cooperation, communication interfaces within or between
@@ -863,7 +861,7 @@ A promise in CFEngine is a single rule in the CFEngine language. The promiser is
 the resource whose properties are described, and the promisee is implicitly the
 CFEngine monitor.
 
-## Reactive Monitoring
+### Reactive Monitoring
 
 Monitoring that takes action in response to an event - for example submitting a
 batch job when the previous job completes, or logging an incident when an error
@@ -876,14 +874,14 @@ any observable condition discernable by CFEngine's monitor. CFEngine is not
 usually considered event driven however, since it does not react "as soon as
 possible" but at programmed intervals.
 
-## Record
+### Record
 
 Information in readable form that is maintained by the service provider about
 operations.
 
 A log entry or database item.
 
-## Recovery
+### Recovery
 
 Returning a Configuration Item or an IT service to a working state. Recovering
 of an IT service often includes recovering data to a known consistent state.
@@ -894,7 +892,7 @@ principle) on every invocation. CFEngine always returns to a known state, due to
 the property of "convergence". There is no distinction between the concepts of
 repair, recovery or remediation.
 
-## Remediation
+### Remediation
 
 Recovery to a known state after a failed change or release.
 
@@ -907,7 +905,7 @@ repair, recovery or remediation.
 However, this concept is like the notion of "rollback" which often involves a
 more significant restoration of a system from backup. This is discussed later.
 
-## Repair
+### Repair
 
 The replacement or correction of a failed configuration item.
 
@@ -917,14 +915,14 @@ principle) on every invocation. CFEngine always returns to a known state, due to
 the property of "convergence". There is no distinction between the concepts of
 repair, recovery or remediation.
 
-## Release, Request for Change, Repair, Summary
+### Release, Request for Change, Repair, Summary
 
 A collection of new or changed configuration items that are introduced together.
 
 An instantiation of the entire CFEngine system under a specific version of a
 policy, i.e. a specific set of promises.
 
-## Request for Change
+### Request for Change
 
 A form to be completed requesting the need for change. This is to be followed
 up.
@@ -937,7 +935,7 @@ sense is part of an organizational process that goes beyond CFEngine's level of
 jurisdiction. This is an example of what ITIL adds to the autonomous CFEngine
 model.
 
-## Abandon Autonomy?
+### Abandon Autonomy?
 
 Why not simply abandon autonomy of machines if this seems to interfere with the
 need for organizational change? There are good reasons why autonomy is the
@@ -951,14 +949,14 @@ discusses how they will change their pattern of collaboration. There is no point
 in this process at which it is necessary for one of the systems to give up its
 autonomy.
 
-## Resilience
+### Resilience
 
 The ability of a configuration item or IT service to resist failure or to
 recover quickly following a failure.
 
 CFEngine's purpose is to make a system resilient to unpredictable change.
 
-## Restoration
+### Restoration
 
 Actions taken to return an IT service to the users after repair and recovery
 from an incident.
@@ -973,7 +971,7 @@ However, this concept seems to suggest a more catastrophic failure which often
 involves a more significant restoration of a system from backup. This is
 discussed later.
 
-## Role
+### Role
 
 A set of responsibilities, activities and authorities granted to a person or a
 team. Roles are defined in processes.
@@ -983,13 +981,13 @@ type of role played by the class is determined by the nature of the promise they
 make. e.g. a promise to run a web server would naturally lead to the role "web
 server".
 
-## Service desk
+### Service desk
 
 Interface between users and service provider.
 
 A help desk. This is not formally part of CFEngine's tool set.
 
-## Service Level Agreement
+### Service Level Agreement
 
 A written agreement between the service provider that documents agreed services,
 levels and penalties for non-compliance.
@@ -999,11 +997,11 @@ of those promises by the client. If we assume that the users are satisfied with
 out policies, then an SLA can be interpreted as a combination of a configuration
 policy (configuration service promises), and the CFEngine execution schedule.
 
-## Service Management
+### Service Management
 
 The management of services.
 
-## Warning
+### Warning
 
 An event that is generated when a service or device is approaching its threshold.
 

--- a/resources/additional-topics/modularity.markdown
+++ b/resources/additional-topics/modularity.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is modularity?
+## What is modularity?
 
 Modularity is the ability to separate concerns within a total process, and hide
 the details of the different concerns in different containers. In CFEngine, this
@@ -15,7 +15,7 @@ and turned into generic components that offer a service. We often talk about
 black boxes, grey boxes or white boxes depending on the extent to which the user
 of a service can see the details within the containers.
 
-# What is orchestration?
+## What is orchestration?
 
 Orchestration is the ability to coordinate many different processes in time and
 space, around a system, so that the sum of those processes yields a harmonious
@@ -36,7 +36,7 @@ information from the policy server (conductor). The coupling between the agents
 is weak - there is slack that makes the behaviour robust to minor errors in
 communication or timing.
 
-# How does CFEngine deal with modularity and orchestration?
+## How does CFEngine deal with modularity and orchestration?
 
 Promise Theory provides simple principles for hiding details: agents are
 considered to reveal a kind of service interface to peers, that is advertised by
@@ -55,13 +55,13 @@ might also need to cooperate because they provide services to one another. The
 principles are the same in both cases, but the confusion between them is
 typically the reason why large systems do not scale well.
 
-# Levels of policy abstraction
+## Levels of policy abstraction
 
 CFEngine offers a number of layers of abstraction. The most fundamental atom in
 CFEngine is the promise. Promises can be made about many system issues, and you
 described in what context promises are to be kept.
 
-## Menu level
+### Menu level
 
 At this high level, a user `selects' from a set of pre-defined `services' (or
 bundles in CFEngine parlance). In commercial editions, users may view the set of
@@ -98,7 +98,7 @@ The resulting menu of services can be browsed in the Mission Portal interface.
 A human-readable Service Catalogue generated from technical specifications shows
 what goals are being attended to automatically
 
-## Bundle level
+### Bundle level
 
 At this level, users can switch on and off predefined features, or re-use
 standard methods, e.g. for editing files:
@@ -117,7 +117,7 @@ bundlesequence => {
 
 The set of bundles that can be selected from is extensible by the user.
 
-## Promise level
+### Promise level
 
 This is the most detailed level of configuration, and gives full convergent
 promise behaviour to the user. At this promise level, you can specificy every
@@ -146,7 +146,7 @@ files:
 }
 ```
 
-## Spread-sheet level (data-driven)
+### Spread-sheet level (data-driven)
 
 CFEngine community and commercial editions support a kind of spreadsheet. In a
 spreadsheet approach, you create only the data to be inserted into predefined
@@ -154,7 +154,7 @@ promises. The data are entered in tabular form, and may be browsed in the web
 interface. This form of entry is preferred in some environments, especially on
 the Windows platform.
 
-# Is CFEngine patch-oriented or package-oriented?
+## Is CFEngine patch-oriented or package-oriented?
 
 Some system management products are patching systems. They package lumps of
 software and configuration along with scripts. If something goes wrong they
@@ -171,7 +171,7 @@ one bit of a flag in each file in a set of directories. The power to express
 sophisticated patterns is what makes CFEngine's approach both non-intrusive and
 robust.
 
-# High level services in CFEngine
+## High level services in CFEngine
 
 CFEngine is designed to handle high level simplicity (without sacrificing low
 level capability) by working with configuration patterns, after all
@@ -250,7 +250,7 @@ services:
 }
 ```
 
-# Hiding details
+## Hiding details
 
 Resource abstraction, or hiding system specific details inside a kind of
 grey-box, is just another service as far as CFEngine is concerned - and we
@@ -297,7 +297,7 @@ decisions, meaning that minor changes in operating system versions require basic
 re-coding of the software. CFEngine does not make decisions for you without your
 permission.
 
-# Black, grey and white box encapsulation in CFEngine
+## Black, grey and white box encapsulation in CFEngine
 
 CFEngine's ability to abstract system decisions as promises also applies to
 bundles of promises. After all, we can package promises as bumper compendia for
@@ -358,7 +358,7 @@ commands:
 }
 ```
 
-# Bulk operations are handled by repeating patterns over lists
+## Bulk operations are handled by repeating patterns over lists
 
 The power of CFEngine is to be able to handle lists of similar patterns in a
 powerful way. You can also wrap the whole experience in a method-bundle, and we
@@ -429,7 +429,7 @@ reports:
 }
 ```
 
-# Ordering operations in CFEngine
+## Ordering operations in CFEngine
 
 Ordering of operations is less important than you probably think. We are taught
 to think of computing as an linear sequence of steps, but this ignores a crucial
@@ -556,7 +556,7 @@ Q: ".../bin/echo four": four
 Q: ".../bin/echo five": five
 ```
 
-# Distributed Orchestration between hosts with CFEngine Enterprise
+## Distributed Orchestration between hosts with CFEngine Enterprise
 
 CFEngine Enterprise edition adds many powerful features to CFEngine, including a
 decentralized approach to coordinating activities across multiple hosts. Some
@@ -570,7 +570,7 @@ location, but this has two problems:
 With CFEngine Nova there are are both decentralized network approaches to this
 problem, and probabilistic methods that do not require the network at all.
 
-## Basic communication methods for orchestration
+### Basic communication methods for orchestration
 
 The two examples below illustrate the basic syntax constructions for
 communication using systems. We can pass class data and variable data between
@@ -739,7 +739,7 @@ R: GOT knowedge scalar value of my test_scalar, can expand variables here - cflu
 R: GOT persistent scalar 1
 ```
 
-## Run job or reboot only if n out m systems are running
+### Run job or reboot only if n out m systems are running
 
 The ability to base local promises on global knowledge seems superficially
 attractive in some cases. As a strategy this way of thinking requires a lot of
@@ -825,7 +825,7 @@ access:
 }
 ```
 
-# The self-healing chain - inverse Dominoes
+## The self-healing chain - inverse Dominoes
 
 A self-healing chain is the opposite of a dominoe event. If a part of the chain
 is `down', it will be revived. If these events depend on one another, then the
@@ -1017,7 +1017,7 @@ R: tier 3 is ok
 R: The Tower is standing
 ```
 
-## A Domino sequence
+### A Domino sequence
 
 A different kind of orchestration is a domino cascade, that starts from some
 initial trigger, and causes a change in one host that causes a change in the
@@ -1207,7 +1207,7 @@ chain multiplied by the run-interval, if normal cf-execd splaytime is used.
 Without any splaying, the average time will be the run interval multiplied by
 the chain length. The completion time could be increased by using cf-runagent.
 
-## A Chinese Dragon star pattern
+### A Chinese Dragon star pattern
 
 The Chinese dragon darts back and forth between different hosts, forming a chain
 of events, and leaving a trail behind it. This pattern is much like the Domino

--- a/resources/additional-topics/open-nebula.markdown
+++ b/resources/additional-topics/open-nebula.markdown
@@ -6,14 +6,14 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is Open Nebula?
+## What is Open Nebula?
 
 Open Nebula is an Open Source framework for Cloud Computing that aims to become
 an industry standard. The project is designed to be scalable and offer
 compatibility with Amazon EC2 the Open Cloud Computing Interface (OCCI). Open
 Nebula is used as a cloud controller in a number of large private clouds.
 
-# How can CFEngine work with Open Nebula?
+## How can CFEngine work with Open Nebula?
 
 CFEngine is a lifecycle management tool that can be integrated with a Cloud
 Computing framework in a number of ways. Of the four phases of the computer
@@ -48,7 +48,7 @@ Open Nebula's focus is on managing the deployment and recycling of the computing
 infrastructure. CFEngine picks up where Open Nebula leaves off and manages the
 dynamic lifecycle of software, applications and runtime state.
 
-# Example setup
+## Example setup
 
 This guide is based on an example setup provding a framework to demonstrate how
 CFEngine can be used to automate Open Nebula configuration. The following
@@ -70,7 +70,7 @@ cluster-node.
 
 ![Open Nebula Architecture](./open-nebula-architecture.png)
 
-##  Installation and dependancy configuration
+###  Installation and dependancy configuration
 
 
 First we can classify the physical machines in this case by IP address:
@@ -286,7 +286,7 @@ Next we will create a directory to hold our virtual machine images:
         create => "true";
 ```
 
-## Open Nebula environment configuration
+### Open Nebula environment configuration
 
 Create the oneadmin bashrc file containing the ONE_XMLRPC environment variable with appropriate permissions:
 
@@ -368,7 +368,7 @@ files:
 		contain => oneadmin;
 ```
 
-## Network configuration
+### Network configuration
 
 Before we can create virtual networks we must configure our node controller
 interfaces. In this example we will bridge a virtual interface (vbr0) with eth0.
@@ -442,7 +442,7 @@ commands:
         contain => oneadmin;
 ```
 
-## Virtual machine template configuration
+### Virtual machine template configuration
 
 This follows the same pattern as virtual network setup. First we create the
 template file:
@@ -485,7 +485,7 @@ If we increase the leases in our network template each time the onevm create
 command is issued a new virtual machine will be launched up to the number of
 available leases.
 
-## Open Nebula commands
+### Open Nebula commands
 
 It should be noted that commands, particularly those that are Open Nebula
 specific, will be run each time cf-agent is executed. Since this goes against
@@ -495,7 +495,7 @@ successfully executed. If this file exists then (or if its time stamp is
 older/newer than some value) the machines classified as having to run the
 command loose that class preventing future execution.
 
-## Virtual machine configuration
+### Virtual machine configuration
 
 With CFEngine preinstalled in our virtual machine image we can configure our
 generic image to the required specification on the fly. For community edition we
@@ -515,7 +515,7 @@ with a meaningful name:
 Now we have define webserver we can simply apply promises to it as if it was any
 other machine for example:
 
-## Webserver in Open Nebula
+### Webserver in Open Nebula
 
 First we install apache:
 
@@ -562,7 +562,7 @@ files:
      action => u_immediate;
 ```
 
-# Open Nebula summary
+## Open Nebula summary
 
 Now we have a convergent self-repairing, Open Nebula powered private cloud! The
 main benefits in combining CFEngine and Open Nebula are the facility to increase

--- a/resources/additional-topics/orchestration.markdown
+++ b/resources/additional-topics/orchestration.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is organizational complexity?
+## What is organizational complexity?
 
 Complexity is a measure of the amount of information needed to explain
 something. It implies a "mental cost" (and therefore a time and monetary cost)
@@ -25,7 +25,7 @@ complexity of a system is commonly defined as the length of the shortest
 document that fully describes it. A complex system requires a long document to
 capture its workings; a simple system requires only a short document.
 
-# What is federation?
+## What is federation?
 
 A federation is a pattern of organization obtained by merging a number of
 initially independent parts. The implication is that the resulting organization
@@ -83,7 +83,7 @@ known as "voluntary cooperation" used by CFEngine, which implies that each
 federated part must effectively choose which inputs it is willing to use from
 external parties.
 
-# The authority paradox
+## The authority paradox
 
 For some, the idea that an organization should be built on voluntary cooperation
 sounds wrong. However, no matter how much we might crave certainty of outcome,
@@ -136,7 +136,7 @@ No central management of either enterprise or computers can force individual
 agents to comply with their wishes, without their low level consent. The
 perception of authority is thus only a fiction1.
 
-# The social contract
+## The social contract
 
 Social contracts lie at the heart of all human and computer organizations. For
 computers these contracts may be as simple as "access control settings",
@@ -159,7 +159,7 @@ worst lead to the disconnection of decision making from expertise.
 Low level autonomy is a cost saving strategy that reduces the overhead of
 management and improves the link between expertise and action.
 
-# Service oriented federation
+## Service oriented federation
 
 Service oriented means business oriented. Let us now consider what this means
 for IT configuration. In particular, how should a CFEngine configuration be
@@ -167,7 +167,7 @@ structured for an efficient organization? In the examples below, we shall adopt
 a service oriented view, in which an enterprise is organized as a set of
 federated entities, some of whom depend on each other for services.
 
-# Each part disconnected, providing services
+## Each part disconnected, providing services
 
 Each federated entity manages its own promises.cf file. Each has, in effect, its
 own independent CFEngine configuration.
@@ -178,7 +178,7 @@ The configuration may still use resources provided by other entities' machines,
 but the other entities have no influence on the set of promises used to maintain
 any given one.
 
-# Disconnected parts inheriting a single baseline
+## Disconnected parts inheriting a single baseline
 
 A more common model for federation is to have a baseline constitution for all
 the parts of the enterprise defined by an umbrella organization. We can refer to
@@ -246,7 +246,7 @@ must be that their own special promises must not conflict with the global
 infrastructure proposal. So all requirements are met without the need for
 central enforcement.
 
-# Handling multiple sources
+## Handling multiple sources
 
 Consider briefly the case in which there is more than one entity offering
 promise proposals. If a part of the federation serves two masters (see
@@ -261,7 +261,7 @@ make the decision about which of the sources to obey.
 The possiblity of conflict is easily handled in this architecture, because it
 recognizes that the federated entity must be the final arbiter of confict.
 
-# Global assurance
+## Global assurance
 
 The lack of a hierarchy has not made information chaotic and disorganized. It
 has only provided a simple means of scalability and conflict resolution.
@@ -279,7 +279,7 @@ federation according to a single standard3.
 CFEngine allows single-point-of-coodination monitoring of hosts by a variety of
 mechanisms, so that compliance can be assured.
 
-# Merging and dividing enterprises
+## Merging and dividing enterprises
 
 Autonomy makes the merging and division of enterprise systems trivial. It is the
 way to enable out-sourcing and in-sourcing.
@@ -298,7 +298,7 @@ house of cards. Service-oriented systems are loosely coupled. By keeping the
 internal organization of systems as far as possible like independent service
 atoms, you facilitate reorganization by merging and division.
 
-# Why federation does not reduce predictabilty
+## Why federation does not reduce predictabilty
 
 The fear that many traditionalists have of federated management is that they
 cannot be certain of the outcome unless they have absolute authority. This fear
@@ -332,7 +332,7 @@ Rules of thumb for scalable management:
 
 * Trust lowers costs.
 
-# The benefits of federated management
+## The benefits of federated management
 
 Hierarchy is familiar, but not essential. A hierarchy is only a so-called
 "spanning tree" for a more general network of relationships. It may be thought

--- a/resources/additional-topics/stigs.markdown
+++ b/resources/additional-topics/stigs.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# CFEngine STIGs compliance example
+## CFEngine STIGs compliance example
 
 The Security Technical Implementation Guides (STIGs) are a method for
 standardized secure installation and maintenance of computer software and
@@ -61,7 +61,7 @@ compliance. What are the different parts of this policy example?
   Explanation of the various policy components (human readable), referencing
   STIGs requirements id (such as ```GEN000560```)
 
-# What are the terms of this STIGs example?
+## What are the terms of this STIGs example?
 
 This example policy is intended as a practical example of how to achieve STIGs
 compliance within the CFEngine framework. It is provided on an as-is basis, with

--- a/resources/additional-topics/teamwork.markdown
+++ b/resources/additional-topics/teamwork.markdown
@@ -6,7 +6,7 @@ sorting: 80
 tags: [overviews, special topics, guide]
 ---
 
-# What is team-work?
+## What is team-work?
 
 
 Team work is a collaboration between individuals with different skills. It is
@@ -39,7 +39,7 @@ Team work and policy design for inter-host cooperation are closely related. Use
 promises as a tool to explain to the individuals in a team which individual is
 responsible for what role, and to what extent.
 
-# Creative roles
+## Creative roles
 
 
 M. Belbin, a researcher in teamwork has identified nine abilities or roles
@@ -80,7 +80,7 @@ ourselves: how can we use the freedom to organize into specialized teams to
 maximize human creativity, while passing hard work over to machines. Solving
 this problem is what CFEngine is about.
 
-# Delegating roles in a collaboration
+## Delegating roles in a collaboration
 
 
 We need to delegate responsiblity to divide and conquer a problem, both when


### PR DESCRIPTION
Don't use h1 within documentation articles, h1 is automatically added, it's the title of the page. First heading should be h2 and so on.

Ticket: ENT-9968
Signed-off-by: Ole Herman Schumacher Elgesem <ole@northern.tech>
(cherry picked from commit 1b58e536ab4072333d447b6cd73801bc42abbbf9)