### PR TITLE
ENT-11752: Adjusted cf-execd schedule examples to not show ranged minute classes (3.21)

### DIFF
--- a/examples/example-snippets/set_up_hpc_clusters.cf
+++ b/examples/example-snippets/set_up_hpc_clusters.cf
@@ -8,7 +8,7 @@ body executor control
       mailmaxlines => "30";
       # Once per hour, on the hour
 
-      schedule     => { "Min00_05" };
+      schedule     => { "Min00" };
 }
 #######################################################
 

--- a/reference/components/cf-execd.markdown
+++ b/reference/components/cf-execd.markdown
@@ -43,7 +43,7 @@ body executor control
     mailto     => "cfengine@example.org";
     mailfrom   => "cfengine@$(host).example.org";
     smtpserver => "localhost";
-    schedule   => { "Min00_05", "Min30_35" }
+    schedule   => { "Min00", "Min30" }
 }
 ```
 
@@ -308,7 +308,7 @@ function may be affected by changing the `schedule`.
 ```cf3
 body executor control
 {
-schedule => { "Min00", "(Evening|Night).Min15_20", "Min30", "(Evening|Night).Min45_50" };
+schedule => { "Min00", "(Evening|Night).Min15", "Min30", "(Evening|Night).Min45" };
 }
 ```
 

--- a/reference/components/cf-hub.markdown
+++ b/reference/components/cf-hub.markdown
@@ -81,9 +81,9 @@ body hub control
 {
 
   # Collect reports every at the top and half of the hour. Additionally collect
-  # reports during the evening or night between Minute 45 and 50.
+  # reports during the evening or night at Minute 45.
 
-  hub_schedule => { "Min00", "Min30", "(Evening|Night).Min45_50" };
+  hub_schedule => { "Min00", "Min30", "(Evening|Night).Min45" };
 
 }
 ```


### PR DESCRIPTION
Using ranged classes for scheduling can result in multiple executions during
that period of time as cf-execd should wake up once during each minute to
determine if exec_command should be scheduled.

Ticket: ENT-11752
Changelog: None
(cherry picked from commit 15787d517f8ff777d3f2226eb1b41d94ea9ab0f7)