### PR TITLE
Backported examples: Fix missing code block (3.21)

### DIFF
--- a/examples/tutorials/distribute-files-from-a-central-location.markdown
+++ b/examples/tutorials/distribute-files-from-a-central-location.markdown
@@ -47,7 +47,7 @@ These variables provide path definitions for storing and deploying patches.
 
 Add the following variable information to the `masterfiles/def.cf` file:
 
-```cf
+```cf3
 [file=def.cf]
 "dir_patch_store"
   string => "/storage/patches",


### PR DESCRIPTION
(cherry picked from commit cbbfbe9dd378617a727b85526a9e2f277dfd478c)