### PR TITLE
Added redirects for /licenses

### DIFF
--- a/redirects.conf
+++ b/redirects.conf
@@ -32,6 +32,12 @@ RewriteRule ^/docs/master/guide-getting-started-with-cfengine-build.html$ /docs/
 RewriteRule ^/docs/master/resources-additional-topics-glossary.html$ /docs/master/overview-glossary.html [R]
 RewriteRule ^/docs/3.21/resources-additional-topics-glossary.html$ /docs/3.21/overview-glossary.html [R]
 
+# Redirect for easy access to 3rd party license information:
+RewriteRule ^/licenses/?$ /docs/master/legal.html [R]
+RewriteRule ^/docs/master/licenses/?$ /docs/master/legal.html [R]
+RewriteRule ^/docs/3.21/licenses/?$ /docs/3.21/legal.html [R]
+RewriteRule ^/docs/3.18/licenses/?$ /docs/3.18/legal.html [R]
+
 # Redirect for the new location of supported platforms:
 RewriteRule ^/docs/3.21/guide-latest-release-supported-platforms.html /docs/3.21/release-notes-supported-platforms.html [R]
 


### PR DESCRIPTION
This can be useful as a nice shorthand to share in other documents.
Especially if we'd like to move some of this information around
later.
