### PR TITLE
Mention that you can add a module by repo AND commit (3.24)

### DIFF
--- a/getting-started/developing-modules.markdown
+++ b/getting-started/developing-modules.markdown
@@ -89,6 +89,8 @@ cfbs remove promise-type-git-example && cfbs add https://github.com/cfengine/pro
 ```
 
 **Tip:** Replace the URL with your own repository URL when you've create one using the template.
+If you are working on a branch of a repo you can add the commit at the end of the URL with `@<commit>`.
+Remember to update the commit in `cfbs.json` when you push changes to your branch.
 
 Then, build and deploy the project again:
 


### PR DESCRIPTION
This comes in handy when you are working on a PR in a branch such as for cfengine/modules

(cherry picked from commit cbb1e9d0b2e9c47b5c95814e565ccedf591b655d)