### PR TITLE
ENT-10250: Now mentiones lack of square bracket glob expression support on Windows (3.18)

### DIFF
--- a/reference/functions/findfiles.markdown
+++ b/reference/functions/findfiles.markdown
@@ -18,7 +18,7 @@ match all files in one directory that end in `.cf` but it won't search
 across directories.  `*/*.cf` on the other hand will look two levels
 deep.
 * `?` matches a single letter
-* `[a-z]` matches any letter from `a` to `z`
+* `[a-z]` matches any letter from `a` to `z` (not yet supported on Windows)
 
 This function, used together with the `bundlesmatching` function,
 allows you to do dynamic inputs and a dynamic bundle call chain.
@@ -26,6 +26,7 @@ allows you to do dynamic inputs and a dynamic bundle call chain.
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.
+- Bracket expressions are currently not supported on Windows. `[a-z]` will be interpreted as its raw string representation on Windows.
 
 **Example:**
 

--- a/reference/functions/findfiles_up.markdown
+++ b/reference/functions/findfiles_up.markdown
@@ -23,11 +23,12 @@ shells:
 
 * `*` matches any filename or directory
 * `?` matches a single letter
-* `[a-z]` matches any letter from `a` to `z`
+* `[a-z]` matches any letter from `a` to `z` (not yet supported on Windows)
 
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.
+- Bracket expressions are currently not supported on Windows. `[a-z]` will be interpreted as its raw string representation on Windows.
 
 [%CFEngine_function_attributes(path, glob, level)%]
 


### PR DESCRIPTION
Ticket: ENT-10250
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 2df0a7f5bcb22a27a848bd4c7f05a241e4c099f2)