### PR TITLE
Adjusted backup and restore commands to use long arguments and dbname where needed (3.24)

### DIFF
--- a/content/web-ui/hub_administration/backup-and-restore.markdown
+++ b/content/web-ui/hub_administration/backup-and-restore.markdown
@@ -43,13 +43,13 @@ restore the history of policy outcomes you must backup and restore.
 **Backup:**
 
 ```command
-pg_dump -Fc cfdb > cfdb.bak
+pg_dump --format=c cfdb > cfdb.bak
 ```
 
 **Restore:**
 
 ```command
-pg_restore -Fc cfdb.bak
+pg_restore --format=c --dbname=cfdb cfdb.bak
 ```
 
 ### Mission Portal
@@ -60,13 +60,13 @@ pg_restore -Fc cfdb.bak
 **Backup:**
 
 ```console
-# pg_dump -Fc cfmp > cfmp.bak
-# pg_dump -Fc cfsettings > cfsettings.bak
+# pg_dump --format=c cfmp > cfmp.bak
+# pg_dump --format=c cfsettings > cfsettings.bak
 ```
 
 **Restore:**
 
 ```console
-# pg_restore -Fc cfmp.bak
-# pg_restore -Fc cfsettings.bak
+# pg_restore --format=c --dbname=cfmp cfmp.bak
+# pg_restore --format=c --dbname=cfsettings cfsettings.bak
 ```


### PR DESCRIPTION
(cherry picked from commit 9a0dab57a2ab3be100f24cfcac9225520cde29e9)
