### PR TITLE
Removed videos from getting started tutorials

### DIFF
--- a/content/getting-started/installation/_index.markdown
+++ b/content/getting-started/installation/_index.markdown
@@ -11,12 +11,6 @@ So, the only thing you need to get started is to set up 1 CFEngine Hub.
 
 ![](https://cfengine.com/images/overview/cfe-desktop.svg)
 
-## Video
-
-There is a video version of this tutorial available on YouTube:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GSaRfDlfh7I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## Linux virtual machine
 
 CFEngine runs on a wide variety of platforms, including Windows, Mac, Linux, and BSD.

--- a/content/getting-started/installation/local-virtual-machine.markdown
+++ b/content/getting-started/installation/local-virtual-machine.markdown
@@ -8,12 +8,6 @@ This short tutorial shows you how to set up a Linux Virtual Machine locally, if 
 
 **Note:** If you are using Digital Ocean or another cloud platform, you don't need this tutorial.
 
-## Video
-
-There is a video version of this tutorial available on YouTube:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/VDe5n2Ugt_w" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## Download and install virtualization software
 
 Install Vagrant and VirtualBox from their respective websites:

--- a/content/getting-started/modules-from-cfengine-build.markdown
+++ b/content/getting-started/modules-from-cfengine-build.markdown
@@ -9,12 +9,6 @@ The workflow will look like this:
 
 ![](workflow.png)
 
-## Video
-
-There is a video version of this tutorial available on YouTube:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/m2vHvJ7_iug" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## Step 0: Creating a new project
 
 Create a folder for you project, for example in your home directory:

--- a/content/getting-started/reporting-and-web-ui.markdown
+++ b/content/getting-started/reporting-and-web-ui.markdown
@@ -13,12 +13,6 @@ https://192.168.56.2/
 
 (Log in with the username and password for your hub, the default is `admin` as both and you will be prompted to change it on the first login).
 
-## Video
-
-There is a video version of this tutorial available on YouTube:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/S7n8lqPzst0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## The host info page
 
 You can find individual hosts by using the search bar in the top right corner of Mission Portal, or by clicking _Hosts_ in the left navigation bar and looking through the different categories in the tree.


### PR DESCRIPTION
These are getting outdated and don't align with what we want to
show in the new getting started tutorial structure for 3.27+.
Removing them and maybe we'll record new ones when the new
tutorials are ready.
