### PR TITLE
Improvements to legal and licenses page

### DIFF
--- a/legal.markdown
+++ b/legal.markdown
@@ -31,14 +31,11 @@ CFEngine includes the following 3rd party libraries and components:
 * [libcrypto](https://www.openssl.org/docs/crypto/crypto.html) under the [LGPL](https://api.libssh.org/master/libcrypto_8h_source.html)
 * [libexpat](https://sourceforge.net/projects/expat/) under the [MIT License](https://opensource.org/licenses/mit-license.html)
 * [libpam](https://www.linux-pam.org) as per the [copyright notice](https://git.fedorahosted.org/cgit/linux-pam.git/tree/Copyright)
-* [libvirt](https://libvirt.org/FAQ.html) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
 * [libxml2](https://xmlsoft.org/FAQ.html) under the [MIT license](https://opensource.org/licenses/mit-license.html)
 * [LMDB](https://symas.com/mdb/) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [OpenSSL](https://www.openssl.org) under the [OpenSSL license](https://www.openssl.org/source/license.html)
 * [PCRE](https://www.pcre.org) under the [PCRE license](https://www.pcre.org/licence.txt)
 * [PEG](https://piumarta.com/software/peg/) under the MIT license
-* [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://www.opensource.org/licenses/lgpl-license.html)
-* [TokyoCabinet](https://fallabs.com/tokyocabinet/) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)
 * [Zlib](https://www.zlib.net) under the [zlib license](https://www.zlib.net/zlib_license.html)
 
 ### Enterprise
@@ -63,10 +60,17 @@ CFEngine includes the following 3rd party libraries and components:
 * [PHP](https://php.net) under the [PHP license version 3.01](https://www.php.net/license/3_01.txt)
 * [php-apc](https://pecl.php.net/package/APC) under the [PHP License](https://www.php.net/license/3_01.txt)
 * [PostgreSQL, libecpg and libecpg_compat](https://www.postgresql.org) under the [PostgreSQL License](https://opensource.org/licenses/postgresql)
-* [redis](https://redis.io) under the [three clause BSD license](https://redis.io/topics/license)
 * [rsync](https://rsync.samba.org) under the [GPLv3](https://rsync.samba.org/GPL.html)
 * [Twitter Bootstrap Framework](https://getbootstrap.com) under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [Bootstrap Icons](https://icons.getbootstrap.com) under the [MIT license](https://github.com/twbs/icons/blob/main/LICENSE.md)
 * [underscore.js](https://underscorejs.org) under the MIT license
+
+### Optional, non-default dependencies
+
+These dependencies are not a part of the packages we build and distribute, but specific users or customers may build CFEngine with support for custom functionality and with custom software dependencies:
+
+* [libvirt](https://libvirt.org/FAQ.html) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
+* [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://www.opensource.org/licenses/lgpl-license.html)
+* [TokyoCabinet](https://fallabs.com/tokyocabinet/) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)
 
 <!--- * [Piwik.js](https://piwik.org) under the [Simplified BSD license](https://piwik.org/free-software/bsd/) -->

--- a/legal.markdown
+++ b/legal.markdown
@@ -32,26 +32,26 @@ These dependencies are used by both CFEngine Community (Open Source) as well as 
 * [libacl](https://savannah.nongnu.org/projects/acl) under the [LGPL](https://git.savannah.gnu.org/cgit/acl.git/tree/include/acl.h)
 * [libattr](https://savannah.nongnu.org/projects/attr) under the [LGPL](https://git.savannah.gnu.org/cgit/attr.git/tree/include/libattr.h)
 * [libcrypto](https://www.openssl.org/docs/crypto/crypto.html) under the [LGPL](https://api.libssh.org/master/libcrypto_8h_source.html)
-* [libexpat](https://sourceforge.net/projects/expat/) under the [MIT License](https://opensource.org/licenses/mit-license.html)
+* [libexpat](https://sourceforge.net/projects/expat/) under the [MIT license](https://opensource.org/licenses/mit-license.html)
 * [libpam](https://www.linux-pam.org) as per the [copyright notice](https://git.fedorahosted.org/cgit/linux-pam.git/tree/Copyright)
 * [libxml2](https://xmlsoft.org/FAQ.html) under the [MIT license](https://opensource.org/licenses/mit-license.html)
 * [LMDB](https://symas.com/mdb/) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [OpenSSL](https://www.openssl.org) under the [OpenSSL license](https://www.openssl.org/source/license.html)
 * [PCRE](https://www.pcre.org) under the [PCRE license](https://www.pcre.org/licence.txt)
 * [PEG](https://piumarta.com/software/peg/) under the MIT license
-* [Zlib](https://www.zlib.net) under the [zlib license](https://www.zlib.net/zlib_license.html)
+* [zlib](https://www.zlib.net) under the [zlib license](https://www.zlib.net/zlib_license.html)
 
 ### Enterprise only dependencies
 
 In addition to the common dependencies listed above, these dependencies are specific to CFEngine Enterprise:
 
-* [Angular.js](https://angularjs.org) through [MIT Licence](https://github.com/angular/angular.js/blob/master/LICENSE)
+* [Angular.js](https://angularjs.org) under the [MIT license](https://github.com/angular/angular.js/blob/master/LICENSE)
 * [Apache](https://httpd.apache.org) under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [APR and APR-util](https://apr.apache.org) under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-* [Chosen](https://harvesthq.github.io/chosen/) under the [MIT License](https://github.com/harvesthq/chosen/blob/master/LICENSE.md)
+* [Chosen](https://harvesthq.github.io/chosen/) under the [MIT license](https://github.com/harvesthq/chosen/blob/master/LICENSE.md)
 * [CodeIgniter](https://codeigniter.com/) under the [CodeIgniter License Agreement](https://ellislab.com/codeigniter/user-guide/license.html)
 * [Disphelper](https://disphelper.sourceforge.net) (only Windows) under the [BSD](https://opensource.org/licenses/bsd-license.php)
-* [Flot](https://www.flotcharts.org/) under a [permissive license](https://github.com/flot/flot/blob/master/LICENSE.txt)
+* [Flot](https://www.flotcharts.org/) under the [MIT license](https://github.com/flot/flot/blob/master/LICENSE.txt)
 * [Font Awesome](https://fontawesome.io) by Dave Gandy - https://fontawesome.io/license/
 * [git](https://git-scm.com) under the [GNU General Public License, version 2 (GPLv2)](https://opensource.org/licenses/GPL-2.0)
 * [Glyphicons](https://glyphicons.com/license/) under [Creative Commons Attribution 3.0 Unported (CC BY 3.0)](https://creativecommons.org/licenses/by-sa/3.0/deed.en_US)
@@ -60,13 +60,13 @@ In addition to the common dependencies listed above, these dependencies are spec
 * [libcurl](https://curl.haxx.se) under the [MIT/X derivative license](https://curl.haxx.se/docs/copyright.html)
 * [libmcrypt](https://mcrypt.sourceforge.net) under the [LGPLv2](https://www.opensource.org/licenses/lgpl-license.html)
 * [mod_ssl](https://www.modssl.org) under a BSD style license
-* [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php) under the [MIT License](https://github.com/bshaffer/oauth2-server-php/blob/develop/LICENSE)
+* [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php) under the [MIT license](https://github.com/bshaffer/oauth2-server-php/blob/develop/LICENSE)
 * [OpenLDAP and liblber](https://www.openldap.org) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
-* [PHP](https://php.net) under the [PHP license version 3.01](https://www.php.net/license/3_01.txt)
+* [PHP](https://php.net) under the [PHP license](https://www.php.net/license/3_01.txt)
 * [php-apc](https://pecl.php.net/package/APC) under the [PHP License](https://www.php.net/license/3_01.txt)
 * [PostgreSQL, libecpg and libecpg_compat](https://www.postgresql.org) under the [PostgreSQL License](https://opensource.org/licenses/postgresql)
 * [rsync](https://rsync.samba.org) under the [GPLv3](https://rsync.samba.org/GPL.html)
-* [Twitter Bootstrap Framework](https://getbootstrap.com) under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+* [Twitter Bootstrap Framework](https://getbootstrap.com) under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [Bootstrap Icons](https://icons.getbootstrap.com) under the [MIT license](https://github.com/twbs/icons/blob/main/LICENSE.md)
 * [underscore.js](https://underscorejs.org) under the MIT license
 

--- a/legal.markdown
+++ b/legal.markdown
@@ -25,7 +25,9 @@ The documentation is licensed under a [Creative Commons Attribution-ShareAlike 3
 
 CFEngine includes the following 3rd party libraries and components:
 
-### Community
+### Common dependencies
+
+These dependencies are used by both CFEngine Community (Open Source) as well as CFEngine Enterprise:
 
 * [libacl](https://savannah.nongnu.org/projects/acl) under the [LGPL](https://git.savannah.gnu.org/cgit/acl.git/tree/include/acl.h)
 * [libattr](https://savannah.nongnu.org/projects/attr) under the [LGPL](https://git.savannah.gnu.org/cgit/attr.git/tree/include/libattr.h)
@@ -39,7 +41,9 @@ CFEngine includes the following 3rd party libraries and components:
 * [PEG](https://piumarta.com/software/peg/) under the MIT license
 * [Zlib](https://www.zlib.net) under the [zlib license](https://www.zlib.net/zlib_license.html)
 
-### Enterprise
+### Enterprise only dependencies
+
+In addition to the common dependencies listed above, these dependencies are specific to CFEngine Enterprise:
 
 * [Angular.js](https://angularjs.org) through [MIT Licence](https://github.com/angular/angular.js/blob/master/LICENSE)
 * [Apache](https://httpd.apache.org) under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/legal.markdown
+++ b/legal.markdown
@@ -77,5 +77,3 @@ These dependencies are not a part of the packages we build and distribute, but s
 * [libvirt](https://libvirt.org/FAQ.html) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
 * [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://www.opensource.org/licenses/lgpl-license.html)
 * [TokyoCabinet](https://fallabs.com/tokyocabinet/) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)
-
-<!--- * [Piwik.js](https://piwik.org) under the [Simplified BSD license](https://piwik.org/free-software/bsd/) -->

--- a/legal.markdown
+++ b/legal.markdown
@@ -31,11 +31,11 @@ These dependencies are used by both CFEngine Community (Open Source) as well as 
 
 * [libacl](https://savannah.nongnu.org/projects/acl) under the [LGPL](https://git.savannah.gnu.org/cgit/acl.git/tree/include/acl.h)
 * [libattr](https://savannah.nongnu.org/projects/attr) under the [LGPL](https://git.savannah.gnu.org/cgit/attr.git/tree/include/libattr.h)
-* [libcrypto](https://www.openssl.org/docs/crypto/crypto.html) under the [LGPL](https://api.libssh.org/master/libcrypto_8h_source.html)
+* [libcrypto](https://www.openssl.org/docs/manmaster/man7/crypto.html) under the [LGPL](https://api.libssh.org/master/libcrypto_8h_source.html)
 * [libexpat](https://sourceforge.net/projects/expat/) under the [MIT license](https://opensource.org/licenses/mit-license.html)
-* [libpam](https://www.linux-pam.org) as per the [copyright notice](https://git.fedorahosted.org/cgit/linux-pam.git/tree/Copyright)
-* [libxml2](https://xmlsoft.org/FAQ.html) under the [MIT license](https://opensource.org/licenses/mit-license.html)
-* [LMDB](https://symas.com/mdb/) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
+* [libpam](https://github.com/linux-pam/linux-pam) as per the [copyright notice](https://github.com/linux-pam/linux-pam?tab=License-1-ov-file#readme)
+* [libxml2](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/FAQ) under the [MIT license](https://opensource.org/licenses/mit-license.html)
+* [LMDB](https://www.symas.com/lmdb) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [OpenSSL](https://www.openssl.org) under the [OpenSSL license](https://www.openssl.org/source/license.html)
 * [PCRE](https://www.pcre.org) under the [PCRE license](https://www.pcre.org/licence.txt)
 * [PEG](https://piumarta.com/software/peg/) under the MIT license
@@ -52,28 +52,28 @@ In addition to the common dependencies listed above, these dependencies are spec
 * [CodeIgniter](https://codeigniter.com/) under the [CodeIgniter License Agreement](https://ellislab.com/codeigniter/user-guide/license.html)
 * [Disphelper](https://disphelper.sourceforge.net) (only Windows) under the [BSD](https://opensource.org/licenses/bsd-license.php)
 * [Flot](https://www.flotcharts.org/) under the [MIT license](https://github.com/flot/flot/blob/master/LICENSE.txt)
-* [Font Awesome](https://fontawesome.io) by Dave Gandy - https://fontawesome.io/license/
+* [Font Awesome](https://fontawesome.com/) by Dave Gandy - https://fontawesome.io/license/
 * [git](https://git-scm.com) under the [GNU General Public License, version 2 (GPLv2)](https://opensource.org/licenses/GPL-2.0)
 * [Glyphicons](https://glyphicons.com/license/) under [Creative Commons Attribution 3.0 Unported (CC BY 3.0)](https://creativecommons.org/licenses/by-sa/3.0/deed.en_US)
 * [HighCharts](https://www.highcharts.com/) under the OEM license by HighSoft
-* [jQuery](https://jquery.org) under the [MIT license](https://en.wikipedia.org/wiki/MIT_License)
-* [libcurl](https://curl.haxx.se) under the [MIT/X derivative license](https://curl.haxx.se/docs/copyright.html)
+* [jQuery](https://jquery.com/) under the [MIT license](https://en.wikipedia.org/wiki/MIT_License)
+* [libcurl](https://curl.se) under the [MIT/X derivative license](https://curl.haxx.se/docs/copyright.html)
 * [libmcrypt](https://mcrypt.sourceforge.net) under the [LGPLv2](https://www.opensource.org/licenses/lgpl-license.html)
-* [mod_ssl](https://www.modssl.org) under a BSD style license
+* [mod_ssl](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html) under a BSD style license
 * [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php) under the [MIT license](https://github.com/bshaffer/oauth2-server-php/blob/develop/LICENSE)
 * [OpenLDAP and liblber](https://www.openldap.org) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [PHP](https://php.net) under the [PHP license](https://www.php.net/license/3_01.txt)
 * [php-apc](https://pecl.php.net/package/APC) under the [PHP License](https://www.php.net/license/3_01.txt)
-* [PostgreSQL, libecpg and libecpg_compat](https://www.postgresql.org) under the [PostgreSQL License](https://opensource.org/licenses/postgresql)
+* [PostgreSQL](https://www.postgresql.org) under the [PostgreSQL License](https://opensource.org/licenses/postgresql)
 * [rsync](https://rsync.samba.org) under the [GPLv3](https://rsync.samba.org/GPL.html)
 * [Twitter Bootstrap Framework](https://getbootstrap.com) under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [Bootstrap Icons](https://icons.getbootstrap.com) under the [MIT license](https://github.com/twbs/icons/blob/main/LICENSE.md)
-* [underscore.js](https://underscorejs.org) under the MIT license
+* [underscore.js](https://underscorejs.org) under the [MIT license](https://opensource.org/licenses/mit-license.html)
 
 ### Optional, non-default dependencies
 
 These dependencies are not a part of the packages we build and distribute, but specific users or customers may build CFEngine with support for custom functionality and with custom software dependencies:
 
-* [libvirt](https://libvirt.org/FAQ.html) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
+* [libvirt](https://libvirt.org/) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
 * [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://www.opensource.org/licenses/lgpl-license.html)
-* [TokyoCabinet](https://fallabs.com/tokyocabinet/) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)
+* [TokyoCabinet](https://github.com/hthetiot/Tokyo-Cabinet) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)

--- a/legal.markdown
+++ b/legal.markdown
@@ -8,7 +8,8 @@ alias: legal.html
 
 ## General legal disclaimer
 
-Please note that CFEngine is offered on an "as is" basis without warranty of
+Please note that unless otherwise noted (through a customer agreement or similar)
+CFEngine is offered on an "as is" basis without warranty of
 any kind, and that our products are not error or bug free. To the maximum
 extent permitted by applicable law, CFEngine on behalf of itself and its
 suppliers, disclaims all warranties and conditions, either express or implied,

--- a/legal.markdown
+++ b/legal.markdown
@@ -63,7 +63,6 @@ In addition to the common dependencies listed above, these dependencies are spec
 * [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php) under the [MIT license](https://github.com/bshaffer/oauth2-server-php/blob/develop/LICENSE)
 * [OpenLDAP and liblber](https://www.openldap.org) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [PHP](https://php.net) under the [PHP license](https://www.php.net/license/3_01.txt)
-* [php-apc](https://pecl.php.net/package/APC) under the [PHP License](https://www.php.net/license/3_01.txt)
 * [PostgreSQL](https://www.postgresql.org) under the [PostgreSQL License](https://opensource.org/licenses/postgresql)
 * [rsync](https://rsync.samba.org) under the [GPLv3](https://rsync.samba.org/GPL.html)
 * [Twitter Bootstrap Framework](https://getbootstrap.com) under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
- legal.markdown: Removed redis
- legal.markdown: Added a clarifying sentence to the general legal disclaimer
- legal.markdown: Clarified the sections
- legal.markdown: Fixed small typos, grammar, capitalization
- legal.markdown: Removed commented out unused dependency
- legal.markdown: Fixed several URLS
- legal.markdown: Removed unused dependency
