### PR TITLE
ENT-10903: Fixed rendering for list (3.23)

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -884,6 +884,7 @@ body agent control
 ```
 
 **Notes:**
+
 * A value of `0` means no locking, all promises will be executed each execution if in context. This also disables function caching.
 * This is not a reliable way to control frequency over a long period of time.
 * Locks provide simple but weak frequency control.


### PR DESCRIPTION
Without a blank line, the list renders all on a single line.

(cherry picked from commit e4ebc3718619c75e17f4249140bd34154c618991)