### PR TITLE
examples: Fix missing code block

### DIFF
--- a/examples/tutorials/distribute-files-from-a-central-location.markdown
+++ b/examples/tutorials/distribute-files-from-a-central-location.markdown
@@ -47,7 +47,7 @@ These variables provide path definitions for storing and deploying patches.
 
 Add the following variable information to the `masterfiles/def.cf` file:
 
-```cf
+```cf3
 [file=def.cf]
 "dir_patch_store"
   string => "/storage/patches",


### PR DESCRIPTION
Fix missing code block in [1] due to wrong language identifier (`cf` instead of `cf3`)

[1] https://docs.cfengine.com/docs/master/examples-tutorials-distribute-files-from-a-central-location.html#define-locations