### PR TITLE
Add missing introduction versions to dnf_group module history [3.24]

### DIFF
--- a/content/reference/promise-types/packages.markdown
+++ b/content/reference/promise-types/packages.markdown
@@ -590,7 +590,7 @@ The `options` attribute supports DNF setopt-style configuration:
 
 **History:**
 
-- Added in CFEngine 3.28.0
+- Added in CFEngine 3.28.0, 3.27.1, 3.24.4
 
 ### apt_get
 


### PR DESCRIPTION
Backport of #3737 to this release branch.

The `dnf_group` package module reference listed only **3.28.0** as its introduction version, but the module was also backported to the `3.24.x` and `3.27.x` release lines.

Verified against the `masterfiles` repo (commit adding `modules/packages/vendored/dnf_group.mustache` on each branch, and the first tag containing it):

| Branch | Commit | First released in |
|--------|--------|-------------------|
| master | `ac3171a2` (2026-04-10) | 3.28.0 |
| 3.27.x | `dade52b5` (2026-04-22) | 3.27.1 |
| 3.24.x | `451ae13c` (2026-04-22) | 3.24.4 |

Updates the History line to `Added in CFEngine 3.28.0, 3.27.1, 3.24.4`, matching the format already used for the neighboring `allow_downgrade` note on this same branch.
