### PR TITLE
ENT-14129: Added documentation for search_up() function alias

### DIFF
--- a/content/reference/functions/findfiles_up.markdown
+++ b/content/reference/functions/findfiles_up.markdown
@@ -3,12 +3,13 @@ layout: default
 title: findfiles_up
 aliases:
   - "/reference-functions-findfiles_up.html"
+  - "/reference/functions/search_up"
 ---
 
 {{< CFEngine_function_prototype(path, glob, level) >}}
 
 **Description:** Return a data array of files that match a given glob pattern
-by searching up the directory tree.
+by searching up the directory tree. Also available as `search_up()`.
 
 This function searches for files matching a given glob pattern `glob` in the
 local filesystem by searching up the directory tree from a given absolute

--- a/content/reference/functions/search_up.markdown
+++ b/content/reference/functions/search_up.markdown
@@ -1,0 +1,15 @@
+---
+layout: default
+title: search_up
+aliases:
+  - "/reference-functions-search_up.html"
+alias: reference-functions-search_up
+---
+
+`search_up()` is an alias for `findfiles_up()`.
+
+See the `findfiles_up()` documentation for usage, examples, and details.
+
+**History:**
+
+- Introduced in 3.18 (as an alias for `findfiles_up()`).


### PR DESCRIPTION
## Summary

`search_up()` is an alias for `findfiles_up()` that has existed since 3.18 but was never documented.

**Changes:**
- Add `content/reference/functions/search_up.markdown` stub page pointing to `findfiles_up()`
- Add Hugo alias `/reference/functions/search_up` on the `findfiles_up` page for URL resolution
- Note `search_up()` as an alias in the `findfiles_up()` description

The stub uses bare backtick `findfiles_up()` patterns so the docs link resolver auto-links them.

Jira: [ENT-14129](https://northerntech.atlassian.net/browse/ENT-14129)

[ENT-14129]: https://northerntech.atlassian.net/browse/ENT-14129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ