### PR TITLE
ENT-11893: Pegged latest patch release for vagrant environment to 7

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-enterprise-vagrant.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise-vagrant.markdown
@@ -59,13 +59,13 @@ running.
 ## Start the CFEngine Enterprise {{site.cfengine.branch}} Vagrant Environment
 
 Step 1. Download our ready-made Vagrant project
-[tar-file](https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-{{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}/misc/CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}-{{site.cfengine.latest_package_build}}.tar.gz).
+[tar-file](https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-{{site.cfengine.branch}}.7/misc/CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.7-{{site.cfengine.latest_package_build}}.tar.gz).
 
 Step 2. Save and unpack the file anywhere on your drive; this
 creates a Vagrant Project directory.
 
 Step 3. Open a terminal and navigate to the Vagrant Project directory (e.g.
-`/home/user/CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}-{{site.cfengine.latest_package_build}}`, or `C:\CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}-{{site.cfengine.latest_package_build}}`) and enter the following command:
+`/home/user/CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.7-{{site.cfengine.latest_package_build}}`, or `C:\CFEngine_Enterprise_vagrant_quickstart-{{site.cfengine.branch}}.7-{{site.cfengine.latest_package_build}}`) and enter the following command:
 
 ```console
 $ vagrant up
@@ -121,7 +121,7 @@ Last login: Fri Jun 13 18:58:10 2014 from 10.0.2.2
 #### Accessing via GUI
 
 If you launch the virtualbox GUI you should find the vagrant vms named
-`CFEngine Enterprise {{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}-{{site.cfengine.latest_package_build}} hub`, and `CFEngine Enterprise {{site.cfengine.branch}}.{{site.cfengine.latest_patch_release}}-{{site.cfengine.latest_package_build}} agent host001`. Additionally, you can uncomment the `v.gui=true`
+`CFEngine Enterprise {{site.cfengine.branch}}.7-{{site.cfengine.latest_package_build}} hub`, and `CFEngine Enterprise {{site.cfengine.branch}}.7-{{site.cfengine.latest_package_build}} agent host001`. Additionally, you can uncomment the `v.gui=true`
 option in the `Vagrantfile` to have the console gui start with the vms.
 **Note:** There are two `v.gui` settings to uncomment; one for the hub, and one
 for the clients.


### PR DESCRIPTION
The vagrant environment moved to a centos 9 stream base and 3.18 doesn't support
el9, so 3.18.7 was the last vagrant environment built for 3.18.