### PR TITLE
fix: removed use of install.sh.log as it was breaking the build of the container image

### DIFF
--- a/generator/build/Dockerfile
+++ b/generator/build/Dockerfile
@@ -10,11 +10,11 @@ RUN echo "jenkins    ALL=(ALL)       NOPASSWD: ALL">> /etc/sudoers
 RUN mkdir -p /home/jenkins
 RUN chown -R jenkins:jenkins /home/jenkins
 
-# Run rest of setup as jenkins user
 COPY install.sh /
+# Run rest of setup as jenkins user
 USER jenkins
 WORKDIR /home/jenkins
-RUN bash -x /install.sh 2>&1 | tee /install.sh.log
+RUN bash -x /install.sh
 
 # This is where our repos will be
 WORKDIR /nt


### PR DESCRIPTION
Due to permissions problems this /install.sh.log would fail the build and cause ruby to not be installed but the image still would be built and used, thus breaking docs-pr jobs.

This change came with some other changes in ef27b0e6dfa3f0d08a3dac251f6947a66e16b62a but is really not needed so just remove the use of a log file.

Ticket: ENT-13085
Changelog: none
