### PR TITLE
Fixed codeblock resolver processed JSON code blocks as flags (3.24)

### DIFF
--- a/generator/_scripts/cfdoc_codeblock_resolver.py
+++ b/generator/_scripts/cfdoc_codeblock_resolver.py
@@ -37,7 +37,7 @@ def transform_codeblocks(content):
 
     pattern = re.compile(
         r'^```([a-zA-Z0-9_-]+)' # language
-        r'\s*\{([^}]*)\}\s*$',  # flags
+        r'[ \t]+\{([^}]*)\}\s*$', # flags
         re.MULTILINE
     )
 


### PR DESCRIPTION
Ticket: ENT-13062

Replaced \s* which targeted spaces and new lines with [ \t]+ that only takes spaces and tabs but not new lines


(cherry picked from commit b2ff9d8bcad61ce62629665e2c011e4412219f47)