### PR TITLE
Fix: Added missing semicolon in example-snippets

### DIFF
--- a/content/examples/example-snippets/software_and_patch_installation_1_2_3.cf
+++ b/content/examples/example-snippets/software_and_patch_installation_1_2_3.cf
@@ -2,7 +2,7 @@
 body common control
 {
   bundlesequence => { "packages" };
-  inputs => { "cfengine_stdlib.cf" }
+  inputs => { "cfengine_stdlib.cf" };
 }
 
 bundle agent packages

--- a/content/reference/functions/regline.markdown
+++ b/content/reference/functions/regline.markdown
@@ -42,6 +42,7 @@ bundle edit_line upgrade_cfexecd
       # bundles and persist until it is explicitly canceled or until the end of
       # the agent run.
       scope => "bundle";
+
   insert_lines:
     exec_fix::
       "0,5,10,15,20,25,30,35,40,45,50,55 * * * * /var/cfengine/bin/cf-execd -F";


### PR DESCRIPTION
Needed for tests to pass: https://github.com/cfengine/cfengine-cli/pull/173