### PR TITLE
Deprecated guest_environments and defaults

### DIFF
--- a/content/reference/promise-types/defaults.markdown
+++ b/content/reference/promise-types/defaults.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: defaults
+title: defaults (deprecated)
 aliases:
   - "/reference-promise-types-defaults.html"
 ---

--- a/content/reference/promise-types/guest_environments.markdown
+++ b/content/reference/promise-types/guest_environments.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: guest_environments
+title: guest_environments (deprecated)
 sorting: 9999
 aliases:
   - "/reference-promise-types-guest_environments.html"

--- a/generator/_references.md
+++ b/generator/_references.md
@@ -64,3 +64,5 @@
 [mpf-services-autorun]: reference-masterfiles-policy-framework-services-autorun.html
 [package-modules-the-api]: reference-language-concepts-modules-package-module-api.html#the-api
 [Functions#collecting functions]: /reference/functions/#collecting-functions
+[guest_environments]: /reference/promise-types/guest_environments.html
+[defaults]: /reference/promise-types/defaults.html


### PR DESCRIPTION
CFEngine is not compiled with guest_environments by default,
so this promise type is not available in most installations.
It also hasn't been updated in a long time, so we decided
it's better to mark it as deprecated.

The defaults promise type is still possible to use, but
seems to not be widely used, nor encouraged. You can achieve
similar functionality through the use of conditionally
setting variables, often by using isvariable() function, and
also by having default values in augments files (def.json).

Thus, since we don't use defaults ourselves, and encourage
users to use normal variables and/or augments instead, it
makes sense to mark it as deprecated in docs to discourage its
use.