### PR TITLE
ENT-11185: Removed mismatching video for tutorial (3.21)

### DIFF
--- a/examples/tutorials/manage-packages.markdown
+++ b/examples/tutorials/manage-packages.markdown
@@ -5,8 +5,6 @@ published: true
 sorting: 3
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/BUajq2b081E" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 Package management is a critical task for any system administrator. In this
 tutorial we will show you how easy it is to install, manage and remove packages
 using CFEngine.


### PR DESCRIPTION
Somehow a video for templating files with mustache got placed instead of a video
about package management. I could not find the correct old video in a short
search and since it's so old anyway, I decided to just remove it.

Ticket: ENT-11185
Changelog: None
(cherry picked from commit fe46e979c71a157450806f09a77c29f35e3dc537)