### PR TITLE
Added fallback fonts to reduce differences while red hat font is loading (3.21)

### DIFF
--- a/generator/_assets/styles/less/article.less
+++ b/generator/_assets/styles/less/article.less
@@ -1,5 +1,5 @@
 article {
-  font-family: "Red Hat Text";
+  font-family: "Red Hat Text", Arial, sans-serif;
   div.article {
     font-weight: 400;
     font-size: 16px;

--- a/generator/_assets/styles/less/base.less
+++ b/generator/_assets/styles/less/base.less
@@ -7,7 +7,7 @@
 }
 
 html {
-  font-family: "Red Hat Display";
+  font-family: "Red Hat Display", Arial, sans-serif;
   font-size: 62.5%; // 1 rem = 10 px
   max-width: 100%;
   overflow-x: hidden;
@@ -206,7 +206,7 @@ table {
 }
 
 code {
-  font-family: "Red Hat Mono";
+  font-family: "Red Hat Mono", "Courier New", monospace;
   background: @gray-100;
   border-radius: 4px;
   padding: 0 5px;
@@ -389,7 +389,7 @@ pre {
   overflow: visible;
   overflow-y: hidden;
   padding: 2rem;
-  font-family: 'Menlo';
+  font-family: 'Menlo', "Courier New", monospace;
   font-style: normal;
   font-weight: 400;
   font-size: 13px;

--- a/generator/_assets/styles/less/header.less
+++ b/generator/_assets/styles/less/header.less
@@ -203,7 +203,7 @@
         font-weight: 400;
         font-size: 12px;
         line-height: 20px;
-        font-family: 'Roboto';
+        font-family: 'Roboto', Arial, sans-serif;
       }
 
       &:after {
@@ -228,7 +228,7 @@
         font-size: 14px;
         line-height: 16px;
         border-top: 1px solid #d1d2d34a;
-        font-family: 'Roboto';
+        font-family: 'Roboto', Arial, sans-serif;
 
         &:first-child {
           border: none;

--- a/generator/_assets/styles/less/home.less
+++ b/generator/_assets/styles/less/home.less
@@ -3,7 +3,7 @@
     color: @blue-800;
     font-size: 3.2rem;
     line-height: 3.6rem;
-    font-family: "Red Hat Display";
+    font-family: "Red Hat Display", Arial, sans-serif;
   }
 
   &-top {

--- a/generator/_assets/styles/less/pages.less
+++ b/generator/_assets/styles/less/pages.less
@@ -69,7 +69,7 @@
   .TOC {
     position: sticky;
     top: 12px;
-    font-family: "Roboto";
+    font-family: "Roboto", Arial, sans-serif;
 
     @media @desktop-down {
       max-width: 28rem;


### PR DESCRIPTION
See:
https://github.com/cfengine/website/pull/890

Signed-off-by: Ole Herman Schumacher Elgesem <ole@northern.tech>
(cherry picked from commit 9f8e73a7f71a3dcf6ef2ed1a6fc7347829b2de1f)
