### PR TITLE
Unfence timer_policy example (follow-up to #3682)

### DIFF
--- a/content/reference/promise-types/classes.markdown
+++ b/content/reference/promise-types/classes.markdown
@@ -383,7 +383,7 @@ defaulted to `reset`.
 
 **Example:**
 
-```cf3 {skip TODO}
+```cf3
 bundle common setclasses
 {
   classes:


### PR DESCRIPTION
## Summary

Follow-up to #3682: removes the `{skip TODO}` fence from the `timer_policy` example in `content/reference/promise-types/classes.markdown`.

## Why

#3682 fenced the example ` ```cf3 {skip TODO}` because the cfengine CLI's bundled `syntax-description.json` did not yet know `timer_policy` on `classes:` promises, so `cfengine dev lint-docs` rejected it. As of **cfengine CLI 0.18.0** that syntax snapshot includes the attribute, so the fence is no longer needed. Dropping it means the example is syntax-checked and reformatted like every other block.

Verified locally with cfengine CLI 0.18.0: `cfengine format --check`, `cfengine dev format-docs` (idempotent, clean `git diff`), and `cfengine dev lint-docs` (block now reports `PASS`) all succeed.

The 3.24 (#3728) and 3.27 (#3729) backports already carry this change.
