### PR TITLE
ENT-10250, ENT-10490: Added warning against using glob patterns on Windows (3.21)

### DIFF
--- a/reference/functions/findfiles.markdown
+++ b/reference/functions/findfiles.markdown
@@ -17,7 +17,7 @@ match all files in one directory that end in `.cf` but it won't search
 across directories.  `*/*.cf` on the other hand will look two levels
 deep.
 * `?` matches a single letter
-* `[a-z]` matches any letter from `a` to `z` (not yet supported on Windows)
+* `[a-z]` matches any letter from `a` to `z`
 
 This function, used together with the `bundlesmatching` function,
 allows you to do dynamic inputs and a dynamic bundle call chain.
@@ -25,7 +25,6 @@ allows you to do dynamic inputs and a dynamic bundle call chain.
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.
-- Bracket expressions are currently not supported on Windows. `[a-z]` will be interpreted as its raw string representation on Windows.
 
 **Example:**
 

--- a/reference/functions/findfiles.markdown
+++ b/reference/functions/findfiles.markdown
@@ -22,6 +22,13 @@ deep.
 This function, used together with the `bundlesmatching` function,
 allows you to do dynamic inputs and a dynamic bundle call chain.
 
+**WARNING:**
+- The current implementation of glob patterns on Windows contains bugs.
+  Therefore, we strongly recommend using the `!windows::` class guard
+  expression to safeguard against any use of the function on Windows platforms.
+  Rest assured, we are actively working on resolving these issues and improving
+  its functionality.
+
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.

--- a/reference/functions/findfiles_up.markdown
+++ b/reference/functions/findfiles_up.markdown
@@ -24,6 +24,13 @@ shells:
 * `?` matches a single letter
 * `[a-z]` matches any letter from `a` to `z`
 
+**WARNING:**
+- The current implementation of glob patterns on Windows contains bugs.
+  Therefore, we strongly recommend using the `!windows::` class guard
+  expression to safeguard against any use of the function on Windows platforms.
+  Rest assured, we are actively working on resolving these issues and improving
+  its functionality.
+
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.

--- a/reference/functions/findfiles_up.markdown
+++ b/reference/functions/findfiles_up.markdown
@@ -22,12 +22,11 @@ shells:
 
 * `*` matches any filename or directory
 * `?` matches a single letter
-* `[a-z]` matches any letter from `a` to `z` (not yet supported on Windows)
+* `[a-z]` matches any letter from `a` to `z`
 
 **Notes:**
 
 - Brace expansion is not currently supported, `{x,y,anything}` will not match `x` or `y` or `anything`.
-- Bracket expressions are currently not supported on Windows. `[a-z]` will be interpreted as its raw string representation on Windows.
 
 [%CFEngine_function_attributes(path, glob, level)%]
 


### PR DESCRIPTION
- Revert "Merge pull request #3085 from larsewi/glob"
- Added warning against using glob patterns on Windows

Back-ported from https://github.com/cfengine/documentation/pull/3088