### PR TITLE
Update versions after release of 3.24.2 (3.24)

### DIFF
--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -31,10 +31,10 @@ Template:
     line_numbers: true
 
 vagrant:
-  version: "2.4.3"
+  version: "2.4.5"
 
 virtualbox:
-  version: "7.0.16"
+  version: "7.1.8"
 
 paginate: 500
 

--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -21,7 +21,7 @@ CFE_manuals_version: "3.24"
 cfengine:
   branch: "3.24"
   core_branch: "3.24.x"
-  latest_patch_release: 1
+  latest_patch_release: 2
   latest_package_build: 1
   vagrant_package_build: 1
   masterfiles_branch: "3.24.x"


### PR DESCRIPTION
- Updated latest patch release for 3.24.2 release
- Bumped vagrant from 2.4.3 to 2.4.5 and virtualbox from 7.0.16 to 7.1.8
