### PR TITLE
ENT-11847: Fixed wrong filename of private key for Custom SSL certs (3.21)

### DIFF
--- a/web-ui/hub_administration/custom-https-certificate.markdown
+++ b/web-ui/hub_administration/custom-https-certificate.markdown
@@ -8,7 +8,7 @@ When first installed a self-signed ssl certificate is automatically generated
 and used to secure Mission Portal and API communications. You can change this
 certificate out with a custom one by replacing
 `/var/cfengine/httpd/ssl/certs/<hostname>.cert` and
-`/var/cfengine/httpd/ssl/private/<hostname>.cert` where hostname is the fully
+`/var/cfengine/httpd/ssl/private/<hostname>.key` where hostname is the fully
 qualified domain name of the host.
 
 After installing the certificate please make sure that the certificate


### PR DESCRIPTION
The default private key is called
`/var/cfengine/httpd/ssl/private/<hostname>.key`, not
`/var/cfengine/httpd/ssl/private/<hostname>.cert`.

Ticket: ENT-11847
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 8da8fb833624d10f5eb8f2a13d8f8043fa906067)

Back ported from https://github.com/cfengine/documentation/pull/3289
