### PR TITLE
CFE-2724: Removed incorrect claim that `arglist` attribute preserve spaces

### DIFF
--- a/reference/promise-types/commands.markdown
+++ b/reference/promise-types/commands.markdown
@@ -125,12 +125,9 @@ So in the example above the command would be:
 **Description:** Allows to separate the arguments to the command from the
 command itself, using an slist.
 
-As with `args`, it is convenient to separate command and arguments.
-With `arglist` you can use a slist directly instead of having to
-provide a single string as with `args`. That's particularly useful
-when there are embedded spaces and quotes in your arguments, but also
-when you want to get them directly from a slist without going through
-`join()` or other functions.
+As with `args`, it is convenient to separate command and arguments.  With
+`arglist` you can use a slist directly instead of having to provide a single
+string as with `args`.
 
 The `arglist` is **appended** to `args` if that's defined, to preserve
 backwards compatibility.


### PR DESCRIPTION
Removed incorrect claim that the `arglist` attribute of the `commands` promise type, preserves spaces in the arguments. I believe it is meant to be that way, but it currently isn't. Thus we can revert this commit from master, once it is implemented in one of the next minor releases. For patch releases, we should keep the behaviour as is, since it may be relied upon.