### PR TITLE
CFE-4699: Removed the incorrect claim that report_to_file falls back to stdout

### DIFF
--- a/content/reference/promise-types/reports.markdown
+++ b/content/reference/promise-types/reports.markdown
@@ -160,8 +160,8 @@ Output:
 **Description:** The path and filename to which output should be appended
 
 Append the output of the report to the named file instead of standard output.
-If the file cannot be opened for writing then the report defaults to the
-standard output.
+If the report cannot be written, an error is logged and the promise is not
+kept.
 
 **Type:** `string`
 


### PR DESCRIPTION
The page said a report that could not be written falls back to standard output, which was never implemented. States what actually happens instead.

Ticket: CFE-4699