### PR TITLE
Fixed version getacls() was introduced in

### DIFF
--- a/reference/functions/getacls.markdown
+++ b/reference/functions/getacls.markdown
@@ -43,6 +43,6 @@ bundle agent __main__
 
 **History:**
 
-- Introduced in 3.27.
+- Introduced in 3.27.0
 
 **See also:** `filestat()`


### PR DESCRIPTION
3.27.0 is more correct and less ambiguous.