### PR TITLE
Update legal.markdown

### DIFF
--- a/legal.markdown
+++ b/legal.markdown
@@ -49,17 +49,17 @@ In addition to the common dependencies listed above, these dependencies are spec
 * [Apache](https://httpd.apache.org) under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [APR and APR-util](https://apr.apache.org) under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [Chosen](https://harvesthq.github.io/chosen/) under the [MIT license](https://github.com/harvesthq/chosen/blob/master/LICENSE.md)
-* [CodeIgniter](https://codeigniter.com/) under the [CodeIgniter License Agreement](https://ellislab.com/codeigniter/user-guide/license.html)
+* [CodeIgniter](https://codeigniter.com/) under the [MIT license](https://github.com/bcit-ci/CodeIgniter/blob/develop/license.txt)
 * [Disphelper](https://disphelper.sourceforge.net) (only Windows) under the [BSD license](https://opensource.org/licenses/bsd-license.php)
 * [Flot](https://www.flotcharts.org/) under the [MIT license](https://github.com/flot/flot/blob/master/LICENSE.txt)
 * [Font Awesome](https://fontawesome.com/) by Dave Gandy - https://fontawesome.io/license/
 * [git](https://git-scm.com) under the [GNU General Public License, version 2 (GPLv2)](https://opensource.org/licenses/GPL-2.0)
 * [Glyphicons](https://glyphicons.com/license/) under [Creative Commons Attribution 3.0 Unported (CC BY 3.0)](https://creativecommons.org/licenses/by-sa/3.0/deed.en_US)
 * [HighCharts](https://www.highcharts.com/) under the [OEM license by HighSoft](https://shop.highcharts.com/)
-* [jQuery](https://jquery.com/) under the [MIT license](https://opensource.org/license/mit/)
+* [jQuery](https://jquery.com/) under the [MIT license](https://github.com/jquery/jquery/blob/main/LICENSE.txt)
 * [libcurl](https://curl.se) under the [MIT/X derivative license](https://curl.se/docs/copyright.html)
-* [libmcrypt](https://mcrypt.sourceforge.net) under the [LGPLv2](https://opensource.org/license/lgpl-license-html/)
-* [mod_ssl](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html) under a BSD style license
+* [libmcrypt](https://mcrypt.sourceforge.net) under the [LGPLv2](https://opensource.org/license/lgpl-2-0/)
+* [mod_ssl](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html) under a [BSD style license](http://www.modssl.org/docs/2.8/ssl_overview.html)
 * [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php) under the [MIT license](https://github.com/bshaffer/oauth2-server-php/blob/develop/LICENSE)
 * [OpenLDAP and liblber](https://www.openldap.org) under the [OpenLDAP Public License](https://www.openldap.org/software/release/license.html)
 * [PHP](https://php.net) under the [PHP license](https://www.php.net/license/3_01.txt)
@@ -74,5 +74,5 @@ In addition to the common dependencies listed above, these dependencies are spec
 These dependencies are not a part of the packages we build and distribute, but specific users or customers may build CFEngine with support for custom functionality and with custom software dependencies:
 
 * [libvirt](https://libvirt.org/) under the [LGPL version 2.1](https://www.opensource.org/licenses/lgpl-license.html)
-* [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://www.opensource.org/licenses/lgpl-license.html)
+* [QDBM](https://sourceforge.net/projects/qdbm/) under the [GNU Library or Lesser General Public License 2.0 (LGPLv2)](https://opensource.org/license/lgpl-2-1/)
 * [TokyoCabinet](https://github.com/hthetiot/Tokyo-Cabinet) under the [GNU Lesser General Public License](https://www.opensource.org/licenses/lgpl-license.html)


### PR DESCRIPTION
mod_ssl doesn't have any public code URLs, inside the source it is indeed a BSD-style licence http://www.modssl.org/source/
from `LICENSE` in the latest tarball:

```
  LICENSE

  The mod_ssl package falls under the Open-Source Software label
  because it's distributed under a BSD-style license. The
  detailed license information follows.

  ====================================================================
  Copyright (c) 1998-2007 Ralf S. Engelschall. All rights reserved.
```

codeigniter I took the version we have from composer.json

```
            "name": "codeigniter/framework",
            "version": "3.1.13",
            "source": {
                "type": "git",
                "url": "https://github.com/bcit-ci/CodeIgniter.git",
                "reference": "bcb17eb8ba53a85de154439d0ab8ff1bed047bc9"
            },
            "dist": {
                "type": "zip",
                "url": "https://api.github.com/repos/bcit-ci/CodeIgniter/zipball/bcb17eb8ba53a85de154439d0ab8ff1bed047bc9",
                "reference": "bcb17eb8ba53a85de154439d0ab8ff1bed047bc9",
                "shasum": ""
            },
```