### PR TITLE
Fixed isconnectable function docs example

### DIFF
--- a/reference/functions/isconnectable.markdown
+++ b/reference/functions/isconnectable.markdown
@@ -16,10 +16,6 @@ This function checks whether a `hostname`:`port` is connectable within `timeout`
 
 [%CFEngine_include_snippet(isconnectable.cf, #\+begin_src cfengine3, .*end_src)%]
 
-Output:
-
-[%CFEngine_include_snippet(isconnectable.cf, #\+begin_src\s+example_output\s*, .*end_src)%]
-
 **History:**
 
 * Introduced in 3.26.0


### PR DESCRIPTION
I removed the output in the core/example because the example won't succeed in various testing environments.

Ticket: ENT-12753
Changelog: none
