### PR TITLE
ENT-11392: Fixed link for meta attribute (3.21)

### DIFF
--- a/reference/promise-types/custom.markdown
+++ b/reference/promise-types/custom.markdown
@@ -71,7 +71,7 @@ These attributes are handled by the agent, and cannot be used inside promise mod
 * `comment`
 * `depends_on`
 * `handle`
-* `meta`
+* [`meta`][Promise types#meta]
 * `with`
 * `classes`
 


### PR DESCRIPTION
The auto-linked target for meta was targeting the meta promise type, but here
the meta attribute was meant. It's global attribute that can be applied to any
promise type and those are documented on the Promise types page in the Common
promise attributes section.

Ticket: ENT-11392
Changelog: None
(cherry picked from commit 2f68477834324df9ed97e9ec22a08846c34ea23d)