### PR TITLE
CFE-4681: document timer_policy attribute on classes: promises (3.27)

### DIFF
--- a/content/examples/example-snippets/software_and_patch_installation_1_2_3.cf
+++ b/content/examples/example-snippets/software_and_patch_installation_1_2_3.cf
@@ -2,7 +2,7 @@
 body common control
 {
   bundlesequence => { "packages" };
-  inputs => { "cfengine_stdlib.cf" }
+  inputs => { "cfengine_stdlib.cf" };
 }
 
 bundle agent packages

--- a/content/examples/tutorials/manage-ntp.markdown
+++ b/content/examples/tutorials/manage-ntp.markdown
@@ -618,6 +618,7 @@ bundle agent ntp
       "servers"
         slist => getvalues("def.ntp[config][servers]"),
         if => isvariable("def.ntp[config][servers]");
+}
 ```
 
 Notice two promises were introduced, one setting `driftfile` to the value of `$(def.ntp[config][driftfile])` if it is defined and one setting servers to the list of values for `def.ntp[config][servers]` if it is defined. [Augments][Augments] allows for variables to be set in the _def_ bundle scope very early before policy is evaluated.

--- a/content/reference/components/cf-agent.markdown
+++ b/content/reference/components/cf-agent.markdown
@@ -529,7 +529,7 @@ body agent control
   copyfrom_restrict_keys => {
     "SHA=6565a8e647e61e4a7ff2c709e0fe772acce2e45aaa294b2bb713de0ba5a6d8c3",
     "SHA=727dd7f6f8b2344c6d69cf1d3ed0446c0f9f095ce1a114481d691bf1cb2b300d",
-  }
+  };
 }
 ```
 

--- a/content/reference/components/cf-execd.markdown
+++ b/content/reference/components/cf-execd.markdown
@@ -43,7 +43,7 @@ body executor control
   mailto => "cfengine@example.org";
   mailfrom => "cfengine@$(host).example.org";
   smtpserver => "localhost";
-  schedule => { "Min00", "Min30" }
+  schedule => { "Min00", "Min30" };
 }
 ```
 

--- a/content/reference/promise-types/classes.markdown
+++ b/content/reference/promise-types/classes.markdown
@@ -328,7 +328,7 @@ defaulted to `reset`.
 
 **Example:**
 
-```cf3 {skip TODO}
+```cf3
 bundle common setclasses
 {
   classes:

--- a/content/reference/promise-types/classes.markdown
+++ b/content/reference/promise-types/classes.markdown
@@ -301,6 +301,52 @@ classes:
 
 **See also:** [`persistence` classes attribute][classes#persistence], [`persist_time` in classes body][Promise types#persist_time]
 
+### timer_policy
+
+**Description:** Determines whether a persistent class restarts its counter
+when rediscovered.
+
+When a [`persistence`][classes#persistence] timer is set, `timer_policy`
+controls what happens on later runs while the class is still defined (loaded
+from the persistent store):
+
+- `reset` re-evaluates the promise and restarts the timer, so the class keeps
+  persisting for as long as the policy keeps running and the expression stays
+  true.
+- `absolute` preserves the original expiry. While the class is already defined
+  the promise is skipped, so the class disappears once the original timer
+  elapses, regardless of how often the policy runs.
+
+This is the counterpart of `timer_policy` in the classes body, which has always
+defaulted to `reset`.
+
+**Type:** (menu option)
+
+**Allowed input range:** `absolute|reset`
+
+**Default value:** absolute
+
+**Example:**
+
+```cf3 {skip TODO}
+bundle common setclasses
+{
+  classes:
+    "cached_class"
+      expression => "any",
+      persistence => "120",
+      timer_policy => "reset";
+}
+```
+
+**History:**
+
+- Introduced in CFEngine 3.27.2.
+- The default is `absolute`, preserving the historical persistent-class
+  behavior. The default changed to `reset` in 3.28.0.
+
+**See also:** [`persistence` classes attribute][classes#persistence], [`timer_policy` in classes body][Promise types#timer_policy], [`persist_time` in classes body][Promise types#persist_time]
+
 ### not
 
 **Description:** Evaluate the negation of string expression in normal form

--- a/content/reference/promise-types/files/_index.markdown
+++ b/content/reference/promise-types/files/_index.markdown
@@ -2063,7 +2063,7 @@ body file_select example
 {
   leaf_name => { "prog.pid", "prog.log" };
   path_name => { "/etc/.*", "/var/run/.*" };
-  file_result => "leaf_name.path_name"
+  file_result => "leaf_name.path_name";
 }
 ```
 

--- a/content/resources/additional-topics/distributed-scheduling.markdown
+++ b/content/resources/additional-topics/distributed-scheduling.markdown
@@ -184,6 +184,7 @@ bundle agent workflow_one
       "/usr/local/bin/my_job",
         action => if_elapsed("100"),
         classes => state_repaired("did_my_job");
+}
 ```
 
 ## Fancy distributed encapsulation
@@ -366,6 +367,7 @@ bundle agent workflow_one
       "/usr/local/bin/my_job",
         action => if_elapsed("100"),
         classes => state_repaired("did_my_job");
+}
 ```
 
 ## Self-healing workflows

--- a/content/resources/additional-topics/security.markdown
+++ b/content/resources/additional-topics/security.markdown
@@ -450,6 +450,7 @@ bundle agent change_management
       ),
       depends_on => { "grant_hash_tables" },
       action => neighbourwatch("File changes observed on $(neighbours)");
+}
 ```
 
 It works by building a list of neighbours for each host. The function peers can


### PR DESCRIPTION
## Summary

Backports the `timer_policy` attribute documentation on `classes:` promises to the **3.27** stream ([CFE-4681](https://northerntech.atlassian.net/browse/CFE-4681)).

Mirrors the master PR (#3682), with the **Default value** and **History** adjusted for this stream: on 3.27 `timer_policy` defaults to `absolute` (the historical persistent-class behavior). The default changed to `reset` in 3.28.0.

## Contents

- **timer_policy docs** — adds `### timer_policy` to `content/reference/promise-types/classes.markdown`, right after `### persistence`. Cross-references use the auto-generated heading anchors (`[classes#persistence]`, `[Promise types#timer_policy]`, `[Promise types#persist_time]`); no `_references.md` change needed.

## Formatting

Rebased onto the current `3.27` tip, which now carries the cherry-picked cf3 reformats from #3732 (merged). The branch-wide reformat commit previously included here has been **dropped** per @olehermanse's review, so this PR is now just the `timer_policy` addition (46 lines, one file).

Also cherry-picks (`-x`) master's `ec725753e` ("Fix: Added missing semicolon and newline for cfengine-cli lint/format-docs" by @SimonThalvorsen) — a pre-existing 3.27 lint failure that the unpinned cfengine CLI (0.18.1) now flags on **any** 3.27 PR. It was already fixed on master but never backported. Fixes a missing `;` in `content/examples/example-snippets/software_and_patch_installation_1_2_3.cf` (the `regline.markdown` hunk was already satisfied on 3.27).

Verified locally against the rebased branch with cfengine CLI 0.18.1: `cfengine format --check`, `cfengine dev format-docs` (idempotent, clean `git diff --exit-code`), and `cfengine lint` on the fixed example all pass.

## Related

- master: #3682
- Reformat backports: #3732 (merged)
- Core: cfengine/core#6167 (attribute, default `absolute`)


[CFE-4681]: https://northerntech.atlassian.net/browse/CFE-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
