### PR TITLE
CFE-4681: document timer_policy attribute on classes: promises

### DIFF
--- a/content/reference/functions/regline.markdown
+++ b/content/reference/functions/regline.markdown
@@ -42,6 +42,7 @@ bundle edit_line upgrade_cfexecd
       # bundles and persist until it is explicitly canceled or until the end of
       # the agent run.
       scope => "bundle";
+
   insert_lines:
     exec_fix::
       "0,5,10,15,20,25,30,35,40,45,50,55 * * * * /var/cfengine/bin/cf-execd -F";

--- a/content/reference/promise-types/classes.markdown
+++ b/content/reference/promise-types/classes.markdown
@@ -356,6 +356,53 @@ classes:
 
 **See also:** [`persistence` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time]
 
+### timer_policy
+
+**Description:** Determines whether a persistent class restarts its counter
+when rediscovered.
+
+When a [`persistence`][classes#persistence] timer is set, `timer_policy`
+controls what happens on later runs while the class is still defined (loaded
+from the persistent store):
+
+- `reset` re-evaluates the promise and restarts the timer, so the class keeps
+  persisting for as long as the policy keeps running and the expression stays
+  true.
+- `absolute` preserves the original expiry. While the class is already defined
+  the promise is skipped, so the class disappears once the original timer
+  elapses, regardless of how often the policy runs.
+
+This is the counterpart of `timer_policy` in the classes body, which has always
+defaulted to `reset`.
+
+**Type:** (menu option)
+
+**Allowed input range:** `absolute|reset`
+
+**Default value:** reset
+
+**Example:**
+
+```cf3 {skip TODO}
+bundle common setclasses
+{
+  classes:
+    "cached_class"
+      expression => "any",
+      persistence => "120",
+      timer_policy => "reset";
+}
+```
+
+**History:**
+
+- Introduced in CFEngine 3.24.5, 3.27.2, and 3.28.0.
+- The default is `reset` as of 3.28.0. In 3.24.5 and 3.27.2 (and later patch
+  releases in those series) the default is `absolute`, preserving the prior
+  behavior.
+
+**See also:** [`persistence` classes attribute][classes#persistence], [`timer_policy` in classes body][Promise types#timer_policy], [`persist_time` in classes body][Promise types#persist_time]
+
 ### not
 
 **Description:** Evaluate the negation of string expression in normal form


### PR DESCRIPTION
## Summary

Documents the new `timer_policy` attribute on `classes:` promises in the promise-type reference ([CFE-4681](https://northerntech.atlassian.net/browse/CFE-4681)).

`timer_policy` controls whether a persistent class restarts its timer when rediscovered:

- `reset` — re-evaluates the promise and restarts the timer, so the class keeps persisting while the policy runs and the expression stays true.
- `absolute` — preserves the original expiry; the promise is skipped while the class is already defined.

This brings the `classes:` promise type to parity with the `classes` body, which has long had a `timer_policy` attribute.

## Version-specific default

The new section documents the default as **`reset`** (master → 3.28.0) and a **History** note records that the attribute is also available on **3.24.5** and **3.27.2**, where the default is **`absolute`** (preserving the historical behavior).

## Notes

- Added under `### timer_policy` in `content/reference/promise-types/classes.markdown`, right after `### persistence`.
- Cross-references use the auto-generated heading anchors (`[classes#persistence]`, `[Promise types#timer_policy]`, `[Promise types#persist_time]`); no `_references.md` change needed.
- `prettier --check` passes; no inline `.markdown` links introduced.

## Related

- Core: cfengine/core#6167 (attribute, default `absolute`) and cfengine/core#6174 (default → `reset` for 3.28.0)

Once this looks right on master, it should be cherry-picked to the `3.24` and `3.27` doc branches with the **Default value** and the History note adjusted to `absolute` for those streams.

Merge with https://github.com/cfengine/core/pull/6174

[CFE-4681]: https://northerntech.atlassian.net/browse/CFE-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ