### PR TITLE
Docker fixups

### DIFF
--- a/generator/build/README.md
+++ b/generator/build/README.md
@@ -14,14 +14,13 @@ You will need to have the following repos checked out:
 * enterprise (used for changelog)
 * masterfiles (used to document masterfies)
 * documentation
-* documentation/generator (this repo)
 
 Usage
 -----
 
 If you have buildah installed:
 
-1. clone the above repos
+1. clone the above repos (run `clone.sh`)
 
 2. export the following env variables:
 
@@ -30,11 +29,11 @@ If you have buildah installed:
 
 	* `$PACKAGE_JOB` - where to take CFEngine HUB package from,
 	  a dir at http://buildcache.cloud.cfengine.com/packages/,
-	  usually testing-pr
+	  usually `testing-pr`
 
 	* `$PACKAGE_UPLOAD_DIRECTORY` - where to take CFEngine HUB package from,
 	  a dir at http://buildcache.cloud.cfengine.com/packages/testing-pr/,
-	  for example, jenkins-master-nightly-pipeline-943
+	  for example, `jenkins-master-nightly-pipeline-943`
 
 	* `$PACKAGE_BUILD` - RELEASE of the build to be downloaded, usually 1
 

--- a/generator/build/clone.sh
+++ b/generator/build/clone.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for repo in core nova enterprise masterfiles documentation; do
+    git clone "git@github.com:cfengine/$repo.git"
+done

--- a/generator/build/install.sh
+++ b/generator/build/install.sh
@@ -70,9 +70,9 @@ gem install jekyll-asset-pipeline --version 0.1.6
 gem install closure-compiler --version 1.1.8
 gem install yui-compressor --version 0.9.6
 gem install albino --version 1.3.3
+gem install execjs --version 1.4.0
 gem install redcarpet --version 2.2.2
 gem install uglifier --version 1.3.0
-gem install execjs --version 1.4.0
 gem install sanitize --version 2.0.3
 
 cat > /tmp/jekyll-0.12.1-cfengine.patch <<EOF

--- a/generator/build/main.sh
+++ b/generator/build/main.sh
@@ -15,7 +15,7 @@ export PACKAGE_UPLOAD_DIRECTORY=$3
 export PACKAGE_BUILD=$4
 
 export JOB_TO_UPLOAD=$PACKAGE_JOB
-export FLAG_FILE_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/PACKAGES_HUB_x86_64_linux_ubuntu_18/core-commitID"
+export FLAG_FILE_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/PACKAGES_HUB_x86_64_linux_ubuntu_22/core-commitID"
 export NO_OUTPUT_DIR=1
 
 env
@@ -74,7 +74,7 @@ done
 wget -O- $FLAG_FILE_URL
 
 echo "Detecting version"
-HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_18
+HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_22
 HUB_DIR_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/$HUB_DIR_NAME/"
 HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/deb/!d;s/.*"\([^"]*\.deb\)".*/\1/')"
 


### PR DESCRIPTION
I tried the docker build and failed. These changes are my quick try for improvement.

- Tidied documentation for readability
- Added clone.sh script to make it easier to get the necessary repos
- Moved installation of execjs before redcarpet to avoid pulling it in with the wrong version as a dependency
```
Building native extensions.  This could take a while...
unable to convert "\xC3" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII for COPYING, skipping
unable to convert "\xC3" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII for COPYING, skipping
Successfully installed redcarpet-2.2.2
1 gem installed
Installing ri documentation for redcarpet-2.2.2...
Installing RDoc documentation for redcarpet-2.2.2...
ERROR:  Error installing uglifier:
        execjs requires Ruby version >= 2.5.0.
The command '/bin/sh -c bash -x /install.sh' returned a non-zero code: 1
```