### PR TITLE
CFE-3714: Added missing argument names to mergedata function attributes macro

### DIFF
--- a/content/reference/functions/mergedata.markdown
+++ b/content/reference/functions/mergedata.markdown
@@ -32,7 +32,7 @@ traditional list and array data types in CFEngine.
 - true and false are reserved bare values
 - In the event of key collision the _last_ key merged wins
 
-{{< CFEngine_function_attributes() >}}
+{{< CFEngine_function_attributes(arg1, arg2, ...) >}}
 
 **Example:**
 


### PR DESCRIPTION
Changed mergedata.markdown from CFEngine_function_attributes() to
CFEngine_function_attributes(arg1, arg2, ...), so the macro has names to
pair with the two parameters core PR #6289 added.

Ticket: CFE-4714
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
