### PR TITLE
CFE-4583: Enhanced default bodies documentation and examples

### DIFF
--- a/content/reference/language-concepts/bodies.markdown
+++ b/content/reference/language-concepts/bodies.markdown
@@ -177,7 +177,7 @@ body in the default namespace. To use a body as default, name it
 ```cf3
 body file control
 {
-   # Default bodies /must/ be defined in the /default/ namespace
+   # Default bodies /must/ be defined in the /bodydefault/ namespace
    namespace => "bodydefault";
 }
 


### PR DESCRIPTION
Clarified the explanation of default bodies, added CFEngine code examples for
their definition and application, and included historical context.

Ticket: CFE-4583