### PR TITLE
Reapply "CFE-4562: classfilterdata(): added docs for object of arrays/objects"

### DIFF
--- a/content/reference/functions/classfilterdata.markdown
+++ b/content/reference/functions/classfilterdata.markdown
@@ -16,10 +16,18 @@ If the `data_structure` argument is specified to be:
 
 - `"array_of_arrays"`, the `data_container` argument is interpreted as an array
   of arrays, and the `key_or_index` argument is interpreted as an index within
-  the children arrays.
+  the children arrays. The `key_or_index` argument is required.
 - `"array_of_objects"`, the `data_container` argument is interpreted as an array
   of objects, and the `key_or_index` argument is interpreted as a key within the
-  children objects.
+  children objects. The `key_or_index` argument is required.
+- `"object_of_arrays"`, the `data_container` argument is interpreted as an object
+  of arrays, and the `key_or_index` argument is interpreted as an index within
+  the children arrays (if specified). If the `key_or_index` argument is omitted,
+  the key of the child array itself is used as a class expression.
+- `"object_of_objects"`, the `data_container` argument is interpreted as an object
+  if objects, and the `key_or_index` argument is interpreted as a key within the
+  children objects (if specified). If the `key_or_index` argument is omitted, the
+  key of the child object itself is used as a class expression.
 - `"auto"`, the interpretation is automatically detected based on the data
   structure.
 
@@ -44,6 +52,46 @@ If the `data_structure` argument is specified to be:
 **Output:**
 
 {{< CFEngine_include_snippet(classfilterdata_array_of_objects.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+
+**Example (with object of arrays):**
+
+**Policy:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays.cf, #\+begin_src cfengine3, .*end_src) >}}
+
+**Output:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+
+**Example (with object of objects):**
+
+**Policy:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects.cf, #\+begin_src cfengine3, .*end_src) >}}
+
+**Output:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+
+**Example (with object of arrays using exogenous key):**
+
+**Policy:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_exogenous_key.cf, #\+begin_src cfengine3, .*end_src) >}}
+
+**Output:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_exogenous_key.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+
+**Example (with object of objects using exogenous key):**
+
+**Policy:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects_exogenous_key.cf, #\+begin_src cfengine3, .*end_src) >}}
+
+**Output:**
+
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects_exogenous_key.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
 
 **Notes:**
 

--- a/content/reference/functions/classfilterdata.markdown
+++ b/content/reference/functions/classfilterdata.markdown
@@ -63,7 +63,7 @@ If the `data_structure` argument is specified to be:
 
 {{< CFEngine_include_snippet(classfilterdata_object_of_arrays.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
 
-**Example (with object of objects):**
+**Example (with object of objects using key inside the object):**
 
 **Policy:**
 
@@ -73,25 +73,25 @@ If the `data_structure` argument is specified to be:
 
 {{< CFEngine_include_snippet(classfilterdata_object_of_objects.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
 
-**Example (with object of arrays using exogenous key):**
+**Example (with object of arrays using key to the object itself):**
 
 **Policy:**
 
-{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_exogenous_key.cf, #\+begin_src cfengine3, .*end_src) >}}
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_key_to_obj.cf, #\+begin_src cfengine3, .*end_src) >}}
 
 **Output:**
 
-{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_exogenous_key.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+{{< CFEngine_include_snippet(classfilterdata_object_of_arrays_key_to_obj.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
 
-**Example (with object of objects using exogenous key):**
+**Example (with object of objects using key to the object itself):**
 
 **Policy:**
 
-{{< CFEngine_include_snippet(classfilterdata_object_of_objects_exogenous_key.cf, #\+begin_src cfengine3, .*end_src) >}}
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects_key_to_obj.cf, #\+begin_src cfengine3, .*end_src) >}}
 
 **Output:**
 
-{{< CFEngine_include_snippet(classfilterdata_object_of_objects_exogenous_key.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
+{{< CFEngine_include_snippet(classfilterdata_object_of_objects_key_to_obj.cf, #\+begin_src\s+example_output\s*, .*end_src) >}}
 
 **Notes:**
 


### PR DESCRIPTION
This commit broke docs because it depends on
https://github.com/cfengine/core/pull/5850. Once the dependency is
merged, it should be safe to reapply this commit.

This reverts commit 3bc63486302c70af5ebb2705a19a06b05cb07707.

Ticket: CFE-4562
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
