### PR TITLE
Adjusted generator/build/main.sh to be more specific about package URLs A package happened to have "deb" in it's commit hash so was included in the downloads list. (3.21)

### DIFF
--- a/generator/build/main.sh
+++ b/generator/build/main.sh
@@ -76,7 +76,7 @@ wget -O- $FLAG_FILE_URL
 echo "Detecting version"
 HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_22
 HUB_DIR_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/$HUB_DIR_NAME/"
-HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/deb/!d;s/.*"\([^"]*\.deb\)".*/\1/')"
+HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/\.deb/!d;s/.*"\([^"]*\.deb\)".*/\1/')"
 
 fetch_file "$HUB_DIR_URL$HUB_PACKAGE_NAME" "cfengine-nova-hub.deb" 12
 


### PR DESCRIPTION
manual cherry pick of 5a31f28c676cf6d886260082b94184209be3f1ee and it's fix: f66019a5d03c565b57c26a5736162d133fc1e566

Ticket: ENT-11149
Changelog: none
