### PR TITLE
Update custom_inventory.markdown (3.24)

### DIFF
--- a/examples/tutorials/custom_inventory.markdown
+++ b/examples/tutorials/custom_inventory.markdown
@@ -67,7 +67,7 @@ bundle agent tutorials_inventory_owner
   reports:
     inform_mode::
       "$(this.bundle): Discovered Owner='$(my_owner)'"
-        if => isvaribale( "my_owner" );
+        if => isvariable( "my_owner" );
 }
 bundle agent __main__
 # @brief Run tutorials_inventory_owner if this policy file is the entry


### PR DESCRIPTION
Typo correction:
`if => isvaribale( "my_owner" );`
changed to
`if => isvariable( "my_owner" );`

(cherry picked from commit 91d1bdf0355d50b589bc2e5b0b5285a20c089399)