### PR TITLE
ENT-10666: Added cross reference between readtcp() and isconnectable() (3.27)

### DIFF
--- a/content/reference/functions/isconnectable.markdown
+++ b/content/reference/functions/isconnectable.markdown
@@ -17,6 +17,8 @@ This function checks whether a `hostname`:`port` is connectable within `timeout`
 
 {{< CFEngine_include_example(isconnectable.cf) >}}
 
+**See also:** `readtcp()`.
+
 **History:**
 
 - Introduced in 3.26.0

--- a/content/reference/functions/readtcp.markdown
+++ b/content/reference/functions/readtcp.markdown
@@ -34,3 +34,5 @@ R: Server is alive
 successfully interrupt the waiting system calls so this might hang if you send
 an incorrect query string. This should not happen, but the cause has yet to be
 diagnosed.
+
+**See also:** `isconnectable()`.


### PR DESCRIPTION
Ticket: ENT-10666