### PR TITLE
Added back parenthesis

### DIFF
--- a/generator/build/main.sh
+++ b/generator/build/main.sh
@@ -76,7 +76,7 @@ wget -O- $FLAG_FILE_URL
 echo "Detecting version"
 HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_22
 HUB_DIR_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/$HUB_DIR_NAME/"
-HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/\.deb/!d;s/.*"\([^"]*\.deb\)".*/\1/'
+HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/\.deb/!d;s/.*"\([^"]*\.deb\)".*/\1/')"
 
 fetch_file "$HUB_DIR_URL$HUB_PACKAGE_NAME" "cfengine-nova-hub.deb" 12
 


### PR DESCRIPTION
Seems like this commit introduced an accident which broke the build:
https://github.com/cfengine/documentation/commit/5a31f28c676cf6d886260082b94184209be3f1ee