### PR TITLE
Custom actions: Reintroduced file label to make it a file component

### DIFF
--- a/web-ui/custom-actions-for-alerts.markdown
+++ b/web-ui/custom-actions-for-alerts.markdown
@@ -106,6 +106,7 @@ When you get this to work as expected on the commmand line, you are ready to upl
 The following Custom action script will log the status and definition of a policy alert to syslog.
 
 ```bash
+[file=cfengine_custom_notification_policy_syslog.sh]
 #!/bin/bash
 
 source $1


### PR DESCRIPTION
Maybe the buggy behavior is only around the newlines, and
this commit could've been done without removing the line?

https://github.com/cfengine/documentation/pull/3258/commits/fba219f045c30909ccfd10caf0b38e0884df5782