### PR TITLE
build-locally.sh: Fixed build issue and added instructions for viewing the result

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -139,3 +139,7 @@ fi
 
 echo "==> Done. Generated site is in: $DOC_WORK/generator/_site"
 echo "    Tarballs (if packaged) are in: $DOC_WORK/output/"
+echo "    Start a webserver:"
+echo "    python3 -m http.server --directory $DOC_WORK/generator/_site/"
+echo "    And then open in your browser:"
+echo "    http://127.0.0.1:8000/"

--- a/generator/build/Dockerfile
+++ b/generator/build/Dockerfile
@@ -15,7 +15,7 @@ COPY install.sh /
 COPY install_hugo.sh /
 USER jenkins
 WORKDIR /home/jenkins
-RUN bash -x /install.sh
+RUN sudo apt-get update -qy && bash -x /install.sh
 RUN bash /install_hugo.sh
 
 # This is where our repos will be


### PR DESCRIPTION
- **generator/build/Dockerfile: Ensured we don't have an outdated (cached) apt-get update for install.sh script**
- **build-locally.sh: Added instructions for viewing the resulting build in a browser**
