### PR TITLE
ENT-10903: Fixed rendering for list (3.21)

### DIFF
--- a/reference/components/cf-agent.markdown
+++ b/reference/components/cf-agent.markdown
@@ -894,6 +894,7 @@ ifelapsed   => "180";   # 3 hours
 ```
 
 **Notes:**
+
 * A value of `0` means no locking, all promises will be executed each execution if in context. This also disables function caching.
 * This is not a reliable way to control frequency over a long period of time.
 * Locks provide simple but weak frequency control.


### PR DESCRIPTION
Without a blank line, the list renders all on a single line.

(cherry picked from commit e4ebc3718619c75e17f4249140bd34154c618991)