### PR TITLE
Removed use of unknown syntax highlighting language conf

### DIFF
--- a/reference/promise-types/custom.markdown
+++ b/reference/promise-types/custom.markdown
@@ -473,7 +473,7 @@ The value may contain anything (including `=` signs) except for newlines and zer
 
 ##### Example requests in line based protocol
 
-```conf
+```
 cf-agent 3.16.0 v1
 
 operation=validate_promise
@@ -494,7 +494,7 @@ log_level=info
 
 ##### Example response in line based protocol
 
-```conf
+```
 git_promise_module 0.0.1 v1 line_based
 
 operation=validate_promise


### PR DESCRIPTION
These end up not being rendered because conf is not a
recognized language.

See:
https://northerntech.atlassian.net/browse/ENT-11407
