### PR TITLE
CFE-4336: Fixed anchor generation when ' - ' is found

### DIFF
--- a/generator/_scripts/cfdoc_linkresolver.py
+++ b/generator/_scripts/cfdoc_linkresolver.py
@@ -99,6 +99,7 @@ def headerToAnchor(header):
     # interpreted by us to not include the header in the link map
     anchor = header.lower()
     anchor = anchor.rstrip("#").rstrip()
+    anchor = anchor.replace("--", "-")
     anchor = anchor.replace(" ", "-")
     anchor = anchor.replace(":", "-")
     anchor = anchor.replace(".", "-")
@@ -109,7 +110,6 @@ def headerToAnchor(header):
     anchor = anchor.replace("(", "-")
     anchor = anchor.replace(")", "-")
     anchor = anchor.replace('"', "")
-    anchor = anchor.replace("--", "-")
     anchor = anchor.lstrip("-").rstrip("-")
     return anchor
 


### PR DESCRIPTION
Because of the order of replace commands ' - ' was becoming '--' incorrectly.
The other side of things where the reference is generated works properly so the links were not matching even though the header and reference matched.

Ticket: CFE-4336
Changelog: none
