### PR TITLE
Update write-cfengine-policy.markdown (3.24)

### DIFF
--- a/examples/tutorials/write-cfengine-policy.markdown
+++ b/examples/tutorials/write-cfengine-policy.markdown
@@ -177,7 +177,7 @@ On the policy server you can run the following command to make sure the syntax
 is correct.
 
 ```command
-cf-promises -cf /var/cfengine/masterfiles/my-policy.cf
+cf-promises -cf /var/cfengine/masterfiles/promises.cf
 ```
 
 After some period of time (CFEngine runs by default every 5 minutes), log in to

--- a/examples/tutorials/write-cfengine-policy.markdown
+++ b/examples/tutorials/write-cfengine-policy.markdown
@@ -177,7 +177,7 @@ On the policy server you can run the following command to make sure the syntax
 is correct.
 
 ```command
-cf-agent -cf /var/cfengine/masterfiles/promises.cf
+cf-promises -cf /var/cfengine/masterfiles/my-policy.cf
 ```
 
 After some period of time (CFEngine runs by default every 5 minutes), log in to


### PR DESCRIPTION
Command to check the user policy corrected.

`cf-agent -cf /var/cfengine/masterfiles/promises.cf` changed to
`cf-promises -cf /var/cfengine/masterfiles/promises.cf`