### PR TITLE
CFE-4495: Added docs indicating classesmatching() returns an empty list when no classes match (3.21)

### DIFF
--- a/reference/functions/classesmatching.markdown
+++ b/reference/functions/classesmatching.markdown
@@ -18,6 +18,8 @@ When any tags are given, only the classes with those tags matching the given
 [anchored][anchored] regular expressions are returned. Class tags are set
 using the [`meta`][Promise types#meta] attribute.
 
+If no classes match `name` and any tags given then an empty list is returned.
+
 [%CFEngine_function_attributes(name, tag1, tag2, ...)%]
 
 **Example:**


### PR DESCRIPTION
Changelog: None
Ticket: CFE-4495