### PR TITLE
CFE-4681: document timer_policy attribute on classes: promises (3.24)

### DIFF
--- a/content/reference/promise-types/classes.markdown
+++ b/content/reference/promise-types/classes.markdown
@@ -312,6 +312,52 @@ classes:
 
 **See also:** [`persistance` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time]
 
+### timer_policy
+
+**Description:** Determines whether a persistent class restarts its counter
+when rediscovered.
+
+When a [`persistence`][classes#persistence] timer is set, `timer_policy`
+controls what happens on later runs while the class is still defined (loaded
+from the persistent store):
+
+- `reset` re-evaluates the promise and restarts the timer, so the class keeps
+  persisting for as long as the policy keeps running and the expression stays
+  true.
+- `absolute` preserves the original expiry. While the class is already defined
+  the promise is skipped, so the class disappears once the original timer
+  elapses, regardless of how often the policy runs.
+
+This is the counterpart of `timer_policy` in the classes body, which has always
+defaulted to `reset`.
+
+**Type:** (menu option)
+
+**Allowed input range:** `absolute|reset`
+
+**Default value:** absolute
+
+**Example:**
+
+```cf3
+bundle common setclasses
+{
+  classes:
+    "cached_class"
+      expression => "any",
+      persistence => "120",
+      timer_policy => "reset";
+}
+```
+
+**History:**
+
+- Introduced in CFEngine 3.24.5.
+- The default is `absolute`, preserving the historical persistent-class
+  behavior. The default changed to `reset` in 3.28.0.
+
+**See also:** [`persistence` classes attribute][classes#persistence], [`timer_policy` in classes body][Promise types#timer_policy], [`persist_time` in classes body][Promise types#persist_time]
+
 ### not
 
 **Description:** Evaluate the negation of string expression in normal form


### PR DESCRIPTION
## Summary

Backports the `timer_policy` attribute documentation on `classes:` promises to the **3.24** stream ([CFE-4681](https://northerntech.atlassian.net/browse/CFE-4681)).

Mirrors the master PR (#3682), with the **Default value** and **History** adjusted for this stream: on 3.24 `timer_policy` defaults to `absolute` (the historical persistent-class behavior). The default changed to `reset` in 3.28.0.

## Notes

- Added `### timer_policy` in `content/reference/promise-types/classes.markdown`, right after `### persistence`.
- Cross-references use the auto-generated heading anchors (`[classes#persistence]`, `[Promise types#timer_policy]`, `[Promise types#persist_time]`); no `_references.md` change needed.

## Related

- master: #3682
- Core: cfengine/core#6167 (attribute, default `absolute`)


[CFE-4681]: https://northerntech.atlassian.net/browse/CFE-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ