### PR TITLE
cmdb-api.markdown: host specific configuration API to v2

### DIFF
--- a/content/api/enterprise-api-ref/cmdb-api.markdown
+++ b/content/api/enterprise-api-ref/cmdb-api.markdown
@@ -78,7 +78,7 @@ HTTP 200 Ok
 
 ## Get host's specific configuration
 
-**URI:** https://hub.cfengine.com/api/cmdb/:hostkey/:type/:name/
+**URI:** https://hub.cfengine.com/api/cmdb/v2/:hostkey/:type/:name/
 
 **Method:** GET
 
@@ -98,7 +98,7 @@ HTTP 200 Ok
 ```console
 curl -k --user <username>:<password> \
   -X GET \
-  https://hub.cfengine.com/api/cmdb/SHA=f622992fa4525070f47da086041a38733496f03a77880f70b1ce6784c38f79ab/variables/HubCMDB:My.hostname/
+  https://hub.cfengine.com/api/cmdb/v2/SHA=f622992fa4525070f47da086041a38733496f03a77880f70b1ce6784c38f79ab/variables/HubCMDB:My.hostname/
 ```
 
 **Example response:**


### PR DESCRIPTION
It appears that there is a new version (v2) of the API:

```
$ curl -k --user admin:password -X GET "https://localhost/api/cmdb/<HOSTKEY>/classes/default:cfengine_internal_masterfiles_update/"
This version of CMDB API is no longer available. Please use /v2/... instead

$ curl -k --user admin:password -X GET "https://localhost/api/cmdb/v2/<HOSTKEY>/classes/default:cfengine_internal_masterfiles_update/"
{"data":[],"meta":{"total":0,"page":2,"count":0}}
```

Ticket: ENT-13208
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
