### PR TITLE
Fixed detection of markdown frontmatter blocks

### DIFF
--- a/generator/_scripts/cfdoc_metadata.py
+++ b/generator/_scripts/cfdoc_metadata.py
@@ -135,12 +135,17 @@ def processMetaData(file_path, config):
 
     out_file = open(file_path, "w")
     in_header = False
+    did_header = False
     for line in lines:
+        if did_header:
+            out_file.write(line)
+            continue
         if line.find("---") == 0:
             in_header = not in_header
             if not in_header:  # write new tags before header is terminated
                 out_file.write("categories: [%s]\n" % category)
                 out_file.write("alias: %s.html\n" % alias)
+                did_header = True
         if in_header:  # skip hard-coded duplicates
             if line.find("categories:") == 0:
                 continue


### PR DESCRIPTION
Implemented the smallest / safest fix I could think of,
when you're done processing / editing the first frontmatter
block skip the rest, don't look for more in the same file.

This issue would cause code blocks which had triple
dashes at the start of lines (like an RSA public key),
to get some funny looking metadata inserted into them.