### PR TITLE
generator/build/main.sh: Updated for new cf-remote cache folder location

### DIFF
--- a/generator/build/main.sh
+++ b/generator/build/main.sh
@@ -96,8 +96,8 @@ if [ "$PACKAGE_JOB" = "cf-remote" ]; then
     _VERSION="$BRANCH" # in case someone copy/pastes this to a repo besides documentation
   fi
   cf-remote --version "$_VERSION" download "${ID}$(echo "${VERSION_ID}" | cut -d. -f1)" hub "$(uname -m)"
-  find "$HOME/.cfengine" # debug
-  find "$HOME/.cfengine" -name '*.deb' -print0 | xargs -0 -I{} cp {} cfengine-nova-hub.deb
+  find "$HOME/.cache/cfengine" # debug
+  find "$HOME/.cache/cfengine" -name '*.deb' -print0 | xargs -0 -I{} cp {} cfengine-nova-hub.deb
 else
   echo "Installing with old-style fetch_file function"
   HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_22


### PR DESCRIPTION
https://github.com/cfengine/cf-remote/releases/tag/0.9.0