### PR TITLE
Fixed missing rvm install in docs-revamp-22 container images on new build hosts

### DIFF
--- a/generator/build/run.sh
+++ b/generator/build/run.sh
@@ -3,8 +3,8 @@
 set -ex
 trap "echo FAILURE" ERR
 
-if ! buildah inspect docs-revamp-22 >/dev/null 2>&1; then
-  buildah build-using-dockerfile -t docs-revamp-22 documentation/generator/build
+if ! buildah inspect docs-hugo >/dev/null 2>&1; then
+  buildah build-using-dockerfile -t docs-hugo documentation/generator/build
 fi
 
 # Current path must have the following repos cloned:
@@ -30,7 +30,7 @@ elif [ -n "$BRANCH_NAME" ]; then
   BRANCH="$BRANCH_NAME"
 fi
 
-c=$(buildah from -v "$PWD":/nt docs-revamp-22)
+c=$(buildah from -v "$PWD":/nt docs-hugo)
 trap 'buildah run "$c" bash -c "sudo chown -R root:root /nt; sudo chmod -R a+rwX /nt"; buildah rm "$c" >/dev/null' EXIT
 buildah run "$c" bash -x documentation/generator/build/main.sh "$BRANCH" "$PACKAGE_JOB" "$PACKAGE_UPLOAD_DIRECTORY" "$PACKAGE_BUILD"
 buildah run "$c" bash -x documentation/generator/_scripts/_publish.sh "$BRANCH"


### PR DESCRIPTION
When we removed rvm install in generator/build/Dockerfile we needed to change the name of the buildah image so that there were two: one using ruby/rvm for pre-hugo and one for hugo going forward.

This mostly affected newer build hosts like elfk-spectre.

Ticket: ENT-13085
Changelog: none
