### PR TITLE
ENT-14130: Fixed empty code blocks in included examples (3.27)

### DIFF
--- a/generator/_scripts/cfdoc_macros.py
+++ b/generator/_scripts/cfdoc_macros.py
@@ -749,6 +749,10 @@ def include_snippet(parameters, config):
             if line.find("#[%-%]") == 0:
                 skip_block = True
                 continue
+            # org-mode src markers are just delimiters, not content. Skip them so they
+            # don't trip the in_documentation toggle below and open an empty code block.
+            if line.startswith("#+begin_src") or line.startswith("#+end_src"):
+                continue
             # #@ interrupts code block, interpret documentation in example code
             if line.find("#@ ") == 0:
                 line = line[3:]


### PR DESCRIPTION
Ticket: ENT-14130

(cherry picked from commit f9c0a137cf7e6a011217f2c951d73ed38e975882)