### PR TITLE
Fixed version installed by cf-remote via fast-build(Jenkinsfile) on LTS branches

### DIFF
--- a/generator/build/main.sh
+++ b/generator/build/main.sh
@@ -84,7 +84,17 @@ if [ "$PACKAGE_JOB" = "cf-remote" ]; then
   # shellcheck source=/dev/null
   source /etc/os-release
   rm -rf ~/.cfengine/cf-remote/packages # to ensure we only get one
-  cf-remote --version "$BRANCH" download "${ID}$(echo "${VERSION_ID}" | cut -d. -f1)" hub "$(uname -m)"
+  # in case of LTS branches like 3.21 (without .x since we are in documentation repo) need to add on .x
+  if [ "$(expr "$BRANCH" : ".*.x")" = 0 ]; then
+    if [ "$BRANCH" = "master" ]; then
+      _VERSION=master
+    else
+      _VERSION="$BRANCH".x
+    fi
+  else
+    _VERSION="$BRANCH" # in case someone copy/pastes this to a repo besides documentation
+  fi
+  cf-remote --version "$_VERSION" download "${ID}$(echo "${VERSION_ID}" | cut -d. -f1)" hub "$(uname -m)"
   find "$HOME/.cfengine" # debug
   find "$HOME/.cfengine" -name '*.deb' -print0 | xargs -0 -I{} cp {} cfengine-nova-hub.deb
 else


### PR DESCRIPTION
On LTS branches, BRANCH=3.21 without the .x suffix and cf-remote doesn't understand this.

Ticket: ENT-12581
Changelog: none
(cherry picked from commit 6b7cb38a6804cb2909c75c69e764b66fd442ff47)
