### PR TITLE
ENT-11309: Updated supported platforms and versions (3.21)

### DIFF
--- a/release-notes/supported-platforms.markdown
+++ b/release-notes/supported-platforms.markdown
@@ -12,11 +12,11 @@ for all supported platforms and [binary packages for popular Linux distributions
 
 ## Hub
 
-| Platform    | Versions                   | Architecture |
-|:-----------:|:--------------------------:|:------------:|
-| CentOS/RHEL | 7, 8.1+, 9                 | x86-64       |
-| Debian      | 9, 10, 11, 12                  | x86-64       |
-| Debian      | 11, 12                         | arm64        |
+| Platform    | Versions                          | Architecture |
+|:-----------:|:---------------------------------:|:------------:|
+| CentOS/RHEL | 7, 8.1+, 9                        | x86-64       |
+| Debian      | 9, 10, 11, 12                     | x86-64       |
+| Debian      | 11, 12                            | arm64        |
 | Ubuntu      | 16.04, 18.04, 20.04, 22.04, 24.04 | x86-64       |
 | Ubuntu      | 22.04, 24.04                      | arm64        |
 
@@ -24,18 +24,18 @@ Any supported host can be a policy server in Community installations of CFEngine
 
 ## Clients
 
-| Platform    | Versions                  | Architectures |
-|:-----------:|:-------------------------:|:-------------:|
-| AIX         | 7.1, 7.2                  | PowerPC       |
-| CentOS/RHEL | 6, 7, 8.1, 9              | x86-64        |
-| Debian      | 9, 10, 11, 12                | x86-64        |
-| Debian      | 11, 12                        | arm64         |
-| HP-UX       | 11.31+                    | Itanium       |
-| SLES        | 12, 15                    | x86-64        |
-| Solaris     | 11                        | UltraSparc    |
+| Platform    | Versions                         | Architectures |
+|:-----------:|:--------------------------------:|:-------------:|
+| AIX         | 7.1, 7.2                         | PowerPC       |
+| CentOS/RHEL | 6, 7, 8.1, 9                     | x86-64        |
+| Debian      | 9, 10, 11, 12                    | x86-64        |
+| Debian      | 11, 12                           | arm64         |
+| HP-UX       | 11.31+                           | Itanium       |
+| SLES        | 12, 15                           | x86-64        |
+| Solaris     | 11                               | UltraSparc    |
 | Ubuntu      | 16.04 18.04, 20.04, 22.04, 24.04 | x86-64        |
 | Ubuntu      | 22.04, 24.04                     | arm64         |
-| Windows     | 2012, 2016, 2019          | x86-64, x86   |
+| Windows     | 2012, 2016, 2019                 | x86-64, x86   |
 
 
 [Known issues][] also includes platform-specific notes.

--- a/release-notes/supported-platforms.markdown
+++ b/release-notes/supported-platforms.markdown
@@ -17,8 +17,8 @@ for all supported platforms and [binary packages for popular Linux distributions
 | CentOS/RHEL | 7, 8.1+, 9                 | x86-64       |
 | Debian      | 9, 10, 11, 12                  | x86-64       |
 | Debian      | 11, 12                         | arm64        |
-| Ubuntu      | 16.04, 18.04, 20.04, 22.04 | x86-64       |
-| Ubuntu      | 22.04                      | arm64        |
+| Ubuntu      | 16.04, 18.04, 20.04, 22.04, 24.04 | x86-64       |
+| Ubuntu      | 22.04, 24.04                      | arm64        |
 
 Any supported host can be a policy server in Community installations of CFEngine.
 
@@ -33,8 +33,8 @@ Any supported host can be a policy server in Community installations of CFEngine
 | HP-UX       | 11.31+                    | Itanium       |
 | SLES        | 12, 15                    | x86-64        |
 | Solaris     | 11                        | UltraSparc    |
-| Ubuntu      | 16.04 18.04, 20.04, 22.04 | x86-64        |
-| Ubuntu      | 22.04                     | arm64         |
+| Ubuntu      | 16.04 18.04, 20.04, 22.04, 24.04 | x86-64        |
+| Ubuntu      | 22.04, 24.04                     | arm64         |
 | Windows     | 2012, 2016, 2019          | x86-64, x86   |
 
 

--- a/release-notes/supported-platforms.markdown
+++ b/release-notes/supported-platforms.markdown
@@ -27,7 +27,7 @@ Any supported host can be a policy server in Community installations of CFEngine
 | Platform    | Versions                         | Architectures |
 |:-----------:|:--------------------------------:|:-------------:|
 | AIX         | 7.1, 7.2                         | PowerPC       |
-| CentOS/RHEL | 6, 7, 8.1, 9                     | x86-64        |
+| CentOS/RHEL | 6, 7, 8.1+, 9                     | x86-64        |
 | Debian      | 9, 10, 11, 12                    | x86-64        |
 | Debian      | 11, 12                           | arm64         |
 | HP-UX       | 11.31+                           | Itanium       |


### PR DESCRIPTION
- Added Ubuntu 24.04 to supported platforms
- Aligned supported platforms tables
