### PR TITLE
fix: make the container image to build docs clear on which platform we rely on: hugo at this time (3.27)

### DIFF
--- a/generator/build/run.sh
+++ b/generator/build/run.sh
@@ -3,8 +3,9 @@
 set -ex
 trap "echo FAILURE" ERR
 
-if ! buildah inspect docs-revamp-22 >/dev/null 2>&1; then
-  buildah build-using-dockerfile -t docs-revamp-22 documentation/generator/build
+image_name=docs-hugo
+if ! buildah inspect ${image_name} >/dev/null 2>&1; then
+  buildah build-using-dockerfile -t ${image_name} documentation/generator/build
 fi
 
 # Current path must have the following repos cloned:
@@ -30,7 +31,7 @@ elif [ -n "$BRANCH_NAME" ]; then
   BRANCH="$BRANCH_NAME"
 fi
 
-c=$(buildah from -v "$PWD":/nt docs-revamp-22)
+c=$(buildah from -v "$PWD":/nt ${image_name})
 trap 'buildah run "$c" bash -c "sudo chown -R root:root /nt; sudo chmod -R a+rwX /nt"; buildah rm "$c" >/dev/null' EXIT
 buildah run "$c" bash -x documentation/generator/build/main.sh "$BRANCH" "$PACKAGE_JOB" "$PACKAGE_UPLOAD_DIRECTORY" "$PACKAGE_BUILD" "$LTS_VERSION"
 buildah run "$c" bash -x documentation/generator/_scripts/_publish.sh "$BRANCH"


### PR DESCRIPTION
Ticket: ENT-13085
Changelog: none
(cherry picked from commit c7d4c9d67f596c68e5d9525ca31c63c3de625695)
